### PR TITLE
Update to Cubism 4 SDK for Native R4 beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.4-beta.1] - 2021-10-07
+
+### Added
+
+* Add a function to parse the opacity from `.motion3.json`.
+* Add a Renderer for Metal API in iOS.
+  * There are some restrictions, see [NOTICE.md](NOTICE.md).
+
+### Fixed
+
+* Fix return correct error values for out-of-index arguments in cubismjson by [@cocor-au-lait](https://github.com/cocor-au-lait).
+* Fix a warning when `SegmentType` could not be obtained when loading motion.
+* Fix renderer for Cocos2d-x v4.0.
+  * Rendering didn't work when using `USE_RENDER_TARGET` and high precision masking.
+
+
 ## [4-r.3] - 2021-06-10
 
 ## [4-r.3-beta.1] - 2021-05-13
@@ -100,6 +116,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.4-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.3...4-r.4-beta.1
 [4-r.3]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.3-beta.1...4-r.3
 [4-r.3-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.2...4-r.3-beta.1
 [4-r.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.1...4-r.2

--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -143,4 +143,24 @@ ACubismMotion::FinishedMotionCallback ACubismMotion::GetFinishedMotionHandler()
     return this->_onFinishedMotion;
 }
 
+csmBool ACubismMotion::IsExistOpacity() const
+{
+    return false;
+}
+
+csmInt32 ACubismMotion::GetOpacityIndex() const
+{
+    return -1;
+}
+
+CubismIdHandle ACubismMotion::GetOpacityId(csmInt32 index)
+{
+    return NULL;
+}
+
+csmFloat32 ACubismMotion::GetOpacityValue(csmFloat32 motionTimeSeconds) const
+{
+    return 1.0f;
+}
+
 }}}

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "CubismFramework.hpp"
+#include "Id/CubismId.hpp"
 #include "Type/csmVector.hpp"
 
 namespace Live2D { namespace Cubism { namespace Framework {
@@ -178,6 +179,38 @@ public:
      */
     FinishedMotionCallback GetFinishedMotionHandler();
 
+    /**
+    * @brief        透明度のカーブが存在するかどうかを確認する
+    *
+    * @retval       true  -> キーが存在する
+    * @retval       false -> キーが存在しない
+    */
+    virtual csmBool IsExistOpacity() const;
+
+    /**
+    * @brief 透明度のカーブのインデックスを返す
+    *
+    *
+    * @return  success：透明度のカーブのインデックス
+    */
+    virtual csmInt32 GetOpacityIndex() const;
+
+    /**
+    * @brief 透明度のIdを返す
+    *
+    *
+    * @return  success：透明度のId
+    */
+    virtual CubismIdHandle GetOpacityId(csmInt32 index);
+
+    /**
+    * @brief 指定時間の透明度の値を返す
+    *
+    * @param[in]   motionTimeSeconds        現在の再生時間[秒]
+    *
+    * @return  success：モーションの当該時間におけるOpacityの値
+    */
+    virtual csmFloat32 GetOpacityValue(csmFloat32 motionTimeSeconds) const;
 
 private:
     // Prevention of copy Constructor

--- a/src/Motion/CubismMotion.hpp
+++ b/src/Motion/CubismMotion.hpp
@@ -166,6 +166,39 @@ public:
     */
     virtual const csmVector<const csmString*>& GetFiredEvent(csmFloat32 beforeCheckTimeSeconds, csmFloat32 motionTimeSeconds);
 
+    /**
+    * @brief        透明度のカーブが存在するかどうかを確認する
+    *
+    * @retval       true  -> キーが存在する
+    * @retval       false -> キーが存在しない
+    */
+    csmBool IsExistOpacity() const;
+
+    /**
+    * @brief 透明度のカーブのインデックスを返す
+    *
+    *
+    * @return  success：透明度のカーブのインデックス
+    */
+    csmInt32 GetOpacityIndex() const;
+
+    /**
+    * @brief 透明度のIdを返す
+    *
+    *
+    * @return  success：透明度のId
+    */
+    CubismIdHandle GetOpacityId(csmInt32 index);
+
+    /**
+    * @brief 指定時間の透明度の値を返す
+    *
+    * @param[in]   motionTimeSeconds        現在の再生時間[秒]
+    *
+    * @return  success：モーションの当該時間におけるOpacityの値
+    */
+    csmFloat32 GetOpacityValue(csmFloat32 motionTimeSeconds) const;
+
 private:
     /**
      * @brief コンストラクタ

--- a/src/Motion/CubismMotionManager.cpp
+++ b/src/Motion/CubismMotionManager.cpp
@@ -44,11 +44,11 @@ CubismMotionQueueEntryHandle CubismMotionManager::StartMotionPriority(ACubismMot
     return CubismMotionQueueManager::StartMotion(motion, autoDelete, _userTimeSeconds);
 }
 
-csmBool CubismMotionManager::UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds)
+csmBool CubismMotionManager::UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds, csmFloat32* opacity)
 {
     _userTimeSeconds += deltaTimeSeconds;
 
-    const csmBool updated = CubismMotionQueueManager::DoUpdateMotion(model, _userTimeSeconds);
+    const csmBool updated = CubismMotionQueueManager::DoUpdateMotion(model, _userTimeSeconds, opacity);
 
     if (IsFinished())
     {

--- a/src/Motion/CubismMotionManager.hpp
+++ b/src/Motion/CubismMotionManager.hpp
@@ -81,10 +81,11 @@ public:
      *
      * @param[in]   model   対象のモデル
      * @param[in]   deltaTimeSeconds    デルタ時間[秒]
+     * @param[in][out]   opacity 透明度の値（Nullable）
      * @retval  true    更新されている
      * @retval  false   更新されていない
      */
-    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds);
+    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds, csmFloat32* opacity = nullptr);
 
     /**
      * @brief モーションの予約

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -8,6 +8,7 @@
 #include "CubismMotionQueueManager.hpp"
 #include "CubismMotionQueueEntry.hpp"
 #include "CubismFramework.hpp"
+#include "CubismMotion.hpp"
 
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -60,7 +61,7 @@ CubismMotionQueueEntryHandle CubismMotionQueueManager::StartMotion(ACubismMotion
     return motionQueueEntry->_motionQueueEntryHandle;
 }
 
-csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds)
+csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32* opacity)
 {
     csmBool updated = false;
 
@@ -90,6 +91,9 @@ csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 
         // ------ 値を反映する ------
         motion->UpdateParameters(model, motionQueueEntry, userTimeSeconds);
         updated = true;
+
+        // ------ 不透明度の値が存在すれば反映する ------
+        opacity = new csmFloat32(motion->GetOpacityValue(userTimeSeconds - motionQueueEntry->GetStartTime()));
 
         // ------ ユーザトリガーイベントを検査する ----
         const csmVector<const csmString*>& firedList = motion->GetFiredEvent(

--- a/src/Motion/CubismMotionQueueManager.hpp
+++ b/src/Motion/CubismMotionQueueManager.hpp
@@ -131,10 +131,11 @@ protected:
     *
     * @param[in]   model   対象のモデル
     * @param[in]   userTimeSeconds   デルタ時間の積算値[秒]
+    * @param[in][out]   opacity 透明度の値（Nullable）
     * @retval  true    モデルへパラメータ値の反映あり
     * @retval  false   モデルへパラメータ値の反映なし(モーションの変化なし)
     */
-    virtual csmBool     DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds);
+    virtual csmBool     DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32* opacity = nullptr);
 
 
     csmFloat32 _userTimeSeconds;        ///< デルタ時間の積算値[秒]

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
@@ -11,6 +11,7 @@
 #include "CubismFramework.hpp"
 #include "CubismOffscreenSurface_Cocos2dx.hpp"
 #include "CubismCommandBuffer_Cocos2dx.hpp"
