### PR TITLE
* Fixed Load String bug in JSON

### DIFF
--- a/src/Type/csmString.cpp
+++ b/src/Type/csmString.cpp
@@ -303,7 +303,7 @@ csmString& csmString::Append(csmInt32 len2, const csmChar c)
     csmChar* newptr = static_cast<csmChar*>(CSM_MALLOC( sizeof(csmChar) * (len1 + len2 + 1)));
 
     memcpy(newptr, this->_ptr, len1); //nullを含めない
-    for (csmInt32 i = len1 + len2 - 1; i >= 0; --i) newptr[i] = c;
+    for (csmInt32 i = len1 + len2 - 1; i >= len1; --i) newptr[i] = c;
 
     Clear(); //現在のポインタを開放してから処理する
 

--- a/src/Utils/CubismJson.cpp
+++ b/src/Utils/CubismJson.cpp
@@ -151,7 +151,7 @@ csmString CubismJson::ParseString(const csmChar* string, csmInt32 length, csmInt
         case '\\': {//エスケープの場合
             i++; //２文字をセットで扱う
 
-            if (i - 1 > buf_start) ret.Append(static_cast<const csmChar*>(string + buf_start), (i - buf_start)); //前の文字までを登録する
+            if (i - 1 > buf_start) ret.Append(static_cast<const csmChar*>(string + buf_start), (i - buf_start - 1)); //前の文字までを登録する
             buf_start = i + 1; //エスケープ（２文字）の次の文字から
 
             if (i < length)


### PR DESCRIPTION
If a line feed code is included in a character string in Json, it can not be read correctly.
I fixed this.