### PR TITLE
Declared default float precision for Android

### DIFF
--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -711,7 +711,7 @@ static const csmChar* VertShaderSrcSetupMask =
         "v_texCoord.y = 1.0 - v_texCoord.y;"
         "}";
 static const csmChar* FragShaderSrcSetupMask =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -763,7 +763,7 @@ static const csmChar* VertShaderSrcMasked =
 //----- フラグメントシェーダプログラム -----
 // Normal & Add & Mult 共通
 static const csmChar* FragShaderSrc =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;" //v2f.texcoord
@@ -777,7 +777,7 @@ static const csmChar* FragShaderSrc =
 
 // Normal & Add & Mult 共通 （PremultipliedAlpha）
 static const csmChar* FragShaderSrcPremultipliedAlpha =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;" //v2f.texcoord
@@ -790,7 +790,7 @@ static const csmChar* FragShaderSrcPremultipliedAlpha =
 
 // Normal （クリッピングされたものの描画用）
 static const csmChar* FragShaderSrcNormalMask =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -811,7 +811,7 @@ static const csmChar* FragShaderSrcNormalMask =
 
 // Normal （クリッピングされたものの描画用、PremultipliedAlpha兼用）
 static const csmChar* FragShaderSrcNormalMaskPremultipliedAlpha =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -831,7 +831,7 @@ static const csmChar* FragShaderSrcNormalMaskPremultipliedAlpha =
 
 // Add （クリッピングされたものの描画用）
 static const csmChar* FragShaderSrcAddMask =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -852,7 +852,7 @@ static const csmChar* FragShaderSrcAddMask =
 
 // Add （クリッピングされたものの描画用、テクスチャがPremultipliedAlphaの場合）
 static const csmChar* FragShaderSrcAddMaskPremultipliedAlpha =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -872,7 +872,7 @@ static const csmChar* FragShaderSrcAddMaskPremultipliedAlpha =
 
 // Mult （クリッピングされたものの描画用）
 static const csmChar* FragShaderSrcMultMask =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -893,7 +893,7 @@ static const csmChar* FragShaderSrcMultMask =
 
 // Mult （クリッピングされたものの描画用、テクスチャがPremultipliedAlphaの場合）
 static const csmChar* FragShaderSrcMultMaskPremultipliedAlpha =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying vec2 v_texCoord;"
@@ -922,7 +922,7 @@ static const csmChar* VertShaderSrcDebug =
         "}";
 
 static const csmChar* FragShaderSrcDebug =
-#ifdef CSM_TARGET_IPHONE_ES2
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
         "precision mediump float;"
 #endif
         "varying lowp vec4 colorVarying; "


### PR DESCRIPTION
In The OpenGL® ES Shading Language 1.0 Specification
> 4.5.3 Default Precision Qualifiers
> The fragment language has no default precision qualifier for floating point types. Hence for float, floating
> point vector and matrix variable declarations, either the declaration must include a precision qualifier or
> the default float precision must have been previously declared.

It caused compilation error like "ERROR: 0:1: 'float' : type requires declaration of default precision qualifier" in Android project.