### PR TITLE
Update to Cubism 4 SDK for Native R1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,10 +3,11 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{c,cpp,h,hpp}]
+[*.{cpp,hpp}]
+indent_size = 4
 charset = utf-8-bom

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vs/
+.vscode/
+.idea/
+*.iml
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+
+## [4-r.1] - 2020-01-30
+
+### Added
+
+* Add the callback function called on finished motion playback.
+
+### Changed
+
+* Include header files in CMake.
+* `<GL/glew>` is not included on macOS if `CSM_TARGET_COCOS` is defined.
+
+### Fixed
+
+* Fix rendering not working properly on Android devices with Tegra.
+
+### Deprecated
+
+* Use `target_include_directories` instead of using `FRAMEWORK_XXX_INCLUDE_PATH` variable in application CMake.
+* Use `target_compile_definitions` instead of using `FRAMEWORK_DEFINITIOINS` variable in application CMake.
+* Specify `FRAMEWORK_SOURCE` variable also in OpenGL application CMake.
 
 
 ## [4-beta.2] - 2019-11-14
@@ -41,5 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-beta.2...4-r.1
 [4-beta.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-beta.1...4-beta.2
 [4-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/0f5da4981cc636fe3892bb94d5c60137c9cf1eb1...4-beta.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,103 +1,31 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
-# includeパスの追加
-include_directories(src)
-include_directories(../Core/include)
+set(LIB_NAME Framework)
 
-# 各プラットフォーム共通ファイル
-set(commonfiles
+# Force static library.
+add_library(${LIB_NAME} STATIC)
 
-    src/Effect/CubismBreath.cpp
-    src/Effect/CubismEyeBlink.cpp
-    src/Effect/CubismPose.cpp
+add_subdirectory(src)
 
-    src/Id/CubismId.cpp
-    src/Id/CubismIdManager.cpp
+# Add include path.
+target_include_directories(${LIB_NAME}
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  PRIVATE
+    ${RENDER_INCLUDE_PATH}
+)
 
-    src/Math/CubismMath.cpp
-    src/Math/CubismMatrix44.cpp
-    src/Math/CubismModelMatrix.cpp
-    src/Math/CubismTargetPoint.cpp
-    src/Math/CubismVector2.cpp
-    src/Math/CubismViewMatrix.cpp
+# Deprecated functions
+# The following expressions are written for compatibility
+# and will be removed in a future release.
 
-    src/Model/CubismModel.cpp
-    src/Model/CubismModelUserData.cpp
-    src/Model/CubismModelUserDataJson.cpp
-    src/Model/CubismUserModel.cpp
-    src/Model/CubismMoc.cpp
-
-    src/Motion/CubismExpressionMotion.cpp
-    src/Motion/CubismMotion.cpp
-    src/Motion/CubismMotionJson.cpp
-    src/Motion/CubismMotionManager.cpp
-    src/Motion/CubismMotionQueueEntry.cpp
-    src/Motion/CubismMotionQueueManager.cpp
-    src/Motion/ACubismMotion.cpp
-
-    src/Physics/CubismPhysicsJson.cpp
-    src/Physics/CubismPhysics.cpp
-
-    src/Rendering/CubismRenderer.cpp
-
-    src/Type/csmRectF.cpp
-    src/Type/csmString.cpp
-
-    src/Utils/CubismDebug.cpp
-    src/Utils/CubismJson.cpp
-    src/Utils/CubismString.cpp
-
-    src/CubismDefaultParameterId.cpp
-    src/CubismFramework.cpp
-    src/CubismModelSettingJson.cpp
-    src/CubismCdiJson.cpp)
-
-if(${FRAMEWORK_SOURCE} MATCHES "D3D9")
-    # ここにプロジェクトに追加するソースファイルを追加 DirectX9
-
-    # アプリケーション側で設定したgl系のincludeパスをセットする
-    include_directories(${FRAMEWORK_DX9_INCLUDE_PATH})
-
-    set(Framework
-
-        ${commonfiles}
-
-        src/Rendering/D3D9/CubismRenderer_D3D9.cpp
-        src/Rendering/D3D9/CubismRenderState_D3D9.cpp
-        src/Rendering/D3D9/CubismShader_D3D9.cpp
-        src/Rendering/D3D9/CubismOffscreenSurface_D3D9.cpp)
-
-elseif(${FRAMEWORK_SOURCE} MATCHES "D3D11")
-    # ここにプロジェクトに追加するソースファイルを追加 DirectX11
-
-    # アプリケーション側で設定したgl系のincludeパスをセットする
-    include_directories(${FRAMEWORK_DX11_INCLUDE_PATH})
-
-    set(Framework
-
-        ${commonfiles}
-
-        src/Rendering/D3D11/CubismOffscreenSurface_D3D11.cpp
-        src/Rendering/D3D11/CubismRenderer_D3D11.cpp
-        src/Rendering/D3D11/CubismRenderState_D3D11.cpp
-        src/Rendering/D3D11/CubismShader_D3D11.cpp)
-else()
-    # ここにプロジェクトに追加するソースファイルを追加 OpenGL
-
-    # アプリケーション側で設定したgl系のincludeパスをセットする
-    include_directories(${FRAMEWORK_GLFW_PATH})
-    include_directories(${FRAMEWORK_GLEW_PATH})
-
-    # プリプロセッサ定義の追加
-    add_definitions(${FRAMEWORK_DEFINITIOINS})
-
-    set(Framework
-
-        ${commonfiles}
-
-        src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
-        src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.cpp)
-endif()
-
-# staticライブラリとして追加
-add_library (Framework STATIC ${Framework})
+# Add core include.
+target_include_directories(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Core/include
+)
+# Add definitions.
+target_compile_definitions(${LIB_NAME}
+  PRIVATE
+    ${FRAMEWORK_DEFINITIOINS}
+)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,39 @@
+## Definitions
+
+### Live2D Cubism Components
+
+Cubism Native Framework is included in Live2D Cubism Components.
+
+Cubism Native Framework は Live2D Cubism Components に含まれます。
+
+
+## Cubism SDK Release License
+
+*All business* users must obtain a Cubism SDK Release License. "Business" means an entity with the annual gross revenue more than ten million (10,000,000) JPY for the most recent fiscal year.
+
+* [Cubism SDK Release License](https://www.live2d.com/en/download/cubism-sdk/release-license/)
+
+直近会計年度の売上高が 1000 万円以上の事業者様がご利用になる場合は、Cubism SDK リリースライセンス（出版許諾契約）に同意していただく必要がございます。
+
+* [Cubism SDK リリースライセンス](https://www.live2d.com/ja/download/cubism-sdk/release-license/)
+
+
+## Live2D Open Software License
+
+Live2D Cubism Components is available under Live2D Open Software License.
+
+* [Live2D Open Software License Agreement](https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html)
+* [Live2D Open Software 使用許諾契約書](https://www.live2d.com/eula/live2d-open-software-license-agreement_jp.html)
+
+
+## Live2D Proprietary Software License
+
+Live2D Cubism Core is available under Live2D Proprietary Software License.
+
+* [Live2D Proprietary Software License Agreement](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_en.html)
+* [Live2D Proprietary Software 使用許諾契約書](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_jp.html)
+
+
+---
+
+Please contact us from [here](https://www.live2d.jp/contact/) for more license information.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Cubism Native Framework
 
-Live2D Cubism 4 Editorで出力したモデルをアプリケーションで利用するためのフレームワークです。
+Live2D Cubism 4 Editor で出力したモデルをアプリケーションで利用するためのフレームワークです。
 
 モデルを表示、操作するための各種機能を提供します。
-モデルをロードするにはCubism Coreライブラリと組み合わせて使用します。
+モデルをロードするには Cubism Core ライブラリと組み合わせて使用します。
+
+
+## ライセンス
+
+本フレームワークを使用する前に、[ライセンス](LICENSE.md)をご確認ください。
 
 
 ## コンポーネント
@@ -14,7 +19,7 @@ Live2D Cubism 4 Editorで出力したモデルをアプリケーションで利�
 
 ### Id
 
-モデルに設定されたパラメータ名・パーツ名・Drawable名を独自の型で管理する機能を提供します。
+モデルに設定されたパラメータ名・パーツ名・Drawable 名を独自の型で管理する機能を提供します。
 
 ### Math
 
@@ -38,16 +43,16 @@ Live2D Cubism 4 Editorで出力したモデルをアプリケーションで利�
 
 ### Type
 
-フレームワーク内で使用するC++型定義を提供します。
+本フレームワーク内で使用する C++ 型定義を提供します。
 
 ### Utils
 
-JSONパーサーやログ出力などのユーティリティ機能を提供します。
+JSON パーサーやログ出力などのユーティリティ機能を提供します。
 
 
 ## Live2D Cubism Core for Native
 
-当リポジトリにはLive2D Cubism Core for Nativeは同梱されていません。
+当リポジトリには Live2D Cubism Core for Native は同梱されていません。
 
 ダウンロードするには[こちら](https://www.live2d.com/download/cubism-sdk/download-native/)のページを参照ください。
 
@@ -66,25 +71,4 @@ JSONパーサーやログ出力などのユーティリティ機能を提供し�
 
 ## 変更履歴
 
-当リポジトリの変更履歴については[CHANGELOG.md](/CHANGELOG.md)を参照ください。
-
-
-## ライセンス
-
-Cubism Native Framework は Live2D Open Software License で提供しています。
-- Live2D Open Software License
-
-  [日本語](https://www.live2d.com/eula/live2d-open-software-license-agreement_jp.html)
-  [English](https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html)
-
-Live2D Cubism Core for Native は Live2D Proprietary Software License で提供しています。
-- Live2D Proprietary Software License
-
-  [日本語](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_jp.html)
-  [English](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_en.html)
-
-直近会計年度の売上高が 1000 万円以上の事業者様がご利用になる場合は、SDKリリース(出版許諾)ライセンスに同意していただく必要がございます。
-- [SDKリリース(出版許諾)ライセンス](https://www.live2d.com/ja/products/releaselicense)
-
-*All business* users must obtain a Publication License. "Business" means an entity  with the annual gross revenue more than ten million (10,000,000) JPY for the most recent fiscal year.
-- [SDK Release (Publication) License](https://www.live2d.com/en/products/releaselicense)
+当リポジトリの変更履歴については [CHANGELOG.md](CHANGELOG.md) を参照ください。

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,26 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismCdiJson.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismCdiJson.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismDefaultParameterId.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismDefaultParameterId.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismFramework.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismFramework.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismFrameworkConfig.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelSettingJson.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelSettingJson.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ICubismAllocator.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ICubismModelSetting.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Live2DCubismCore.hpp
+)
+
+# Add sub directories.
+add_subdirectory(Effect)
+add_subdirectory(Id)
+add_subdirectory(Math)
+add_subdirectory(Model)
+add_subdirectory(Motion)
+add_subdirectory(Physics)
+add_subdirectory(Rendering)
+add_subdirectory(Type)
+add_subdirectory(Utils)

--- a/src/CubismFramework.hpp
+++ b/src/CubismFramework.hpp
@@ -26,7 +26,7 @@
 #include <new>
 #include "ICubismAllocator.hpp"
 
-#ifdef linux
+#ifdef __linux__
 #include <cstdlib>
 #endif
 

--- a/src/Effect/CMakeLists.txt
+++ b/src/Effect/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismBreath.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismBreath.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismEyeBlink.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismEyeBlink.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPose.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPose.hpp
+)

--- a/src/Id/CMakeLists.txt
+++ b/src/Id/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismId.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismId.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismIdManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismIdManager.hpp
+)

--- a/src/Math/CMakeLists.txt
+++ b/src/Math/CMakeLists.txt
@@ -1,0 +1,15 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMath.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMath.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMatrix44.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMatrix44.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelMatrix.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelMatrix.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismTargetPoint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismTargetPoint.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismVector2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismVector2.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismViewMatrix.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismViewMatrix.hpp
+)

--- a/src/Model/CMakeLists.txt
+++ b/src/Model/CMakeLists.txt
@@ -1,0 +1,13 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMoc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMoc.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModel.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserData.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserData.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserDataJson.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserDataJson.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismUserModel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismUserModel.hpp
+)

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -157,9 +157,9 @@ csmBool CubismUserModel::IsHit(CubismIdHandle drawableId, csmFloat32 pointX, csm
     return ((left <= tx) && (tx <= right) && (top <= ty) && (ty <= bottom));
 }
 
-ACubismMotion* CubismUserModel::LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name)
+ACubismMotion* CubismUserModel::LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name, ACubismMotion::FinishedMotionCallback onFinishedMotionHandler)
 {
-    return CubismMotion::Create(buffer, size);
+    return CubismMotion::Create(buffer, size, onFinishedMotionHandler);
 }
 
 void CubismUserModel::SetDragging(csmFloat32 x, csmFloat32 y)

--- a/src/Model/CubismUserModel.hpp
+++ b/src/Model/CubismUserModel.hpp
@@ -145,12 +145,13 @@ public:
      *
      * モーションデータを読み込む。
      *
-     * @param[in]   buffer  motion3.jsonファイルが読み込まれているバッファ
-     * @param[in]   size    バッファのサイズ
-     * @param[in]   name    モーションの名前
+     * @param[in]   buffer                      motion3.jsonファイルが読み込まれているバッファ
+     * @param[in]   size                        バッファのサイズ
+     * @param[in]   name                        モーションの名前
+     * @param[in]   onFinishedMotionHandler     モーション再生終了時に呼び出されるコールバック関数。NULLの場合、呼び出されない。
      * @return  モーションクラス
      */
-    virtual ACubismMotion*  LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name);
+    virtual ACubismMotion*  LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name, ACubismMotion::FinishedMotionCallback onFinishedMotionHandler = NULL);
 
     /**
      * @brief 表情データの読み込み

--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -23,6 +23,7 @@ ACubismMotion::ACubismMotion()
     , _fadeOutSeconds(-1.0f)
     , _weight(1.0f)
     , _offsetSeconds(0.0f) //再生の開始時刻
+    , _onFinishedMotion(NULL)
 { }
 
 ACubismMotion::~ACubismMotion()
@@ -53,7 +54,7 @@ void ACubismMotion::UpdateParameters(CubismModel* model, CubismMotionQueueEntry*
         }
     }
 
-    csmFloat32 fadeWeight = _weight; //現在の値と掛け合わせる割合　
+    csmFloat32 fadeWeight = _weight; //現在の値と掛け合わせる割合
 
     //---- フェードイン・アウトの処理 ----
     //単純なサイン関数でイージングする
@@ -130,6 +131,16 @@ void ACubismMotion::SetOffsetTime(csmFloat32 offsetSeconds)
 const csmVector<const csmString*>& ACubismMotion::GetFiredEvent(csmFloat32 beforeCheckTimeSeconds, csmFloat32 motionTimeSeconds)
 {
     return _firedEventValues;
+}
+
+void ACubismMotion::SetFinishedMotionHandler(FinishedMotionCallback onFinishedMotionHandler)
+{
+    this->_onFinishedMotion = onFinishedMotionHandler;
+}
+
+ACubismMotion::FinishedMotionCallback ACubismMotion::GetFinishedMotionHandler()
+{
+    return this->_onFinishedMotion;
 }
 
 }}}

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -24,6 +24,8 @@ class CubismModel;
 class ACubismMotion
 {
 public:
+    /// モーション再生終了コールバック関数定義
+    typedef void (*FinishedMotionCallback)(ACubismMotion* self);
     /**
      * @brief インスタンスの破棄
      *
@@ -152,6 +154,31 @@ public:
     */
     virtual const csmVector<const csmString*>& GetFiredEvent(csmFloat32 beforeCheckTimeSeconds,
                                                                    csmFloat32 motionTimeSeconds);
+
+
+    /**
+     * @brief モーション再生終了コールバックの登録
+     *
+     * モーション再生終了コールバックを登録する。
+     * IsFinishedフラグを設定するタイミングで呼び出される。
+     * 以下の状態の際には呼び出されない:
+     *   1. 再生中のモーションが「ループ」として設定されているとき
+     *   2. コールバックにNULLが登録されているとき
+     *
+     * @param[in]   onFinishedMotionHandler     モーション再生終了コールバック関数
+     */
+    void SetFinishedMotionHandler(FinishedMotionCallback onFinishedMotionHandler);
+
+    /**
+     * @brief モーション再生終了コールバックの取得
+     *
+     * モーション再生終了コールバックを取得する。
+     *
+     * @return  登録されているモーション再生終了コールバック関数。NULLのとき、関数は何も登録されていない。
+     */
+    FinishedMotionCallback GetFinishedMotionHandler();
+
+
 private:
     // Prevention of copy Constructor
     ACubismMotion(const ACubismMotion&);
@@ -183,6 +210,9 @@ protected:
     csmFloat32    _offsetSeconds;        ///< モーション再生の開始時刻[秒]
 
     csmVector<const csmString*>    _firedEventValues;
+
+    // モーション再生終了コールバック関数
+    FinishedMotionCallback _onFinishedMotion;
 };
 
 }}}