+#include "Math/CubismVector2.hpp"
 #include "Type/csmVector.hpp"
 #include "Type/csmRectF.hpp"
 #include "Type/csmMap.hpp"
@@ -137,7 +138,7 @@ private:
      *@param  size -> クリッピングマスクバッファのサイズ
      *
      */
-    void SetClippingMaskBufferSize(csmInt32 size);
+    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
 
     /**
      *@brief  クリッピングマスクバッファのサイズを取得する
@@ -145,14 +146,14 @@ private:
      *@return クリッピングマスクバッファのサイズ
      *
      */
-    csmInt32 GetClippingMaskBufferSize() const;
+    CubismVector2 GetClippingMaskBufferSize() const;
 
     csmInt32    _currentFrameNo;         ///< マスクテクスチャに与えるフレーム番号
 
     csmVector<CubismRenderer::CubismTextureColor*>  _channelColors;
     csmVector<CubismClippingContext*>               _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
     csmVector<CubismClippingContext*>               _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
-    csmInt32                                        _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
+    CubismVector2                                   _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
 
     CubismMatrix44  _tmpMatrix;              ///< マスク計算用の行列
     CubismMatrix44  _tmpMatrixForMask;       ///< マスク計算用の行列
@@ -404,10 +405,11 @@ public:
      * @brief  クリッピングマスクバッファのサイズを設定する<br>
      *         マスク用のFrameBufferを破棄・再作成するため処理コストは高い。
      *
