### PR TITLE
Fixes 'M_PI' : undeclared identifier error on MSVC 9

### DIFF
--- a/src/Math/CubismMath.hpp
+++ b/src/Math/CubismMath.hpp
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
+
 #include <math.h>
 #include "Type/CubismBasicType.hpp"
 #include "Math/CubismVector2.hpp"


### PR DESCRIPTION
MSVC 9 required _USE_MATH_DEFINES define to avoid compilation error:
CubismMath.hpp(97) : error C2065: 'M_PI' : undeclared identifier