--- a/src/Motion/CMakeLists.txt
+++ b/src/Motion/CMakeLists.txt
@@ -1,0 +1,18 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/ACubismMotion.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ACubismMotion.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionMotion.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionMotion.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotion.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotion.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionInternal.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionJson.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionJson.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueEntry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueEntry.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueManager.hpp
+)

--- a/src/Motion/CubismMotion.cpp
+++ b/src/Motion/CubismMotion.cpp
@@ -132,13 +132,14 @@ CubismMotion::~CubismMotion()
     CSM_DELETE(_motionData);
 }
 
-CubismMotion* CubismMotion::Create(const csmByte* buffer, csmSizeInt size)
+CubismMotion* CubismMotion::Create(const csmByte* buffer, csmSizeInt size, FinishedMotionCallback onFinishedMotionHandler)
 {
     CubismMotion* ret = CSM_NEW CubismMotion();
 
     ret->Parse(buffer, size);
     ret->_sourceFrameRate = ret->_motionData->Fps;
     ret->_loopDurationSeconds = ret->_motionData->Duration;
+    ret->_onFinishedMotion = onFinishedMotionHandler;
 
     // NOTE: Editorではループありのモーション書き出しは非対応
     // ret->_loop = (ret->_motionData->Loop > 0);
@@ -384,6 +385,11 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
         }
         else
         {
+            if (this->_onFinishedMotion != NULL)
+            {
+                this->_onFinishedMotion(this);
+            }
+
             motionQueueEntry->IsFinished(true);
         }
     }