-     * @param[in]  size -> クリッピングマスクバッファのサイズ
+     * @param[in]  width -> クリッピングマスクバッファの横サイズ
+     * @param[in]  height -> クリッピングマスクバッファの縦サイズ
      *
      */
-    void SetClippingMaskBufferSize(csmInt32 size);
+    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
 
     /**
      * @brief  クリッピングマスクバッファのサイズを取得する
@@ -415,13 +417,14 @@ public:
      * @return クリッピングマスクバッファのサイズ
      *
      */
-    csmInt32 GetClippingMaskBufferSize() const;
+    CubismVector2 GetClippingMaskBufferSize() const;
 
 
-    CubismCommandBuffer_Cocos2dx* GetCommandBuffer()
-    {
-        return &_commandBuffer;
-    }
+    static CubismCommandBuffer_Cocos2dx* GetCommandBuffer();
+
+    static void StartFrame(CubismCommandBuffer_Cocos2dx* commandBuffer);
+
+    static void EndFrame(CubismCommandBuffer_Cocos2dx* commandBuffer);
 
 protected:
     /**
@@ -547,7 +550,6 @@ private:
     CubismClippingContext*              _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
 
     CubismOffscreenFrame_Cocos2dx      _offscreenFrameBuffer;          ///< マスク描画用のフレームバッファ
-    CubismCommandBuffer_Cocos2dx       _commandBuffer;
     csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*>  _drawableDrawCommandBuffer;
 };
 

--- a/src/Utils/CubismJson.cpp
+++ b/src/Utils/CubismJson.cpp
@@ -26,13 +26,13 @@ void Value::StaticReleaseNotForClientCall()
 {
     CSM_DELETE(Boolean::TrueValue);
     CSM_DELETE(Boolean::FalseValue);
-    CSM_DELETE(Error::ErrorValue);
+    CSM_DELETE(Value::ErrorValue);
     CSM_DELETE(Value::NullValue);
     CSM_DELETE(Value::s_dummyKeys);
 
     Boolean::TrueValue = NULL;
     Boolean::FalseValue = NULL;
-    Error::ErrorValue = NULL;
+    Value::ErrorValue = NULL;
     Value::NullValue = NULL;
     Value::s_dummyKeys = NULL;
 }
@@ -42,8 +42,8 @@ void Value::StaticInitializeNotForClientCall()
     Boolean::TrueValue = CSM_NEW Boolean(true);
     Boolean::FalseValue = CSM_NEW Boolean(false);
 
-    Error::ErrorValue = CSM_NEW Error("ERROR", true);
-    NullValue = CSM_NEW Utils::NullValue();
+    Value::ErrorValue = CSM_NEW Error("ERROR", true);
+    Value::NullValue = CSM_NEW Utils::NullValue();
 
     Value::s_dummyKeys = CSM_NEW csmVector<csmString>();
 }

--- a/src/Utils/CubismJson.hpp
+++ b/src/Utils/CubismJson.hpp
@@ -90,7 +90,13 @@ public:
      * @brief   要素をコンテナで返す(csmVector<Value*>)
      *
      */
-    virtual csmVector<Value*>* GetVector(csmVector<Value*>* defaultValue = NULL) { return defaultValue; }
+    virtual csmVector<Value*>* GetVector(csmVector<Value*>* defaultValue = NULL) {
+        if (!defaultValue)
+        {
+            defaultValue = new csmVector<Value*>;
+        }
+        return defaultValue;
+    }
 
     /**
      * @brief   要素をマップで返す(csmMap<csmString, Value*>)
@@ -203,7 +209,10 @@ public:
     /**
      *@brief Valueにエラー値をセットする
      */
-    virtual Value* SetErrorNotForClientCall(const csmChar* errorStr) { return ErrorValue; }
+    virtual Value* SetErrorNotForClientCall(const csmChar* errorStr) {
+        this->_stringBuffer = errorStr;
+        return NullValue;
+    }
 
 protected:
     csmString _stringBuffer;        ///< 文字列バッファ


### PR DESCRIPTION
### Added

* Add a function to parse the opacity from `.motion3.json`.
* Add a Renderer for Metal API in iOS.
  * There are some restrictions, see [NOTICE.md](NOTICE.md).

### Fixed

* Fix return correct error values for out-of-index arguments in cubismjson by [@cocor-au-lait](https://github.com/cocor-au-lait).
* Fix a warning when `SegmentType` could not be obtained when loading motion.
* Fix renderer for Cocos2d-x v4.0.
  * Rendering didn't work when using `USE_RENDER_TARGET` and high precision masking.