### PR TITLE
MSVC 9 compatibility

### DIFF
--- a/src/Motion/CubismMotionInternal.hpp
+++ b/src/Motion/CubismMotionInternal.hpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -44,8 +44,13 @@ enum CubismMotionSegmentType
  */
 struct CubismMotionPoint
 {
-    csmFloat32 Time = 0.0f;         ///< 時間[秒]
-    csmFloat32 Value = 0.0f;        ///< 値
+    CubismMotionPoint()
+        : Time(0.0f)
+        , Value(0.0f)
+    { }
+            
+    csmFloat32 Time;         ///< 時間[秒]
+    csmFloat32 Value;        ///< 値
 };
 
 /**
@@ -112,7 +117,11 @@ struct CubismMotionCurve
 */
 struct CubismMotionEvent
 {
-    csmFloat32  FireTime = 0.0f;
+    CubismMotionEvent()
+        : FireTime(0.0f)
+    { }
+        
+    csmFloat32  FireTime;
     csmString   Value;
 };
 
@@ -129,15 +138,13 @@ struct CubismMotionData
         , CurveCount(0)
         , Fps(0.0f)
         , EventCount(0)
-    {
-        
-    }
+    { }
 
     csmFloat32 Duration;                                ///< モーションの長さ[秒]
-    csmInt16 Loop = 0;                                  ///< ループするかどうか
-    csmInt16 CurveCount = 0;                            ///< カーブの個数
-    csmInt32 EventCount = 0;                         ///< UserDataの個数
-    csmFloat32 Fps = 0.0f;                              ///< フレームレート
+    csmInt16 Loop;                                  ///< ループするかどうか
+    csmInt16 CurveCount;                            ///< カーブの個数
+    csmInt32 EventCount;                         ///< UserDataの個数
+    csmFloat32 Fps;                              ///< フレームレート
     csmVector<CubismMotionCurve> Curves;                ///< カーブのリスト
     csmVector<CubismMotionSegment> Segments;            ///< セグメントのリスト
     csmVector<CubismMotionPoint> Points;                ///< ポイントのリスト

--- a/src/Physics/CubismPhysics.cpp
+++ b/src/Physics/CubismPhysics.cpp
@@ -423,25 +423,25 @@ void CubismPhysics::Initialize()
         strand = &_physicsRig->Particles[currentSetting->BaseParticleIndex];
 
         // Initialize the top of particle.
-        strand[0].InitialPosition = { 0.0f, 0.0f };
+        strand[0].InitialPosition = CubismVector2(0.0f, 0.0f);
         strand[0].LastPosition = strand[0].InitialPosition;
-        strand[0].LastGravity = { 0.0f, -1.0f };
+        strand[0].LastGravity = CubismVector2(0.0f, -1.0f);
         strand[0].LastGravity.Y *= -1.0f;
-        strand[0].Velocity = { 0.0f, 0.0f };
-        strand[0].Force = { 0.0f, 0.0f };
+        strand[0].Velocity = CubismVector2(0.0f, 0.0f);
+        strand[0].Force = CubismVector2(0.0f, 0.0f);
 
         // Initialize paritcles.
         for (i = 1; i < currentSetting->ParticleCount; ++i)
         {
-            radius = { 0.0f, 0.0f };
+            radius = CubismVector2(0.0f, 0.0f);
             radius.Y = strand[i].Radius;
 			strand[i].InitialPosition = strand[i - 1].InitialPosition + radius;
             strand[i].Position = strand[i].InitialPosition;
             strand[i].LastPosition = strand[i].InitialPosition;
-            strand[i].LastGravity = { 0.0f, -1.0f };
+            strand[i].LastGravity = CubismVector2(0.0f, -1.0f);
             strand[i].LastGravity.Y *= -1.0f;
-            strand[i].Velocity = { 0.0f, 0.0f };
-            strand[i].Force = { 0.0f, 0.0f };
+            strand[i].Velocity = CubismVector2(0.0f, 0.0f);
+            strand[i].Force = CubismVector2(0.0f, 0.0f);
         }
     }
 }

--- a/src/Physics/CubismPhysicsJson.cpp
+++ b/src/Physics/CubismPhysicsJson.cpp
@@ -223,9 +223,7 @@ csmInt32 CubismPhysicsJson::GetParticleRadius(csmInt32 physicsSettingIndex, csmI
 
 CubismVector2 CubismPhysicsJson::GetParticlePosition(csmInt32 physicsSettingIndex, csmInt32 vertexIndex) const
 {
-    CubismVector2 ret = {
-        _json->GetRoot()[PhysicsSettings][physicsSettingIndex][Vertices][vertexIndex][Position][X].ToFloat(),
-        _json->GetRoot()[PhysicsSettings][physicsSettingIndex][Vertices][vertexIndex][Position][Y].ToFloat() };
-    return ret;
+    return CubismVector2(_json->GetRoot()[PhysicsSettings][physicsSettingIndex][Vertices][vertexIndex][Position][X].ToFloat(),
+        _json->GetRoot()[PhysicsSettings][physicsSettingIndex][Vertices][vertexIndex][Position][Y].ToFloat() );
 }
 }}}


### PR DESCRIPTION
These commits improve compatibility with MSVC 9. This is helpful to someone who would try to compile Framework for Python 2.7 (RenPy support for example).