--- a/src/Motion/CubismMotion.hpp
+++ b/src/Motion/CubismMotion.hpp
@@ -30,11 +30,12 @@ public:
      *
      * インスタンスを作成する。
      *
-     * @param[in]   buffer  motion3.jsonが読み込まれているバッファ
-     * @param[in]   size    バッファのサイズ
+     * @param[in]   buffer                      motion3.jsonが読み込まれているバッファ
+     * @param[in]   size                        バッファのサイズ
+     * @param[in]   onFinishedMotionHandler     モーション再生終了時に呼び出されるコールバック関数。NULLの場合、呼び出されない。
      * @return  作成されたインスタンス
      */
-    static CubismMotion* Create(const csmByte* buffer, csmSizeInt size);
+    static CubismMotion* Create(const csmByte* buffer, csmSizeInt size, FinishedMotionCallback onFinishedMotionHandler = NULL);
 
     /**
     * @brief モデルのパラメータの更新の実行

--- a/src/Physics/CMakeLists.txt
+++ b/src/Physics/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysics.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysics.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysicsInternal.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysicsJson.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysicsJson.hpp
+)

--- a/src/Rendering/CMakeLists.txt
+++ b/src/Rendering/CMakeLists.txt
@@ -1,0 +1,24 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer.hpp
+)
+
+if(NOT DEFINED FRAMEWORK_SOURCE)
+  message(WARNING
+    "[${LIB_NAME}] Set 'FRAMEWORK_SOURCE' variable to 'OpenGL' when using OpenGL rendering."
+  )
+  set(FRAMEWORK_SOURCE OpenGL)
+endif()
+
+# Add specified rendering directory.
+add_subdirectory(${FRAMEWORK_SOURCE})
+
+# Add include path set in application (Deprecated).
+set(RENDER_INCLUDE_PATH
+  ${FRAMEWORK_DX9_INCLUDE_PATH}
+  ${FRAMEWORK_DX11_INCLUDE_PATH}
+  ${FRAMEWORK_GLEW_PATH}
+  ${FRAMEWORK_GLFW_PATH}
+  PARENT_SCOPE
+)

--- a/src/Rendering/D3D11/CMakeLists.txt
+++ b/src/Rendering/D3D11/CMakeLists.txt
@@ -1,0 +1,13 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismNativeInclude_D3D11.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_D3D11.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_D3D11.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_D3D11.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_D3D11.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderState_D3D11.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderState_D3D11.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_D3D11.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_D3D11.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismType_D3D11.hpp
+)

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
@@ -212,12 +212,12 @@ class CubismRenderer_D3D11 : public CubismRenderer
 public:
 
     /**
-    　* @brief    レンダラを作成するための各種設定
-    　*           モデルロードの前に一度だけ呼び出す
-    　*
-    　* @param[in]   bufferSetNum -> 描画コマンドバッファ数
-      * @param[in]   device     -> 使用デバイス
-    　*/
+     * @brief    レンダラを作成するための各種設定
+     *           モデルロードの前に一度だけ呼び出す
+     *
+     * @param[in]   bufferSetNum -> 描画コマンドバッファ数
+     * @param[in]   device       -> 使用デバイス
+     */
     static void InitializeConstantSettings(csmUint32 bufferSetNum, ID3D11Device* device);
 
     /**

--- a/src/Rendering/D3D9/CMakeLists.txt
+++ b/src/Rendering/D3D9/CMakeLists.txt
@@ -1,0 +1,13 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismNativeInclude_D3D9.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_D3D9.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_D3D9.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_D3D9.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_D3D9.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderState_D3D9.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderState_D3D9.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_D3D9.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_D3D9.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismType_D3D9.hpp
+)

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
@@ -213,12 +213,12 @@ class CubismRenderer_D3D9 : public CubismRenderer
 public:
 
     /**
-    　* @brief    レンダラを作成するための各種設定
-    　*           モデルロードの前に一度だけ呼び出す
-    　*
-    　* @param[in]   bufferSetNum -> 1パーツに付き作成するバッファ数
-      * @param[in]   device     -> 使用デバイス
-    　*/
+     * @brief    レンダラを作成するための各種設定
+     *           モデルロードの前に一度だけ呼び出す
+     *
+     * @param[in]   bufferSetNum -> 1パーツに付き作成するバッファ数
+     * @param[in]   device       -> 使用デバイス
+     */
     static void InitializeConstantSettings(csmUint32 bufferSetNum, LPDIRECT3DDEVICE9 device);
 
     /**

--- a/src/Rendering/OpenGL/CMakeLists.txt
+++ b/src/Rendering/OpenGL/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_OpenGLES2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_OpenGLES2.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_OpenGLES2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_OpenGLES2.hpp
+)

--- a/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp
@@ -25,19 +25,16 @@
 #include <OpenGLES/ES2/glext.h>
 #endif
 
-#ifdef CSM_TARGET_WIN_GL
+#if defined(CSM_TARGET_WIN_GL) || defined(CSM_TARGET_LINUX_GL)
 #include <GL/glew.h>
 #include <GL/gl.h>
 #endif
 
 #ifdef CSM_TARGET_MAC_GL
+#ifndef CSM_TARGET_COCOS
 #include <GL/glew.h>
-#include <OpenGL/gl.h>
 #endif
-
-#ifdef CSM_TARGET_LINUX_GL
-#include <GL/glew.h>
-#include <GL/gl.h>
+#include <OpenGL/gl.h>
 #endif
 
 //------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -720,6 +720,27 @@ static const csmChar* FragShaderSrcSetupMask =
 
         "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
         "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcSetupMaskTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision mediump float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_myPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "void main()"
+        "{"
+        "float isInside = "
+        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
+        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
+        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
+        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
+
+        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
+        "}";
+#endif
 
 //----- バーテックスシェーダプログラム -----
 // Normal & Add & Mult 共通
@@ -778,6 +799,20 @@ static const csmChar* FragShaderSrc =
         "vec4 color = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
         "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
         "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision mediump float;"
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform sampler2D s_texture0;" //_MainTex
+        "uniform vec4 u_baseColor;" //v2f.color
+        "void main()"
+        "{"
+        "vec4 color = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
+        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
+        "}";
+#endif
 
 // Normal & Add & Mult 共通 （PremultipliedAlpha）
 static const csmChar* FragShaderSrcPremultipliedAlpha =
@@ -794,6 +829,19 @@ static const csmChar* FragShaderSrcPremultipliedAlpha =
         "{"
         "gl_FragColor = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
         "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision mediump float;"
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform sampler2D s_texture0;" //_MainTex
+        "uniform vec4 u_baseColor;" //v2f.color
+        "void main()"
+        "{"
+        "gl_FragColor = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
+        "}";
+#endif
 
 // Normal & Add & Mult 共通（クリッピングされたものの描画用）
 static const csmChar* FragShaderSrcMask =
@@ -818,6 +866,27 @@ static const csmChar* FragShaderSrcMask =
         "col_formask = col_formask * maskVal;"
         "gl_FragColor = col_formask;"
         "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision mediump float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "void main()"
+        "{"
+        "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
+        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * maskVal;"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
 
 // Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
 static const csmChar* FragShaderSrcMaskInverted =
@@ -842,6 +911,27 @@ static const csmChar* FragShaderSrcMaskInverted =
         "col_formask = col_formask * (1.0 - maskVal);"
         "gl_FragColor = col_formask;"
         "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskInvertedTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision mediump float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "void main()"
+        "{"
+        "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
+        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * (1.0 - maskVal);"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
 
 // Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
 static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
@@ -865,6 +955,26 @@ static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
         "col_formask = col_formask * maskVal;"
         "gl_FragColor = col_formask;"
         "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision mediump float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "void main()"
+        "{"
+        "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * maskVal;"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
 
 // Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
 static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
@@ -888,161 +998,25 @@ static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
         "col_formask = col_formask * (1.0 - maskVal);"
         "gl_FragColor = col_formask;"
         "}";
-
-#ifdef CSM_TARGET_ANDROID_ES2
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//----- Tegra用フラグメントシェーダプログラム -----
-
-    // マスク生成用
-    const static csmChar* FragShaderSrcSetupMaskForTegra =
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-
+        "precision mediump float;"
         "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
+        "varying vec4 v_clipPos;"
         "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
         "uniform vec4 u_channelFlag;"
         "uniform vec4 u_baseColor;"
         "void main()"
         "{"
-        "float isInside = "
-        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-        "vec4 Cs = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-        "float As = Cs.a;"
-        "Cs.r = gl_LastFragColor.r*(1.0-Cs.r);"
-        "Cs.g = gl_LastFragColor.g*(1.0-Cs.g);"
-        "Cs.b = gl_LastFragColor.b*(1.0-Cs.b);"
-        "Cs.a = gl_LastFragColor.a*(1.0-As);"
-        "gl_FragColor = Cs;"
+        "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * (1.0 - maskVal);"
+        "gl_FragColor = col_formask;"
         "}";
-
-
-    // 共通（上）
-#define  FragShaderSrcHeaderForTegra \
-        "#version 100\n"\
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"\
-        \
-        "varying vec2 v_texCoord;"\
-        "uniform sampler2D s_texture0;"\
-        "uniform vec4 u_baseColor;"\
-        "void main()"\
-        "{"\
-            "vec4 Cs = texture2D(s_texture0 , v_texCoord) * u_baseColor;"\
-            "float As = Cs.a;"
-    // 共通（下）
-#define FragShaderSrcFooterForTegra \
-            "#version 100\n"\
-            "gl_FragColor = Cs ;"\
-        "}"
-
-    // 共通：マスク（上）
-#define  FragShaderSrcHeaderMaskForTegra \
-        "#version 100\n"\
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"\
-        \
-        "varying vec2 v_texCoord;"\
-        "varying vec4 v_clipPos;"\
-        "uniform sampler2D s_texture0;"\
-        "uniform sampler2D s_texture1;"\
-        "uniform vec4 u_channelFlag;"\
-        "uniform vec4 u_baseColor;"\
-        "void main()"\
-        "{"\
-            "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"\
-            "float As = col_formask.a;"
-
-    // 共通：マスク（中）
-#define  FragShaderSrcMiderMaskForTegra \
-        "#version 100\n"\
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
-
-    // 共通：マスク（下）
-#define  FragShaderSrcFooterMaskForTegra \
-        "#version 100\n"\
-        "gl_FragColor = col_formask;"\
-        "}"
-
-#define  FragShaderSrcStrateMask \
-        "#version 100\n"\
-        "col_formask = col_formask * maskVal;"
-
-#define  FragShaderSrcInvertedMask \
-        "#version 100\n"\
-        "col_formask = col_formask * ( 1.0 - maskVal);"\
-
-    // Normal
-#define  FragShaderSrcNormalForTegra \
-        "#version 100\n"\
-        "col_formask.r = col_formask.r * As + gl_LastFragColor.r*(1.0-As);"\
-        "col_formask.g = col_formask.g * As + gl_LastFragColor.g*(1.0-As);"\
-        "col_formask.b = col_formask.b * As + gl_LastFragColor.b*(1.0-As);"\
-        "col_formask.a = col_formask.a      + gl_LastFragColor.a*(1.0-As);"
-
-    // Normal （PremultipliedAlpha）
-#define  FragShaderSrcNormalPremultipliedAlphaForTegra \
-        "#version 100\n"\
-        "col_formask.r = col_formask.r + gl_LastFragColor.r*(1.0-As);"\
-        "col_formask.g = col_formask.g + gl_LastFragColor.g*(1.0-As);"\
-        "col_formask.b = col_formask.b + gl_LastFragColor.b*(1.0-As);"\
-        "col_formask.a = col_formask.a + gl_LastFragColor.a*(1.0-As);"
-
-    // Add
-#define  FragShaderSrcAddForTegra \
-        "#version 100\n"\
-        "col_formask.r = col_formask.r * As + gl_LastFragColor.r;"\
-        "col_formask.g = col_formask.g * As + gl_LastFragColor.g;"\
-        "col_formask.b = col_formask.b * As + gl_LastFragColor.b;"\
-        "col_formask.a = gl_LastFragColor.a;"
-
-    // Add （PremultipliedAlpha）
-#define  FragShaderSrcAddPremultipliedAlphaForTegra \
-        "#version 100\n"\
-        "col_formask.r = col_formask.r + gl_LastFragColor.r;"\
-        "col_formask.g = col_formask.g + gl_LastFragColor.g;"\
-        "col_formask.b = col_formask.b + gl_LastFragColor.b;"\
-        "col_formask.a = gl_LastFragColor.a;"
-
-    // Mult
-#define  FragShaderSrcMultForTegra \
-        "#version 100\n"\
-        "col_formask.r = col_formask.r * gl_LastFragColor.r * As + gl_LastFragColor.r*(1.0-As);"\
-        "col_formask.g = col_formask.g * gl_LastFragColor.g * As + gl_LastFragColor.g*(1.0-As);"\
-        "col_formask.b = col_formask.b * gl_LastFragColor.b * As + gl_LastFragColor.b*(1.0-As);"\
-        "col_formask.a = gl_LastFragColor.a;"
-
-    // Mult （PremultipliedAlpha）
-#define  FragShaderSrcMultPremultipliedAlphaForTegra \
-        "#version 100\n"\
-        "col_formask.r = col_formask.r * gl_LastFragColor.r + gl_LastFragColor.r*(1.0-As);"\
-        "col_formask.g = col_formask.g * gl_LastFragColor.g + gl_LastFragColor.g*(1.0-As);"\
-        "col_formask.b = col_formask.b * gl_LastFragColor.b + gl_LastFragColor.b*(1.0-As);"\
-        "col_formask.a = gl_LastFragColor.a;"
-
-    static const csmChar * FragSrcNormal = FragShaderSrcHeaderForTegra FragShaderSrcNormalForTegra FragShaderSrcFooterForTegra;
-    static const csmChar * FragSrcNormalMask = FragShaderSrcHeaderMaskForTegra FragShaderSrcNormalForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcStrateMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcNormalMaskInverted = FragShaderSrcHeaderMaskForTegra FragShaderSrcNormalForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcInvertedMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcNormalPremultipliedAlpha = FragShaderSrcHeaderForTegra FragShaderSrcNormalPremultipliedAlphaForTegra FragShaderSrcFooterForTegra;
-    static const csmChar * FragSrcNormalMaskPremultipliedAlpha = FragShaderSrcHeaderMaskForTegra FragShaderSrcNormalPremultipliedAlphaForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcStrateMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcNormalMaskInvertedPremultipliedAlpha = FragShaderSrcHeaderMaskForTegra FragShaderSrcNormalPremultipliedAlphaForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcInvertedMask FragShaderSrcFooterMaskForTegra;
-
-    static const csmChar * FragSrcAdd = FragShaderSrcHeaderForTegra FragShaderSrcAddForTegra FragShaderSrcFooterForTegra;
-    static const csmChar * FragSrcAddMask = FragShaderSrcHeaderMaskForTegra FragShaderSrcAddForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcStrateMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcAddMaskInverted = FragShaderSrcHeaderMaskForTegra FragShaderSrcAddForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcInvertedMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcAddPremultipliedAlpha = FragShaderSrcHeaderForTegra FragShaderSrcAddPremultipliedAlphaForTegra FragShaderSrcFooterForTegra;
-    static const csmChar * FragSrcAddMaskPremultipliedAlpha = FragShaderSrcHeaderMaskForTegra FragShaderSrcAddPremultipliedAlphaForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcStrateMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcAddMaskInvertedPremultipliedAlpha = FragShaderSrcHeaderMaskForTegra FragShaderSrcAddPremultipliedAlphaForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcInvertedMask FragShaderSrcFooterMaskForTegra;
-
-    static const csmChar * FragSrcMult = FragShaderSrcHeaderForTegra FragShaderSrcMultForTegra FragShaderSrcFooterForTegra;
-    static const csmChar * FragSrcMultMask = FragShaderSrcHeaderMaskForTegra FragShaderSrcMultForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcStrateMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcMultMaskInverted = FragShaderSrcHeaderMaskForTegra FragShaderSrcMultForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcInvertedMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcMultPremultipliedAlpha = FragShaderSrcHeaderForTegra FragShaderSrcMultPremultipliedAlphaForTegra FragShaderSrcFooterForTegra;
-    static const csmChar * FragSrcMultMaskPremultipliedAlpha = FragShaderSrcHeaderMaskForTegra FragShaderSrcMultPremultipliedAlphaForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcStrateMask FragShaderSrcFooterMaskForTegra;
-    static const csmChar * FragSrcMultMaskInvertedPremultipliedAlpha = FragShaderSrcHeaderMaskForTegra FragShaderSrcMultPremultipliedAlphaForTegra FragShaderSrcMiderMaskForTegra FragShaderSrcInvertedMask FragShaderSrcFooterMaskForTegra;
-
 #endif
 
 CubismShader_OpenGLES2::CubismShader_OpenGLES2()
@@ -1090,28 +1064,14 @@ void CubismShader_OpenGLES2::GenerateShaders()
 #ifdef CSM_TARGET_ANDROID_ES2
     if (s_extMode)
     {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskForTegra);
+        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskTegra);
 
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragSrcNormal);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcNormalMask);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcNormalMaskInverted);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragSrcNormalPremultipliedAlpha);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcNormalMaskPremultipliedAlpha);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcNormalMaskInvertedPremultipliedAlpha);
-
-        _shaderSets[7]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragSrcAdd);
-        _shaderSets[8]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcAddMask);
-        _shaderSets[9]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcAddMaskInverted);
-        _shaderSets[10]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragSrcAddPremultipliedAlpha);
-        _shaderSets[11]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcAddMaskPremultipliedAlpha);
-        _shaderSets[12]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcAddMaskInvertedPremultipliedAlpha);
-
-        _shaderSets[13]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragSrcMult);
-        _shaderSets[14]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcMultMask);
-        _shaderSets[15]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcMultMaskInverted);
-        _shaderSets[16]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragSrcMultMask);
-        _shaderSets[17]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcMultMaskPremultipliedAlpha);
-        _shaderSets[18]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragSrcMultMaskInvertedPremultipliedAlpha);
+        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcTegra);
+        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskTegra);
+        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedTegra);
+        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlphaTegra);
+        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlphaTegra);
+        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlphaTegra);
     }
     else
     {
@@ -1123,23 +1083,23 @@ void CubismShader_OpenGLES2::GenerateShaders()
         _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
         _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
         _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
-
-        // 加算も通常と同じシェーダーを利用する
-        _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-        _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-        _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-        _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-        _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-        _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-        // 乗算も通常と同じシェーダーを利用する
-        _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-        _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-        _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-        _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-        _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-        _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
     }
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
 
 #else
 

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp
@@ -26,19 +26,16 @@
 #include <OpenGLES/ES2/glext.h>
 #endif
 
-#ifdef CSM_TARGET_WIN_GL
+#if defined(CSM_TARGET_WIN_GL) || defined(CSM_TARGET_LINUX_GL)
 #include <GL/glew.h>
 #include <GL/gl.h>
 #endif
 
 #ifdef CSM_TARGET_MAC_GL
+#ifndef CSM_TARGET_COCOS
 #include <GL/glew.h>
-#include <OpenGL/gl.h>
 #endif
-
-#ifdef CSM_TARGET_LINUX_GL
-#include <GL/glew.h>
-#include <GL/gl.h>
+#include <OpenGL/gl.h>
 #endif
 
 //------------ LIVE2D NAMESPACE ------------

--- a/src/Type/CMakeLists.txt
+++ b/src/Type/CMakeLists.txt
@@ -1,0 +1,10 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csmMap.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csmRectF.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csmRectF.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csmString.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csmString.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csmVector.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismBasicType.hpp
+)

--- a/src/Utils/CMakeLists.txt
+++ b/src/Utils/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismDebug.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismDebug.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismJson.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismJson.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismString.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismString.hpp
+)


### PR DESCRIPTION
### Added

* Add the callback function called on finished motion playback.

### Changed

* Include header files in CMake.
* `<GL/glew>` is not included on macOS if `CSM_TARGET_COCOS` is defined.

### Fixed

* Fix rendering not working properly on Android devices with Tegra.

### Deprecated

* Use `target_include_directories` instead of using `FRAMEWORK_XXX_INCLUDE_PATH` variable in application CMake.
* Use `target_compile_definitions` instead of using `FRAMEWORK_DEFINITIOINS` variable in application CMake.
* Specify `FRAMEWORK_SOURCE` variable also in OpenGL application CMake.
