### PR TITLE
Fix memory bug causing segmentation fault when reallocating memory

### DIFF
--- a/src/Type/csmVector.hpp
+++ b/src/Type/csmVector.hpp
@@ -616,14 +616,19 @@ void csmVector<T>::PrepareCapacity(csmInt32 newSize)
         {
             csmInt32 tmp_capacity = newSize;
             T* tmp = static_cast<T *>(CSM_MALLOC(sizeof(T) * tmp_capacity));
+            csmInt32 tmp_size = _size;
 
             CSM_ASSERT(tmp != NULL);
 
-            memcpy(static_cast<void*>(tmp), static_cast<void*>(_ptr), sizeof(T) * _capacity); // 通常のMALLOCになったためコピーする
-            CSM_FREE(_ptr);
+            for (csmInt32 i = 0; i < _size; i++)
+            {
+                CSM_PLACEMENT_NEW(&tmp[i]) T(_ptr[i]);
+            }
+            Clear();
 
             _ptr = tmp;
             _capacity = newSize;
+            _size = tmp_size;
         }
     }
 }


### PR DESCRIPTION
When csmVector is used with std::string, as it is in the Linux
sample code, a segmentation fault occurs. This is due to csmVector
using memcpy when reallocating memory.

A proper way to handle memory would be to explicitly construct
new objects and then destroying the old ones, one by one,
instead of using memcpy().

It is understood that this approach may have performance penalties,
and it is also not well tested for cases where PushBack is called
with callPlacementNew set to false. This commit is provided to
the upstream maintainers to let them decide which approach to fix
the segfault is best for them.