### PR TITLE
[#2] Update to Cubism 4 SDK for Native R4 beta1

### DIFF
--- a/src/Rendering/Metal/CMakeLists.txt
+++ b/src/Rendering/Metal/CMakeLists.txt
@@ -1,0 +1,18 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_Metal.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_Metal.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Metal.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Metal.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismCommandBuffer_Metal.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismCommandBuffer_Metal.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderingInstanceSingleton_Metal.m
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderingInstanceSingleton_Metal.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/MetalShaderTypes.h
+)
+
+set_source_files_properties(
+  CubismRenderingInstanceSingleton_Metal.m
+  TARGET_DIRECTORY ${LIB_NAME}
+  PROPERTIES COMPILE_FLAGS "-fno-objc-arc"
+)

--- a/src/Rendering/Metal/CubismCommandBuffer_Metal.hpp
+++ b/src/Rendering/Metal/CubismCommandBuffer_Metal.hpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <MetalKit/MetalKit.h>
+#include "CubismFramework.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+class CubismOffscreenFrame_Metal;
+
+class CubismCommandBuffer_Metal
+{
+public:
+    class DrawCommandBuffer
+    {
+    public:
+        class DrawCommand
+        {
+        public:
+            DrawCommand();
+            virtual ~DrawCommand();
+
+            id <MTLCommandBuffer> GetMTLCommandBuffer();
+            void SetMTLCommandBuffer(id <MTLCommandBuffer> commandBuffer);
+
+            /**
+             * @brief   MTLRenderPassDescriptor生成・取得
+             */
+            MTLRenderPassDescriptor* GetRenderPassDescriptor();
+            id <MTLRenderPipelineState> GetRenderPipelineState();
+            void SetRenderPipelineState(id <MTLRenderPipelineState> renderPipelineState);
+
+        private:
+            DrawCommand& operator=(const DrawCommand&);
+            id <MTLCommandBuffer> _mtlCommandBuffer;
+            MTLRenderPassDescriptor* _renderPassDescriptor;
+            id <MTLRenderPipelineState> _pipelineState;
+        };
+
+        DrawCommandBuffer();
+        virtual ~DrawCommandBuffer();
+
+        /**
+         * @brief  頂点バッファ生成
+         * @param  device     MTLDevice
+         * @param  stride    頂点ごとのバッファ長
+         * @param  count       頂点数
+         */
+        void CreateVertexBuffer(id<MTLDevice> device, csmSizeInt stride, csmSizeInt count);
+
+        /**
+         * @brief  頂点インデックス生成
+         * @param  device     MTLDevice
+         * @param  count       頂点数
+         */
+        void CreateIndexBuffer(id<MTLDevice> device, csmSizeInt count);
+
+        /**
+         * @brief  頂点バッファ更新
+         * @param  data     頂点座標データ
+         * @param  uvData    UVデータ
+         * @param  count       頂点数
+         */
+        void UpdateVertexBuffer(void* data, void* uvData, csmSizeInt count);
+
+        /**
+         * @brief  頂点インデックス更新
+         * @param  data     頂点インデックスデータ
+         * @param  count       頂点数
+         */
+        void UpdateIndexBuffer(void* data, csmSizeInt count);
+
+        void SetCommandBuffer(id <MTLCommandBuffer> commandBuffer);
+
+        DrawCommand* GetCommandDraw();
+        id <MTLBuffer> GetVertexBuffer();
+        id <MTLBuffer> GetUvBuffer();
+        id <MTLBuffer> GetIndexBuffer();
+
+    private:
+        DrawCommand _drawCommandDraw;
+        csmSizeInt _vbStride;
+        csmSizeInt _vbCount;
+        csmSizeInt _ibCount;
+        csmUint8* _drawBuffer;
+        id <MTLBuffer> _vertices;
+        id <MTLBuffer> _uvs;
+        id <MTLBuffer> _indices;
+    };
+
+    CubismCommandBuffer_Metal();
+    virtual ~CubismCommandBuffer_Metal();
+};
+
+}}}}

--- a/src/Rendering/Metal/CubismCommandBuffer_Metal.mm
+++ b/src/Rendering/Metal/CubismCommandBuffer_Metal.mm
@@ -1,0 +1,143 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismCommandBuffer_Metal.hpp"
+#include "CubismFramework.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D {
+namespace Cubism {
+namespace Framework {
+namespace Rendering {
+CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::DrawCommand()
+{
+}
+
+CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::~DrawCommand()
+{
+}
+
+id <MTLCommandBuffer> CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::GetMTLCommandBuffer()
+{
+    return _mtlCommandBuffer;
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::SetMTLCommandBuffer(id <MTLCommandBuffer> commandBuffer)
+{
+    _mtlCommandBuffer = commandBuffer;
+}
+
+MTLRenderPassDescriptor* CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::GetRenderPassDescriptor()
+{
+    if (_renderPassDescriptor == NULL) {
+        _renderPassDescriptor = [MTLRenderPassDescriptor new];
+    }
+    return _renderPassDescriptor;
+}
+
+id <MTLRenderPipelineState> CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::GetRenderPipelineState()
+{
+    return _pipelineState;
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::SetRenderPipelineState(id <MTLRenderPipelineState> renderPipelineState)
+{
+    _pipelineState = renderPipelineState;
+}
+
+CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommandBuffer()
+    : _vbStride(0)
+    , _vbCount(0)
+    , _ibCount(0)
+{
+}
+
+CubismCommandBuffer_Metal::DrawCommandBuffer::~DrawCommandBuffer()
+{
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::CreateVertexBuffer(id<MTLDevice> device, csmSizeInt stride, csmSizeInt count)
+{
+    _vbStride = stride;
+    _vbCount = count;
+    _vertices = [device newBufferWithLength:_vbStride * count
+                                                options:MTLResourceStorageModeShared];
+
+    _uvs = [device newBufferWithLength:_vbStride * count
+                                                options:MTLResourceStorageModeShared];
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::CreateIndexBuffer(id<MTLDevice> device, csmSizeInt count)
+{
+    _ibCount = count;
+    _indices = [device newBufferWithLength:sizeof(csmInt16) * _ibCount
+                                                options:MTLResourceStorageModeShared];
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::UpdateVertexBuffer(void* data, void* uvData, csmSizeInt count)
+{
+    csmSizeInt length = count * _vbStride;
+    csmFloat32* destVertices = reinterpret_cast<csmFloat32*>([_vertices contents]);
+    csmFloat32* destUvs = reinterpret_cast<csmFloat32*>([_uvs contents]);
+    csmFloat32* sourceVertices = reinterpret_cast<csmFloat32*>(data);
+    csmFloat32* sourceUvs = reinterpret_cast<csmFloat32*>(uvData);
+
+    memcpy(destVertices, sourceVertices, length);
+    memcpy(destUvs, sourceUvs, length);
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::UpdateIndexBuffer(void* data, csmSizeInt count)
+{
+    csmSizeInt length = count * sizeof(csmInt16);
+
+    csmInt16* dest = reinterpret_cast<csmInt16*>([_indices contents]);
+
+    csmInt16* sourceIndices = reinterpret_cast<csmInt16*>(data);
+
+    for (csmUint32 i = 0, j = 0; i < count; ++i)
+    {
+
+        *dest = *sourceIndices;
+        dest++;
+        sourceIndices++;
+    }
+}
+
+CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* CubismCommandBuffer_Metal::DrawCommandBuffer::GetCommandDraw()
+{
+    return &_drawCommandDraw;
+}
+
+void CubismCommandBuffer_Metal::DrawCommandBuffer::SetCommandBuffer(id <MTLCommandBuffer> commandBuffer)
+{
+    _drawCommandDraw.SetMTLCommandBuffer(commandBuffer);
+}
+
+id <MTLBuffer> CubismCommandBuffer_Metal::DrawCommandBuffer::GetVertexBuffer()
+{
+    return _vertices;
+}
+
+id <MTLBuffer> CubismCommandBuffer_Metal::DrawCommandBuffer::GetUvBuffer()
+{
+    return _uvs;
+}
+
+id <MTLBuffer> CubismCommandBuffer_Metal::DrawCommandBuffer::GetIndexBuffer()
+{
+    return _indices;
+}
+
+CubismCommandBuffer_Metal::CubismCommandBuffer_Metal()
+{
+}
+
+CubismCommandBuffer_Metal::~CubismCommandBuffer_Metal()
+{
+}
+
+}}}}

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <MetalKit/MetalKit.h>
+#include "CubismFramework.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/**
+ * @brief  オフスクリーン描画用構造体
+ */
+class CubismOffscreenFrame_Metal
+{
+public:
+
+    CubismOffscreenFrame_Metal();
+
+    /**
+     * @brief  CubismOffscreenFrame作成
+     * @param  displayBufferWidth     作成するバッファ幅
+     * @param  displayBufferHeight    作成するバッファ高さ
+     * @param  colorBuffer            0以外の場合、ピクセル格納領域としてcolorBufferを使用する
+     */
+    csmBool CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, id <MTLTexture> colorBuffer = NULL);
+
+    /**
+     * @brief   CubismOffscreenFrameの削除
+     */
+    void DestroyOffscreenFrame();
+
+    /**
+     * @brief   カラーバッファメンバーへのアクセッサ
+     */
+    id <MTLTexture> GetColorBuffer() const;
+
+    /**
+     * @brief   バッファ幅取得
+     */
+    csmUint32 GetBufferWidth() const;
+
+    /**
+     * @brief   バッファ高さ取得
+     */
+    csmUint32 GetBufferHeight() const;
+
+    /**
+     * @brief   MTLViewport取得
+     */
+    const MTLViewport* GetViewport() const;
+
+    /**
+     * @brief   MTLRenderPassDescriptor取得
+     */
+    MTLRenderPassDescriptor* GetRenderPassDescriptor() const;
+
+private:
+    id <MTLTexture>  _colorBuffer; ///レンダーテクスチャ
+    csmBool _isInheritedRenderTexture;
+    MTLRenderPassDescriptor *_renderPassDescriptor;
+    csmUint32   _bufferWidth;           ///< Create時に指定された幅
+    csmUint32   _bufferHeight;          ///< Create時に指定された高さ
+    MTLViewport _viewPort;
+};
+
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
@@ -1,0 +1,126 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismOffscreenSurface_Metal.hpp"
+#include "CubismRenderingInstanceSingleton_Metal.h"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+CubismOffscreenFrame_Metal::CubismOffscreenFrame_Metal()
+    :
+     _colorBuffer(NULL)
+    , _isInheritedRenderTexture(false)
+    , _bufferWidth(0)
+    , _bufferHeight(0)
+{
+}
+
+csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, id <MTLTexture> colorBuffer)
+{
+    // 一旦削除
+    DestroyOffscreenFrame();
+
+    do
+    {
+        if (colorBuffer == nil)
+        {
+            csmBool initResult = false;
+
+            _renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+            _renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+            _renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+            _renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(1.0, 1.0, 1.0, 1.0);
+
+            _renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
+            _renderPassDescriptor.depthAttachment.storeAction = MTLStoreActionDontCare;
+            _renderPassDescriptor.depthAttachment.clearDepth = 1.0;
+
+            _renderPassDescriptor.renderTargetWidth = displayBufferWidth;
+            _renderPassDescriptor.renderTargetHeight = displayBufferHeight;
+            _isInheritedRenderTexture = false;
+
+            // Set up a texture for rendering to and sampling from
+            MTLTextureDescriptor *texDescriptor = [[MTLTextureDescriptor alloc] init];
+            texDescriptor.textureType = MTLTextureType2D;
+            texDescriptor.width = displayBufferWidth;
+            texDescriptor.height = displayBufferHeight;
+            texDescriptor.pixelFormat = MTLPixelFormatRGBA8Unorm;
+            texDescriptor.usage = MTLTextureUsageRenderTarget |
+                                  MTLTextureUsageShaderRead;
+            CubismRenderingInstanceSingleton_Metal *single = [CubismRenderingInstanceSingleton_Metal sharedManager];
+            id <MTLDevice> device = [single getMTLDevice];
+            _colorBuffer = [device newTextureWithDescriptor:texDescriptor];
+
+        }
+        else
+        {
+            _colorBuffer = colorBuffer;
+            _isInheritedRenderTexture = true;
+        }
+
+        if (_colorBuffer)
+        {
+            _renderPassDescriptor.colorAttachments[0].texture = _colorBuffer;
+            _viewPort = { 0.0f, 0.0f, static_cast<double>(_colorBuffer.width), static_cast<double>(_colorBuffer.height), 0.0, 1.0};
+        }
+        else
+        {
+            _viewPort = {0.0, 0.0, static_cast<double>(_bufferWidth), static_cast<double>(_bufferHeight), 0.0, 1.0};
+        }
+
+        _bufferWidth = displayBufferWidth;
+        _bufferHeight = displayBufferHeight;
+
+        // 成功
+        return true;
+
+    } while (0);
+
+    // 失敗したので削除
+    DestroyOffscreenFrame();
+
+    return false;
+}
+
+void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
+{
+    if((_renderPassDescriptor != NULL) && !_isInheritedRenderTexture)
+    {
+        _colorBuffer = NULL;
+    }
+
+}
+
+id <MTLTexture> CubismOffscreenFrame_Metal::GetColorBuffer() const
+{
+    return _colorBuffer;
+}
+
+csmUint32 CubismOffscreenFrame_Metal::GetBufferWidth() const
+{
+    return _bufferWidth;
+}
+
+csmUint32 CubismOffscreenFrame_Metal::GetBufferHeight() const
+{
+    return _bufferHeight;
+}
+
+const MTLViewport* CubismOffscreenFrame_Metal::GetViewport() const
+{
+    return &_viewPort;
+}
+
+MTLRenderPassDescriptor* CubismOffscreenFrame_Metal::GetRenderPassDescriptor() const
+{
+    return _renderPassDescriptor;
+}
+
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -1,0 +1,501 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <MetalKit/MetalKit.h>
+#include "../CubismRenderer.hpp"
+#include "CubismFramework.hpp"
+#include "CubismOffscreenSurface_Metal.hpp"
+#include "CubismCommandBuffer_Metal.hpp"
+#include "Type/csmVector.hpp"
+#include "Type/csmRectF.hpp"
+#include "Type/csmMap.hpp"
+#include "Math/CubismVector2.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+//  前方宣言
+class CubismRenderer_Metal;
+class CubismClippingContext;
+
+/**
+ * @brief  クリッピングマスクの処理を実行するクラス
+ *
+ */
+class CubismClippingManager_Metal
+{
+    friend class CubismShader_Metal;
+    friend class CubismRenderer_Metal;
+
+private:
+
+    /**
+     * @brief カラーチャンネル(RGBA)のフラグを取得する
+     *
+     * @param[in]   channelNo   ->   カラーチャンネル(RGBA)の番号(0:R , 1:G , 2:B, 3:A)
+     */
+    CubismRenderer::CubismTextureColor* GetChannelFlagAsColor(csmInt32 channelNo);
+
+    /**
+     * @brief   マスクされる描画オブジェクト群全体を囲む矩形(モデル座標系)を計算する
+     *
+     * @param[in]   model            ->  モデルのインスタンス
+     * @param[in]   clippingContext  ->  クリッピングマスクのコンテキスト
+     */
+    void CalcClippedDrawTotalBounds(CubismModel& model, CubismClippingContext* clippingContext);
+
+    /**
+     * @brief    コンストラクタ
+     */
+    CubismClippingManager_Metal();
+
+    /**
+     * @brief    デストラクタ
+     */
+    virtual ~CubismClippingManager_Metal();
+
+    /**
+     * @brief    マネージャの初期化処理<br>
+     *           クリッピングマスクを使う描画オブジェクトの登録を行う
+     *
+     * @param[in]   model           ->  モデルのインスタンス
+     * @param[in]   drawableCount   ->  描画オブジェクトの数
+     * @param[in]   drawableMasks   ->  描画オブジェクトをマスクする描画オブジェクトのインデックスのリスト
+     * @param[in]   drawableMaskCounts   ->  描画オブジェクトをマスクする描画オブジェクトの数
+     */
+    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts);
+
+    /**
+     * @brief   クリッピングコンテキストを作成する。モデル描画時に実行する。
+     *
+     * @param[in]   model        ->  モデルのインスタンス
+     * @param[in]   renderer     ->  レンダラのインスタンス
+     * @param[in]   lastFBO      ->  フレームバッファ
+     * @param[in]   lastViewport ->  ビューポート
+     */
+    void SetupClippingContext(CubismModel& model, CubismRenderer_Metal* renderer, CubismOffscreenFrame_Metal* lastColorBuffer, csmRectF lastViewport);
+
+    /**
+     * @brief   既にマスクを作っているかを確認。<br>
+     *          作っているようであれば該当するクリッピングマスクのインスタンスを返す。<br>
+     *          作っていなければNULLを返す
+     *
+     * @param[in]   drawableMasks    ->  描画オブジェクトをマスクする描画オブジェクトのリスト
+     * @param[in]   drawableMaskCounts ->  描画オブジェクトをマスクする描画オブジェクトの数
+     * @return          該当するクリッピングマスクが存在すればインスタンスを返し、なければNULLを返す。
+     */
+    CubismClippingContext* FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const;
+
+    /**
+     * @brief   クリッピングコンテキストを配置するレイアウト。<br>
+     *           ひとつのレンダーテクスチャを極力いっぱいに使ってマスクをレイアウトする。<br>
+     *           マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する。
+     *
+     * @param[in]   usingClipCount  ->  配置するクリッピングコンテキストの数
+     */
+    void SetupLayoutBounds(csmInt32 usingClipCount) const;
+
+    /**
+     * @brief   画面描画に使用するクリッピングマスクのリストを取得する
+     *
+     * @return  画面描画に使用するクリッピングマスクのリスト
+     */
+    csmVector<CubismClippingContext*>* GetClippingContextListForDraw();
+
+    /**
+     * @brief  クリッピングマスクバッファのサイズを設定する
+     *
+     * @param  size -> クリッピングマスクバッファのサイズ
+     *
+     */
+    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
+
+    /**
+     * @brief  クリッピングマスクバッファのサイズを取得する
+     *
+     * @return クリッピングマスクバッファのサイズ
+     *
+     */
+    CubismVector2 GetClippingMaskBufferSize() const;
+
+    csmInt32    _currentFrameNo;         ///< マスクテクスチャに与えるフレーム番号
+
+    csmVector<CubismRenderer::CubismTextureColor*>  _channelColors;
+    csmVector<CubismClippingContext*>               _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
+    csmVector<CubismClippingContext*>               _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
+    CubismVector2                                   _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
+
+    CubismMatrix44  _tmpMatrix;              ///< マスク計算用の行列
+    CubismMatrix44  _tmpMatrixForMask;       ///< マスク計算用の行列
+    CubismMatrix44  _tmpMatrixForDraw;       ///< マスク計算用の行列
+    csmRectF        _tmpBoundsOnModel;       ///< マスク配置計算用の矩形
+
+};
+
+/**
+ * @brief   クリッピングマスクのコンテキスト
+ */
+class CubismClippingContext
+{
+    friend class CubismClippingManager_Metal;
+    friend class CubismShader_Metal;
+    friend class CubismRenderer_Metal;
+
+private:
+    /**
+     * @brief   引数付きコンストラクタ
+     *
+     */
+    CubismClippingContext(CubismClippingManager_Metal* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
+
+    /**
+     * @brief   デストラクタ
+     */
+    virtual ~CubismClippingContext();
+
+    /**
+     * @brief   このマスクにクリップされる描画オブジェクトを追加する
+     *
+     * @param[in]   drawableIndex   ->  クリッピング対象に追加する描画オブジェクトのインデックス
+     */
+    void AddClippedDrawable(csmInt32 drawableIndex);
+
+    /**
+     * @brief   このマスクを管理するマネージャのインスタンスを取得する。
+     *
+     * @return  クリッピングマネージャのインスタンス
+     */
+    CubismClippingManager_Metal* GetClippingManager();
+
+    csmBool _isUsing;                                ///< 現在の描画状態でマスクの準備が必要ならtrue
+    const csmInt32* _clippingIdList;                 ///< クリッピングマスクのIDリスト
+    csmInt32 _clippingIdCount;                       ///< クリッピングマスクの数
+    csmInt32 _layoutChannelNo;                       ///< RGBAのいずれのチャンネルにこのクリップを配置するか(0:R , 1:G , 2:B , 3:A)
+    csmRectF* _layoutBounds;                         ///< マスク用チャンネルのどの領域にマスクを入れるか(View座標-1..1, UVは0..1に直す)
+    csmRectF* _allClippedDrawRect;                   ///< このクリッピングで、クリッピングされる全ての描画オブジェクトの囲み矩形（毎回更新）
+    CubismMatrix44 _matrixForMask;                   ///< マスクの位置計算結果を保持する行列
+    CubismMatrix44 _matrixForDraw;                   ///< 描画オブジェクトの位置計算結果を保持する行列
+    csmVector<csmInt32>* _clippedDrawableIndexList;  ///< このマスクにクリップされる描画オブジェクトのリスト
+    csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>* _clippingCommandBufferList;
+
+    CubismClippingManager_Metal* _owner;        ///< このマスクを管理しているマネージャのインスタンス
+};
+
+/**
+ * @brief   Metal用のシェーダプログラムを生成・破棄するクラス<br>
+ *           シングルトンなクラスであり、CubismShader_Metal::GetInstance()からアクセスする。
+ *
+ */
+class CubismShader_Metal
+{
+    friend class CubismRenderer_Metal;
+
+private:
+    /**
+     * @brief   インスタンスを取得する（シングルトン）。
+     *
+     * @return  インスタンスのポインタ
+     */
+    static CubismShader_Metal* GetInstance();
+
+    /**
+     * @brief   インスタンスを解放する（シングルトン）。
+     */
+    static void DeleteInstance();
+
+    struct ShaderProgram
+    {
+        id <MTLFunction> vertexFunction;
+        id <MTLFunction> fragmentFunction;
+    };
+
+    /**
+    * @bref    シェーダープログラムとシェーダ変数のアドレスを保持する構造体
+    *
+    */
+    struct CubismShaderSet
+    {
+        ShaderProgram *ShaderProgram; ///< シェーダプログラムのアドレス
+        id<MTLRenderPipelineState> RenderPipelineState;
+        id<MTLDepthStencilState> DepthStencilState;
+        id<MTLSamplerState> SamplerState;
+    };
+
+    /**
+     * @brief   privateなコンストラクタ
+     */
+    CubismShader_Metal();
+
+    /**
+     * @brief   privateなデストラクタ
+     */
+    virtual ~CubismShader_Metal();
+
+    /**
+     * @brief   シェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   renderer              ->  レンダラのインスタンス
+     * @param[in]   textureId             ->  GPUのテクスチャID
+     * @param[in]   vertexCount           ->  ポリゴンメッシュの頂点数
+     * @param[in]   vertexArray           ->  ポリゴンメッシュの頂点配列
+     * @param[in]   uvArray               ->  uv配列
+     * @param[in]   opacity               ->  不透明度
+     * @param[in]   colorBlendMode        ->  カラーブレンディングのタイプ
+     * @param[in]   baseColor             ->  ベースカラー
+     * @param[in]   isPremultipliedAlpha  ->  乗算済みアルファかどうか
+     * @param[in]   matrix4x4             ->  Model-View-Projection行列
+     * @param[in]   invertedMask           ->  マスクを反転して使用するフラグ
+     * @param[in]   renderEncoder           ->  MTLRenderCommandEncoder
+     */
+    void SetupShaderProgram(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, CubismRenderer_Metal* renderer, id <MTLTexture> texture
+                            , csmFloat32 opacity
+                            , CubismRenderer::CubismBlendMode colorBlendMode
+                            , CubismRenderer::CubismTextureColor baseColor
+                            , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
+                            , csmBool invertedMask
+                            , id <MTLRenderCommandEncoder> renderEncoder);
+
+    /**
+     * @brief   シェーダプログラムを初期化する
+     */
+    void GenerateShaders();
+
+    /**
+     * @brief   シェーダプログラムをロードしてアドレス返す。
+     *
+     * @param[in]   vertShaderSrc   ->  頂点シェーダのソース
+     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのソース
+     *
+     * @return  シェーダプログラムのアドレス
+     */
+    ShaderProgram* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
+    id<MTLRenderPipelineState> MakeRenderPipelineState(id<MTLDevice> device, ShaderProgram* shaderProgram, int blendMode);
+    id<MTLDepthStencilState> MakeDepthStencilState(id<MTLDevice> device);
+    id<MTLSamplerState> MakeSamplerState(id<MTLDevice> device);
+
+    id<MTLLibrary> _shaderLib;
+
+    csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
+
+};
+
+/**
+ * @brief   Cubismモデルを描画する直前のMetalのステートを保持・復帰させるクラス
+ *
+ */
+class CubismRendererProfile_Metal
+{
+    friend class CubismRenderer_Metal;
+
+private:
+    /**
+     * @brief   privateなコンストラクタ
+     */
+    CubismRendererProfile_Metal() {};
+
+    /**
+     * @brief   privateなデストラクタ
+     */
+    virtual ~CubismRendererProfile_Metal() {};
+
+    csmBool _lastScissorTest;             ///< モデル描画直前のGL_VERTEX_ATTRIB_ARRAY_ENABLEDパラメータ
+    csmBool _lastBlend;                   ///< モデル描画直前のGL_SCISSOR_TESTパラメータ
+    csmBool _lastStencilTest;             ///< モデル描画直前のGL_STENCIL_TESTパラメータ
+    csmBool _lastDepthTest;               ///< モデル描画直前のGL_DEPTH_TESTパラメータ
+    CubismOffscreenFrame_Metal* _lastColorBuffer;                         ///< モデル描画直前のフレームバッファ
+    id <MTLTexture> _lastDepthBuffer;
+    id <MTLTexture> _lastStencilBuffer;
+    csmRectF _lastViewport;                 ///< モデル描画直前のビューポート
+};
+
+/**
+ * @brief   Metal用の描画命令を実装したクラス
+ *
+ */
+class CubismRenderer_Metal : public CubismRenderer
+{
+    friend class CubismRenderer;
+    friend class CubismClippingManager_Metal;
+    friend class CubismShader_Metal;
+
+public:
+
+    static void StartFrame(id<MTLDevice> device, id<MTLCommandBuffer> commandBuffer, id<MTLTexture> renderTarget, id<MTLTexture> depthTarget);
+
+    /**
+     * @brief    レンダラの初期化処理を実行する<br>
+     *           引数に渡したモデルからレンダラの初期化処理に必要な情報を取り出すことができる
+     *
+     * @param[in]  model -> モデルのインスタンス
+     */
+    void Initialize(Framework::CubismModel* model);
+
+    /**
+     * @brief   テクスチャのバインド処理<br>
+     *           CubismRendererにテクスチャを設定し、CubismRenderer中でその画像を参照するためのIndex値を戻り値とする
+     *
+     * @param[in]   modelTextureNo  ->  セットするモデルテクスチャの番号
+     * @param[in]   texture     ->  バックエンドテクスチャ
+     *
+     */
+    void BindTexture(csmUint32 modelTextureNo, id <MTLTexture> texture);
+
+    /**
+     * @brief   バインドされたテクスチャのリストを取得する
+     *
+     * @return  テクスチャのアドレスのリスト
+     */
+    const csmMap<csmInt32, id <MTLTexture>>& GetBindedTextures() const;
+
+    /**
+     * @brief  クリッピングマスクバッファのサイズを設定する<br>
+     *         マスク用のFrameBufferを破棄・再作成するため処理コストは高い。
+     *
+     * @param[in]  size -> クリッピングマスクバッファのサイズ
+     *
+     */
+    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
+
+    /**
+     * @brief  クリッピングマスクバッファのサイズを取得する
+     *
+     * @return クリッピングマスクバッファのサイズ
+     *
+     */
+    CubismVector2 GetClippingMaskBufferSize() const;
+
+    CubismCommandBuffer_Metal* GetCommandBuffer()
+    {
+        return &_commandBuffer;
+    }
+
+protected:
+    /**
+     * @brief   コンストラクタ
+     */
+    CubismRenderer_Metal();
+
+    /**
+     * @brief   デストラクタ
+     */
+    virtual ~CubismRenderer_Metal();
+
+    /**
+     * @brief   モデルを描画する実際の処理
+     *
+     */
+    void DoDrawModel();
+
+    /**
+     * @brief   [オーバーライド]<br>
+     *           描画オブジェクト（アートメッシュ）を描画する。<br>
+     *           ポリゴンメッシュとテクスチャ番号をセットで渡す。
+     *
+     * @param[in]   textureNo       ->  描画するテクスチャ番号
+     * @param[in]   indexCount      ->  描画オブジェクトのインデックス値
+     * @param[in]   vertexCount     ->  ポリゴンメッシュの頂点数
+     * @param[in]   indexArray      ->  ポリゴンメッシュのインデックス配列
+     * @param[in]   vertexArray     ->  ポリゴンメッシュの頂点配列
+     * @param[in]   uvArray         ->  uv配列
+     * @param[in]   opacity         ->  不透明度
+     * @param[in]   colorBlendMode  ->  カラー合成タイプ
+     * @param[in]   invertedMask     ->  マスク使用時のマスクの反転使用
+     * @param[in]   drawableIndex     ->  DrawCommandBuffer番号
+     * @param[in]   renderEncoder     ->  MTLRenderCommandEncoder
+     *
+     */
+
+    void DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount, csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray, csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
+
+    void DrawMeshMetal(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
+                  , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+                  , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask
+                  , csmInt32 drawableIndex
+                  , id <MTLRenderCommandEncoder> renderEncoder);
+
+    CubismCommandBuffer_Metal::DrawCommandBuffer* GetDrawCommandBufferData(csmInt32 drawableIndex);
+
+private:
+
+    // Prevention of copy Constructor
+    CubismRenderer_Metal(const CubismRenderer_Metal&);
+    CubismRenderer_Metal& operator=(const CubismRenderer_Metal&);
+
+    static id<MTLCommandBuffer> s_commandBuffer;
+    static id<MTLDevice> s_device;
+    static id<MTLTexture> s_renderTarget;
+    static id<MTLTexture> s_depthTarget;
+
+    /**
+     * @brief   レンダラが保持する静的なリソースを解放する<br>
+     *           Metalの静的なシェーダプログラムを解放する
+     */
+    static void DoStaticRelease();
+
+    /**
+     * @brief   描画開始時の追加処理。<br>
+     *           モデルを描画する前にクリッピングマスクに必要な処理を実装している。
+     * @return  描画に使うMTLRenderCommandEncoder
+     */
+    id <MTLRenderCommandEncoder> PreDraw(id <MTLCommandBuffer> commandBuffer, MTLRenderPassDescriptor* drawableRenderDescriptor);
+
+    /**
+     * @brief   描画完了後の追加処理。
+     *
+     */
+    void PostDraw(id <MTLRenderCommandEncoder> renderEncoder);
+
+    /**
+     * @brief   SuperClass対応
+     */
+    virtual void SaveProfile();
+
+    /**
+     * @brief   SuperClass対応
+     */
+    virtual void RestoreProfile();
+
+    /**
+     * @brief   マスクテクスチャに描画するクリッピングコンテキストをセットする。
+     */
+    void SetClippingContextBufferForMask(CubismClippingContext* clip);
+
+    /**
+     * @brief   マスクテクスチャに描画するクリッピングコンテキストを取得する。
+     *
+     * @return  マスクテクスチャに描画するクリッピングコンテキスト
+     */
+    CubismClippingContext* GetClippingContextBufferForMask() const;
+
+    /**
+     * @brief   画面上に描画するクリッピングコンテキストをセットする。
+     */
+    void SetClippingContextBufferForDraw(CubismClippingContext* clip);
+
+    /**
+     * @brief   画面上に描画するクリッピングコンテキストを取得する。
+     *
+     * @return  画面上に描画するクリッピングコンテキスト
+     */
+    CubismClippingContext* GetClippingContextBufferForDraw() const;
+
+    csmMap<csmInt32, id <MTLTexture>>            _textures;                      ///< モデルが参照するテクスチャとレンダラでバインドしているテクスチャとのマップ
+    csmVector<csmInt32>                 _sortedDrawableIndexList;       ///< 描画オブジェクトのインデックスを描画順に並べたリスト
+    CubismRendererProfile_Metal     _rendererProfile;               ///< Metalのステートを保持するオブジェクト
+    CubismClippingManager_Metal*    _clippingManager;               ///< クリッピングマスク管理オブジェクト
+    CubismClippingContext*              _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
+    CubismClippingContext*              _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
+
+    CubismOffscreenFrame_Metal      _offscreenFrameBuffer;          ///< マスク描画用のフレームバッファ
+    CubismCommandBuffer_Metal       _commandBuffer;
+    csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>  _drawableDrawCommandBuffer;
+};
+
+}}}}
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Metal/CubismRenderer_Metal.mm
+++ b/src/Rendering/Metal/CubismRenderer_Metal.mm
@@ -1,0 +1,1553 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismRenderer_Metal.hpp"
+#include "Math/CubismMatrix44.hpp"
+#include "Model/CubismModel.hpp"
+#include "CubismRenderingInstanceSingleton_Metal.h"
+#include "MetalShaderTypes.h"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/*********************************************************************************************************************
+*                                      CubismClippingManager_Metal
+********************************************************************************************************************/
+///< ファイルスコープの変数宣言
+namespace {
+const csmInt32 ColorChannelCount = 4;   ///< 実験時に1チャンネルの場合は1、RGBだけの場合は3、アルファも含める場合は4
+}
+
+CubismClippingManager_Metal::CubismClippingManager_Metal() :
+                                                _currentFrameNo(0),
+                                                _clippingMaskBufferSize(256, 256)
+{
+    CubismRenderer::CubismTextureColor* tmp;
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 1.0f;
+    tmp->G = 0.0f;
+    tmp->B = 0.0f;
+    tmp->A = 0.0f;
+    _channelColors.PushBack(tmp);
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 0.0f;
+    tmp->G = 1.0f;
+    tmp->B = 0.0f;
+    tmp->A = 0.0f;
+    _channelColors.PushBack(tmp);
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 0.0f;
+    tmp->G = 0.0f;
+    tmp->B = 1.0f;
+    tmp->A = 0.0f;
+    _channelColors.PushBack(tmp);
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 0.0f;
+    tmp->G = 0.0f;
+    tmp->B = 0.0f;
+    tmp->A = 1.0f;
+    _channelColors.PushBack(tmp);
+
+}
+
+CubismClippingManager_Metal::~CubismClippingManager_Metal()
+{
+    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
+    {
+        if (_clippingContextListForMask[i]) CSM_DELETE_SELF(CubismClippingContext, _clippingContextListForMask[i]);
+        _clippingContextListForMask[i] = NULL;
+    }
+
+    // _clippingContextListForDrawは_clippingContextListForMaskにあるインスタンスを指している。上記の処理により要素ごとのDELETEは不要。
+    for (csmUint32 i = 0; i < _clippingContextListForDraw.GetSize(); i++)
+    {
+        _clippingContextListForDraw[i] = NULL;
+    }
+
+    for (csmUint32 i = 0; i < _channelColors.GetSize(); i++)
+    {
+        if (_channelColors[i]) CSM_DELETE(_channelColors[i]);
+        _channelColors[i] = NULL;
+    }
+}
+
+void CubismClippingManager_Metal::Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts)
+{
+    //クリッピングマスクを使う描画オブジェクトを全て登録する
+    //クリッピングマスクは、通常数個程度に限定して使うものとする
+    for (csmInt32 i = 0; i < drawableCount; i++)
+    {
+        if (drawableMaskCounts[i] <= 0)
+        {
+            //クリッピングマスクが使用されていないアートメッシュ（多くの場合使用しない）
+            _clippingContextListForDraw.PushBack(NULL);
+            continue;
+        }
+
+        // 既にあるClipContextと同じかチェックする
+        CubismClippingContext* cc = FindSameClip(drawableMasks[i], drawableMaskCounts[i]);
+        if (cc == NULL)
+        {
+            // 同一のマスクが存在していない場合は生成する
+            cc = CSM_NEW CubismClippingContext(this, model, drawableMasks[i], drawableMaskCounts[i]);
+            _clippingContextListForMask.PushBack(cc);
+        }
+
+        cc->AddClippedDrawable(i);
+
+        _clippingContextListForDraw.PushBack(cc);
+
+    }
+}
+
+CubismClippingContext* CubismClippingManager_Metal::FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const
+{
+    // 作成済みClippingContextと一致するか確認
+    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
+    {
+        CubismClippingContext* cc = _clippingContextListForMask[i];
+        const csmInt32 count = cc->_clippingIdCount;
+        if (count != drawableMaskCounts) continue; //個数が違う場合は別物
+        csmInt32 samecount = 0;
+
+        // 同じIDを持つか確認。配列の数が同じなので、一致した個数が同じなら同じ物を持つとする。
+        for (csmInt32 j = 0; j < count; j++)
+        {
+            const csmInt32 clipId = cc->_clippingIdList[j];
+            for (csmInt32 k = 0; k < count; k++)
+            {
+                if (drawableMasks[k] == clipId)
+                {
+                    samecount++;
+                    break;
+                }
+            }
+        }
+        if (samecount == count)
+        {
+            return cc;
+        }
+    }
+    return NULL; //見つからなかった
+}
+
+void CubismClippingManager_Metal::SetupClippingContext(CubismModel& model, CubismRenderer_Metal* renderer, CubismOffscreenFrame_Metal* lastColorBuffer, csmRectF lastViewport)
+{
+    _currentFrameNo++;
+
+    // 全てのクリッピングを用意する
+    // 同じクリップ（複数の場合はまとめて１つのクリップ）を使う場合は１度だけ設定する
+    csmInt32 usingClipCount = 0;
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // １つのクリッピングマスクに関して
+        CubismClippingContext* cc = _clippingContextListForMask[clipIndex];
+
+        // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
+        CalcClippedDrawTotalBounds(model, cc);
+
+        if (cc->_isUsing)
+        {
+            usingClipCount++; //使用中としてカウント
+        }
+    }
+
+    // マスク作成処理
+    if (usingClipCount > 0)
+    {
+        id <MTLRenderCommandEncoder> renderEncoder = nil;
+        MTLViewport clipVp = {0, 0, GetClippingMaskBufferSize().X, GetClippingMaskBufferSize().Y, 0.0, 1.0};
+
+        // 前処理方式の場合
+        if (!renderer->IsUsingHighPrecisionMask())
+        {
+            // 生成したFrameBufferと同じサイズでビューポートを設定
+
+            // モデル描画時にDrawMeshNowに渡される変換（モデルtoワールド座標変換）
+            CubismMatrix44 modelToWorldF = renderer->GetMvpMatrix();
+
+            renderEncoder = renderer->PreDraw(renderer->s_commandBuffer, renderer->_offscreenFrameBuffer.GetRenderPassDescriptor());
+            [renderEncoder setViewport:clipVp];
+        }
+
+        // 各マスクのレイアウトを決定していく
+        SetupLayoutBounds(renderer->IsUsingHighPrecisionMask() ? 0 : usingClipCount);
+
+        // 実際にマスクを生成する
+        // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
+        for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+        {
+            // --- 実際に１つのマスクを描く ---
+            CubismClippingContext* clipContext = _clippingContextListForMask[clipIndex];
+            csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+            csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
+            const csmFloat32 MARGIN = 0.05f;
+            csmFloat32 scaleX = 0.0f;
+            csmFloat32 scaleY = 0.0f;
+
+            if (renderer->IsUsingHighPrecisionMask())
+            {
+                const csmFloat32 ppu = model.GetPixelsPerUnit();
+                const csmFloat32 maskPixelWidth = clipContext->_owner->_clippingMaskBufferSize.X;
+                const csmFloat32 maskPixelHeight = clipContext->_owner->_clippingMaskBufferSize.Y;
+                const csmFloat32 physicalMaskWidth = layoutBoundsOnTex01->Width * maskPixelWidth;
+                const csmFloat32 physicalMaskHeight = layoutBoundsOnTex01->Height * maskPixelHeight;
+
+
+                _tmpBoundsOnModel.SetRect(allClippedDrawRect);
+
+                if (_tmpBoundsOnModel.Width * ppu > physicalMaskWidth)
+                {
+                    _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, 0.0f);
+                    scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
+                }
+                else
+                {
+                    scaleX = ppu / physicalMaskWidth;
+                }
+
+                if (_tmpBoundsOnModel.Height * ppu > physicalMaskHeight)
+                {
+                    _tmpBoundsOnModel.Expand(0.0f, allClippedDrawRect->Height * MARGIN);
+                    scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
+                }
+                else
+                {
+                    scaleY = ppu / physicalMaskHeight;
+                }
+            }
+            else
+            {
+                // モデル座標上の矩形を、適宜マージンを付けて使う
+                _tmpBoundsOnModel.SetRect(allClippedDrawRect);
+                _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, allClippedDrawRect->Height * MARGIN);
+                //########## 本来は割り当てられた領域の全体を使わず必要最低限のサイズがよい
+
+                // シェーダ用の計算式を求める。回転を考慮しない場合は以下のとおり
+                // movePeriod' = movePeriod * scaleX + offX     [[ movePeriod' = (movePeriod - tmpBoundsOnModel.movePeriod)*scale + layoutBoundsOnTex01.movePeriod ]]
+                scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
+                scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
+            }
+
+            // マスク生成時に使う行列を求める
+            {
+                // シェーダに渡す行列を求める <<<<<<<<<<<<<<<<<<<<<<<< 要最適化（逆順に計算すればシンプルにできる）
+                _tmpMatrix.LoadIdentity();
+                {
+                    // Layout0..1 を -1..1に変換
+                    _tmpMatrix.TranslateRelative(-1.0f, -1.0f);
+                    _tmpMatrix.ScaleRelative(2.0f, 2.0f);
+                }
+                {
+                    // view to Layout0..1
+                    _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
+                    _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
+                    _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y);
+                    //new = [translate][scale][translate]
+                }
+                // tmpMatrixForMask が計算結果
+                _tmpMatrixForMask.SetMatrix(_tmpMatrix.GetArray());
+            }
+
+            //--------- draw時の mask 参照用行列を計算
+            {
+                // シェーダに渡す行列を求める <<<<<<<<<<<<<<<<<<<<<<<< 要最適化（逆順に計算すればシンプルにできる）
+                _tmpMatrix.LoadIdentity();
+                {
+                    _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
+                    _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
+                    _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y);
+                    //new = [translate][scale][translate]
+                }
+
+                _tmpMatrixForDraw.SetMatrix(_tmpMatrix.GetArray());
+            }
+
+            clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
+
+            clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
+
+            if (!renderer->IsUsingHighPrecisionMask())
+            {
+                const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
+                for (csmInt32 i = 0; i < clipDrawCount; i++)
+                {
+                    const csmInt32 clipDrawIndex = clipContext->_clippingIdList[i];
+                    CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBufferData = clipContext->_clippingCommandBufferList->At(i);// [i];
+
+                    // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
+                    if (!model.GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
+                    {
+                        continue;
+                    }
+
+                    {
+                        // Update Vertex / Index buffer.
+                        {
+                            csmFloat32* vertices = const_cast<csmFloat32*>(model.GetDrawableVertices(clipDrawIndex));
+                            Core::csmVector2* uvs = const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(clipDrawIndex));
+                            csmUint16* vertexIndices = const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex));
+                            const csmUint32 vertexCount = model.GetDrawableVertexCount(clipDrawIndex);
+                            const csmUint32 vertexIndexCount = model.GetDrawableVertexIndexCount(clipDrawIndex);
+
+                            drawCommandBufferData->UpdateVertexBuffer(vertices, uvs, vertexCount);
+                            if (vertexIndexCount > 0)
+                            {
+                                drawCommandBufferData->UpdateIndexBuffer(vertexIndices, vertexIndexCount);
+                            }
+
+                            if (vertexCount <= 0)
+                            {
+                                continue;
+                            }
+
+                        }
+                    }
+
+                    renderer->IsCulling(model.GetDrawableCulling(clipDrawIndex) != 0);
+
+                    // 今回専用の変換を適用して描く
+                    // チャンネルも切り替える必要がある(A,R,G,B)
+                    renderer->SetClippingContextBufferForMask(clipContext);
+
+                    renderer->DrawMeshMetal(
+                        drawCommandBufferData,
+                        model.GetDrawableTextureIndices(clipDrawIndex),
+                        model.GetDrawableVertexIndexCount(clipDrawIndex),
+                        model.GetDrawableVertexCount(clipDrawIndex),
+                        const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
+                        const_cast<csmFloat32*>(model.GetDrawableVertices(clipDrawIndex)),
+                        reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(clipDrawIndex))),
+                        model.GetDrawableOpacity(clipDrawIndex),
+                        CubismRenderer::CubismBlendMode_Normal,   //クリッピングは通常描画を強制
+                        false,   // マスク生成時はクリッピングの反転使用は全く関係がない
+                        clipDrawIndex,
+                        renderEncoder
+                    );
+                }
+            }
+        }
+
+        if (!renderer->IsUsingHighPrecisionMask())
+        {
+            // --- 後処理 ---
+            [renderEncoder endEncoding];
+            renderer->SetClippingContextBufferForMask(NULL);
+        }
+    }
+}
+
+void CubismClippingManager_Metal::CalcClippedDrawTotalBounds(CubismModel& model, CubismClippingContext* clippingContext)
+{
+    // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
+    csmFloat32 clippedDrawTotalMinX = FLT_MAX, clippedDrawTotalMinY = FLT_MAX;
+    csmFloat32 clippedDrawTotalMaxX = -FLT_MAX, clippedDrawTotalMaxY = -FLT_MAX;
+
+    // このマスクが実際に必要か判定する
+    // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある
+
+    const csmInt32 clippedDrawCount = clippingContext->_clippedDrawableIndexList->GetSize();
+    for (csmInt32 clippedDrawableIndex = 0; clippedDrawableIndex < clippedDrawCount; clippedDrawableIndex++)
+    {
+        // マスクを使用する描画オブジェクトの描画される矩形を求める
+        const csmInt32 drawableIndex = (*clippingContext->_clippedDrawableIndexList)[clippedDrawableIndex];
+
+        const csmInt32 drawableVertexCount = model.GetDrawableVertexCount(drawableIndex);
+        csmFloat32* drawableVertexes = const_cast<csmFloat32*>(model.GetDrawableVertices(drawableIndex));
+
+        csmFloat32 minX = FLT_MAX, minY = FLT_MAX;
+        csmFloat32 maxX = -FLT_MAX, maxY = -FLT_MAX;
+
+        csmInt32 loop = drawableVertexCount * Constant::VertexStep;
+        for (csmInt32 pi = Constant::VertexOffset; pi < loop; pi += Constant::VertexStep)
+        {
+            csmFloat32 x = drawableVertexes[pi];
+            csmFloat32 y = drawableVertexes[pi + 1];
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+        }
+
+        //
+        if (minX == FLT_MAX) continue; //有効な点がひとつも取れなかったのでスキップする
+
+        // 全体の矩形に反映
+        if (minX < clippedDrawTotalMinX) clippedDrawTotalMinX = minX;
+        if (minY < clippedDrawTotalMinY) clippedDrawTotalMinY = minY;
+        if (maxX > clippedDrawTotalMaxX) clippedDrawTotalMaxX = maxX;
+        if (maxY > clippedDrawTotalMaxY) clippedDrawTotalMaxY = maxY;
+    }
+    if (clippedDrawTotalMinX == FLT_MAX)
+    {
+        clippingContext->_allClippedDrawRect->X = 0.0f;
+        clippingContext->_allClippedDrawRect->Y = 0.0f;
+        clippingContext->_allClippedDrawRect->Width = 0.0f;
+        clippingContext->_allClippedDrawRect->Height = 0.0f;
+        clippingContext->_isUsing = false;
+    }
+    else
+    {
+        clippingContext->_isUsing = true;
+        csmFloat32 w = clippedDrawTotalMaxX - clippedDrawTotalMinX;
+        csmFloat32 h = clippedDrawTotalMaxY - clippedDrawTotalMinY;
+        clippingContext->_allClippedDrawRect->X = clippedDrawTotalMinX;
+        clippingContext->_allClippedDrawRect->Y = clippedDrawTotalMinY;
+        clippingContext->_allClippedDrawRect->Width = w;
+        clippingContext->_allClippedDrawRect->Height = h;
+    }
+}
+
+void CubismClippingManager_Metal::SetupLayoutBounds(csmInt32 usingClipCount) const
+{
+    if (usingClipCount <= 0)
+    {// この場合は一つのマスクターゲットを毎回クリアして使用する
+        for (csmUint32 index = 0; index < _clippingContextListForMask.GetSize(); index++)
+        {
+            CubismClippingContext* cc = _clippingContextListForMask[index];
+            cc->_layoutChannelNo = 0; // どうせ毎回消すので固定で良い
+            cc->_layoutBounds->X = 0.0f;
+            cc->_layoutBounds->Y = 0.0f;
+            cc->_layoutBounds->Width = 1.0f;
+            cc->_layoutBounds->Height = 1.0f;
+        }
+        return;
+    }
+
+    // ひとつのRenderTextureを極力いっぱいに使ってマスクをレイアウトする
+    // マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する
+
+    // RGBAを順番に使っていく。
+    const csmInt32 div = usingClipCount / ColorChannelCount; //１チャンネルに配置する基本のマスク個数
+    const csmInt32 mod = usingClipCount % ColorChannelCount; //余り、この番号のチャンネルまでに１つずつ配分する
+
+    // RGBAそれぞれのチャンネルを用意していく(0:R , 1:G , 2:B, 3:A, )
+    csmInt32 curClipIndex = 0; //順番に設定していく
+
+    for (csmInt32 channelNo = 0; channelNo < ColorChannelCount; channelNo++)
+    {
+        // このチャンネルにレイアウトする数
+        const csmInt32 layoutCount = div + (channelNo < mod ? 1 : 0);
+
+        // 分割方法を決定する
+        if (layoutCount == 0)
+        {
+            // 何もしない
+        }
+        else if (layoutCount == 1)
+        {
+            //全てをそのまま使う
+            CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+            cc->_layoutChannelNo = channelNo;
+            cc->_layoutBounds->X = 0.0f;
+            cc->_layoutBounds->Y = 0.0f;
+            cc->_layoutBounds->Width = 1.0f;
+            cc->_layoutBounds->Height = 1.0f;
+        }
+        else if (layoutCount == 2)
+        {
+            for (csmInt32 i = 0; i < layoutCount; i++)
+            {
+                const csmInt32 xpos = i % 2;
+
+                CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                cc->_layoutChannelNo = channelNo;
+
+                cc->_layoutBounds->X = xpos * 0.5f;
+                cc->_layoutBounds->Y = 0.0f;
+                cc->_layoutBounds->Width = 0.5f;
+                cc->_layoutBounds->Height = 1.0f;
+                //UVを2つに分解して使う
+            }
+        }
+        else if (layoutCount <= 4)
+        {
+            //4分割して使う
+            for (csmInt32 i = 0; i < layoutCount; i++)
+            {
+                const csmInt32 xpos = i % 2;
+                const csmInt32 ypos = i / 2;
+
+                CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                cc->_layoutChannelNo = channelNo;
+
+                cc->_layoutBounds->X = xpos * 0.5f;
+                cc->_layoutBounds->Y = ypos * 0.5f;
+                cc->_layoutBounds->Width = 0.5f;
+                cc->_layoutBounds->Height = 0.5f;
+            }
+        }
+        else if (layoutCount <= 9)
+        {
+            //9分割して使う
+            for (csmInt32 i = 0; i < layoutCount; i++)
+            {
+                const csmInt32 xpos = i % 3;
+                const csmInt32 ypos = i / 3;
+
+                CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                cc->_layoutChannelNo = channelNo;
+
+                cc->_layoutBounds->X = xpos / 3.0f;
+                cc->_layoutBounds->Y = ypos / 3.0f;
+                cc->_layoutBounds->Width = 1.0f / 3.0f;
+                cc->_layoutBounds->Height = 1.0f / 3.0f;
+            }
+        }
+        else
+        {
+            CubismLogError("not supported mask count : %d", layoutCount);
+
+            // 開発モードの場合は停止させる
+            CSM_ASSERT(0);
+
+            // 引き続き実行する場合、 SetupShaderProgramでオーバーアクセスが発生するので仕方なく適当に入れておく
+            // もちろん描画結果はろくなことにならない
+            for (csmInt32 i = 0; i < layoutCount; i++)
+            {
+                CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                cc->_layoutChannelNo = 0;
+                cc->_layoutBounds->X = 0.0f;
+                cc->_layoutBounds->Y = 0.0f;
+                cc->_layoutBounds->Width = 1.0f;
+                cc->_layoutBounds->Height = 1.0f;
+            }
+        }
+    }
+}
+
+CubismRenderer::CubismTextureColor* CubismClippingManager_Metal::GetChannelFlagAsColor(csmInt32 channelNo)
+{
+    return _channelColors[channelNo];
+}
+
+csmVector<CubismClippingContext*>* CubismClippingManager_Metal::GetClippingContextListForDraw()
+{
+    return &_clippingContextListForDraw;
+}
+
+void CubismClippingManager_Metal::SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height)
+{
+    _clippingMaskBufferSize = CubismVector2(width, height);
+}
+
+CubismVector2 CubismClippingManager_Metal::GetClippingMaskBufferSize() const
+{
+    return _clippingMaskBufferSize;
+}
+
+/*********************************************************************************************************************
+*                                      CubismClippingContext
+********************************************************************************************************************/
+CubismClippingContext::CubismClippingContext(CubismClippingManager_Metal* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+{
+    CubismRenderingInstanceSingleton_Metal *single = [CubismRenderingInstanceSingleton_Metal sharedManager];
+    id <MTLDevice> device = [single getMTLDevice];
+    CAMetalLayer* metalLayer = [single getMetalLayer];
+
+    _owner = manager;
+
+    // クリップしている（＝マスク用の）Drawableのインデックスリスト
+    _clippingIdList = clippingDrawableIndices;
+
+    // マスクの数
+    _clippingIdCount = clipCount;
+
+    _layoutChannelNo = 0;
+
+    _allClippedDrawRect = CSM_NEW csmRectF();
+    _layoutBounds = CSM_NEW csmRectF();
+
+    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
+    _clippingCommandBufferList = CSM_NEW csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>;
+
+
+    for (csmUint32 i = 0; i < _clippingIdCount; ++i)
+    {
+        const csmInt32 clippingId = _clippingIdList[i];
+        CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer = NULL;
+        const csmInt32 drawableVertexCount = model.GetDrawableVertexCount(clippingId);
+        const csmInt32 drawableVertexIndexCount = model.GetDrawableVertexIndexCount(clippingId);
+        const csmSizeInt vertexSize = sizeof(csmFloat32) * 2;
+
+
+        drawCommandBuffer = CSM_NEW CubismCommandBuffer_Metal::DrawCommandBuffer();
+        drawCommandBuffer->CreateVertexBuffer(device, vertexSize, drawableVertexCount * 2);      // Vertices + UVs
+        drawCommandBuffer->CreateIndexBuffer(device, drawableVertexIndexCount);
+
+
+        _clippingCommandBufferList->PushBack(drawCommandBuffer);
+    }
+}
+
+CubismClippingContext::~CubismClippingContext()
+{
+    if (_layoutBounds != NULL)
+    {
+        CSM_DELETE(_layoutBounds);
+        _layoutBounds = NULL;
+    }
+
+    if (_allClippedDrawRect != NULL)
+    {
+        CSM_DELETE(_allClippedDrawRect);
+        _allClippedDrawRect = NULL;
+    }
+
+    if (_clippedDrawableIndexList != NULL)
+    {
+        CSM_DELETE(_clippedDrawableIndexList);
+        _clippedDrawableIndexList = NULL;
+    }
+
+    if (_clippingCommandBufferList != NULL)
+    {
+        for (csmUint32 i = 0; i < _clippingCommandBufferList->GetSize(); ++i)
+        {
+            CSM_DELETE(_clippingCommandBufferList->At(i));
+            _clippingCommandBufferList->At(i) = NULL;
+        }
+
+        CSM_DELETE(_clippingCommandBufferList);
+        _clippingCommandBufferList = NULL;
+    }
+}
+
+void CubismClippingContext::AddClippedDrawable(csmInt32 drawableIndex)
+{
+    _clippedDrawableIndexList->PushBack(drawableIndex);
+}
+
+CubismClippingManager_Metal* CubismClippingContext::GetClippingManager()
+{
+    return _owner;
+}
+
+/*********************************************************************************************************************
+*                                       CubismShader_Metal
+********************************************************************************************************************/
+namespace {
+    const csmInt32 ShaderCount = 19; ///< シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
+    CubismShader_Metal* s_instance;
+}
+
+enum ShaderNames
+{
+    // SetupMask
+    ShaderNames_SetupMask,
+
+    //Normal
+    ShaderNames_Normal,
+    ShaderNames_NormalMasked,
+    ShaderNames_NormalMaskedInverted,
+    ShaderNames_NormalPremultipliedAlpha,
+    ShaderNames_NormalMaskedPremultipliedAlpha,
+    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
+
+    //Add
+    ShaderNames_Add,
+    ShaderNames_AddMasked,
+    ShaderNames_AddMaskedInverted,
+    ShaderNames_AddPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlphaInverted,
+
+    //Mult
+    ShaderNames_Mult,
+    ShaderNames_MultMasked,
+    ShaderNames_MultMaskedInverted,
+    ShaderNames_MultPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlphaInverted,
+};
+
+//// SetupMask
+static const csmChar* VertShaderSrcSetupMask = "VertShaderSrcSetupMask";
+
+static const csmChar* FragShaderSrcSetupMask = "FragShaderSrcSetupMask";
+
+//----- バーテックスシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* VertShaderSrc = "VertShaderSrc";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* VertShaderSrcMasked = "VertShaderSrcMasked";
+
+//----- フラグメントシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* FragShaderSrc = "FragShaderSrc";
+
+// Normal & Add & Mult 共通 （PremultipliedAlpha）
+static const csmChar* FragShaderSrcPremultipliedAlpha = "FragShaderSrcPremultipliedAlpha";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* FragShaderSrcMask = "FragShaderSrcMask";
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
+static const csmChar* FragShaderSrcMaskInverted = "FragShaderSrcMaskInverted";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskPremultipliedAlpha = "FragShaderSrcMaskPremultipliedAlpha";
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha = "FragShaderSrcMaskInvertedPremultipliedAlpha";
+
+CubismShader_Metal::CubismShader_Metal()
+{
+}
+
+CubismShader_Metal::~CubismShader_Metal()
+{
+}
+
+CubismShader_Metal* CubismShader_Metal::GetInstance()
+{
+    if (s_instance == NULL)
+    {
+        s_instance = CSM_NEW CubismShader_Metal();
+    }
+    return s_instance;
+}
+
+void CubismShader_Metal::DeleteInstance()
+{
+    if (s_instance)
+    {
+        CSM_DELETE_SELF(CubismShader_Metal, s_instance);
+        s_instance = NULL;
+    }
+}
+
+
+void CubismShader_Metal::GenerateShaders()
+{
+    for (csmInt32 i = 0; i < ShaderCount; i++)
+    {
+        _shaderSets.PushBack(CSM_NEW CubismShaderSet());
+    }
+
+    //シェーダライブラリのロード（.metal）
+    CubismRenderingInstanceSingleton_Metal *single = [CubismRenderingInstanceSingleton_Metal sharedManager];
+    id <MTLDevice> device = [single getMTLDevice];
+    _shaderLib = [device newDefaultLibrary];
+
+    if(!_shaderLib)
+    {
+        NSLog(@" ERROR: Couldnt create a default shader library");
+        // assert here because if the shader libary isn't loading, nothing good will happen
+        return;
+    }
+
+    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+
+    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
+    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
+    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
+    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
+    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
+    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+
+    _shaderSets[0]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[0]->ShaderProgram, -1);
+    _shaderSets[0]->SamplerState = MakeSamplerState(device);
+
+    _shaderSets[1]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[1]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[2]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[2]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[3]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[3]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[4]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[4]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[5]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[5]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[6]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[6]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+
+    _shaderSets[1]->DepthStencilState = MakeDepthStencilState(device);
+    _shaderSets[2]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[3]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[4]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[5]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[6]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+
+    _shaderSets[1]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[2]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[3]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[4]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[5]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[6]->SamplerState = _shaderSets[0]->SamplerState;
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    _shaderSets[7]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[7]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[8]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[8]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[9]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[9]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[10]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[10]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[11]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[11]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[12]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[12]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+
+    _shaderSets[7]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[8]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[9]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[10]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[11]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[12]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+
+    _shaderSets[7]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[8]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[9]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[10]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[11]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[12]->SamplerState = _shaderSets[0]->SamplerState;
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    _shaderSets[13]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[13]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[14]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[14]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[15]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[15]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[16]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[16]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[17]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[17]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[18]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[18]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+
+    _shaderSets[13]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[14]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[15]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[16]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[17]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[18]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+
+    _shaderSets[13]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[14]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[15]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[16]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[17]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[18]->SamplerState = _shaderSets[0]->SamplerState;
+}
+
+void CubismShader_Metal::SetupShaderProgram(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, CubismRenderer_Metal* renderer, id <MTLTexture> texture
+                                                , csmFloat32 opacity
+                                                , CubismRenderer::CubismBlendMode colorBlendMode
+                                                , CubismRenderer::CubismTextureColor baseColor
+                                                , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
+                                                , csmBool invertedMask
+                                                , id <MTLRenderCommandEncoder> renderEncoder)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders();
+    }
+
+    CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* drawCommand = drawCommandBuffer->GetCommandDraw();
+
+    if (renderer->GetClippingContextBufferForMask() != NULL) // マスク生成時
+    {
+        CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
+
+        //テクスチャ設定
+        [renderEncoder setFragmentTexture:texture atIndex:0];
+
+        [renderEncoder setVertexBuffer:(drawCommandBuffer->GetVertexBuffer()) offset:0 atIndex:MetalVertexInputIndexVertices];
+        [renderEncoder setVertexBuffer:(drawCommandBuffer->GetUvBuffer()) offset:0 atIndex:MetalVertexInputUVs];
+
+        CubismSetupMaskedShaderUniforms maskedShaderUniforms;
+        const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        maskedShaderUniforms.channelFlag = (vector_float4){ colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
+
+        csmFloat32* srcArray = renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray();
+
+        maskedShaderUniforms.clipMatrix = simd::float4x4(
+                            simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                            simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                            simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                            simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+
+        csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
+
+        maskedShaderUniforms.baseColor = (vector_float4){ rect->X * 2.0f - 1.0f,
+                                    rect->Y * 2.0f - 1.0f,
+                                    rect->GetRight() * 2.0f - 1.0f,
+                                    rect->GetBottom() * 2.0f - 1.0f };
+
+        // 転送
+        [renderEncoder setVertexBytes:&maskedShaderUniforms length:sizeof(CubismSetupMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+        [renderEncoder setFragmentBytes:&maskedShaderUniforms length:sizeof(CubismSetupMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+        [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+        drawCommand->SetRenderPipelineState(shaderSet->RenderPipelineState);
+    }
+    else // マスク生成以外の場合
+    {
+        const csmBool masked = renderer->GetClippingContextBufferForDraw() != NULL;  // この描画オブジェクトはマスク対象か
+        const csmInt32 offset = (masked ? ( invertedMask ? 2 : 1 ) : 0) + (isPremultipliedAlpha ? 3 : 0);
+
+        CubismShaderSet* shaderSet;
+
+        switch (colorBlendMode)
+        {
+        case CubismRenderer::CubismBlendMode_Normal:
+        default:
+            //_shaderSetsにshaderが入っていて、それをブレンドモードごとに切り替えている
+            shaderSet = _shaderSets[ShaderNames_Normal + offset];
+            break;
+
+        case CubismRenderer::CubismBlendMode_Additive:
+            shaderSet = _shaderSets[ShaderNames_Add + offset];
+            break;
+
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            shaderSet = _shaderSets[ShaderNames_Mult + offset];
+            break;
+        }
+
+        // 頂点配列の設定
+        [renderEncoder setVertexBuffer:(drawCommandBuffer->GetVertexBuffer()) offset:0 atIndex:MetalVertexInputIndexVertices];
+
+        // テクスチャ頂点の設定
+        [renderEncoder setVertexBuffer:(drawCommandBuffer->GetUvBuffer()) offset:0 atIndex:MetalVertexInputUVs];
+
+        if (masked)
+        {
+            CubismMaskedShaderUniforms maskedShaderUniforms;
+            CubismFragMaskedShaderUniforms fragMaskedShaderUniforms;
+
+            // frameBufferに書かれたテクスチャ
+            id <MTLTexture> tex = renderer->_offscreenFrameBuffer.GetColorBuffer();
+
+            //テクスチャ設定
+            [renderEncoder setFragmentTexture:tex atIndex:1];
+
+            // 使用するカラーチャンネルを設定
+            const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
+            CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+
+            fragMaskedShaderUniforms.channelFlag = (vector_float4){ colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
+            {
+                csmFloat32* srcArray = renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray();
+
+                maskedShaderUniforms.clipMatrix = simd::float4x4(
+                                    simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                                    simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                                    simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                                    simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+            }
+            {
+                //座標変換
+                csmFloat32* srcArray = matrix4x4.GetArray();
+                maskedShaderUniforms.matrix = simd::float4x4(
+                                                             simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                                                             simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                                                             simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                                                             simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+            }
+
+            //テクスチャ設定
+            [renderEncoder setFragmentTexture:texture atIndex:0];
+
+            maskedShaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+            fragMaskedShaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+
+            // 転送
+            [renderEncoder setVertexBytes:&maskedShaderUniforms length:sizeof(CubismMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+            [renderEncoder setFragmentBytes:&fragMaskedShaderUniforms length:sizeof(CubismFragMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+            [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+
+        } else {
+            CubismNormalShaderUniforms normalShaderUniforms;
+
+            //テクスチャ設定
+            [renderEncoder setFragmentTexture:texture atIndex:0];
+
+            //座標変換
+            csmFloat32* srcArray = matrix4x4.GetArray();
+            normalShaderUniforms.matrix = simd::float4x4(
+                                                         simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                                                         simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                                                         simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                                                         simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+            normalShaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+
+            // 転送
+            [renderEncoder setVertexBytes:&normalShaderUniforms length:sizeof(CubismNormalShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+            [renderEncoder setFragmentBytes:&normalShaderUniforms length:sizeof(CubismNormalShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+            [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+        }
+
+        [renderEncoder setDepthStencilState:shaderSet->DepthStencilState];
+        drawCommand->SetRenderPipelineState(shaderSet->RenderPipelineState);
+    }
+}
+
+CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
+{
+    // Create shader program.
+    ShaderProgram *shaderProgram = new ShaderProgram;
+
+    //頂点シェーダの取得
+    NSString *vertShaderStr = [NSString stringWithCString: vertShaderSrc encoding:NSUTF8StringEncoding];
+
+    shaderProgram->vertexFunction = [_shaderLib newFunctionWithName:vertShaderStr];
+    if(!shaderProgram->vertexFunction)
+    {
+        delete shaderProgram;
+        NSLog(@">> ERROR: Couldn't load vertex function from default library");
+        return nil;
+    }
+
+    //フラグメントシェーダの取得
+    NSString *fragShaderStr = [NSString stringWithCString: fragShaderSrc encoding:NSUTF8StringEncoding];
+    shaderProgram->fragmentFunction = [_shaderLib newFunctionWithName:fragShaderStr];
+    if(!shaderProgram->fragmentFunction)
+    {
+        delete shaderProgram;
+        NSLog(@" ERROR: Couldn't load fragment function from default library");
+        return nil;
+    }
+
+    return shaderProgram;
+}
+
+id<MTLRenderPipelineState> CubismShader_Metal::MakeRenderPipelineState(id<MTLDevice> device, CubismShader_Metal::ShaderProgram* shaderProgram, int blendMode)
+{
+    MTLRenderPipelineDescriptor* renderPipelineDescriptor = [MTLRenderPipelineDescriptor new];
+    NSError *error;
+
+    renderPipelineDescriptor.vertexFunction = shaderProgram->vertexFunction;
+    renderPipelineDescriptor.fragmentFunction = shaderProgram->fragmentFunction;
+    renderPipelineDescriptor.colorAttachments[0].blendingEnabled = true;
+
+    switch (blendMode)
+    {
+    default:
+            // only Setup masking
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceColor;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
+            break;
+
+    case CubismRenderer::CubismBlendMode_Normal:
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+
+        break;
+
+    case CubismRenderer::CubismBlendMode_Additive:
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+
+        break;
+
+    case CubismRenderer::CubismBlendMode_Multiplicative:
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorDestinationColor;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+
+        break;
+    }
+
+    return [device newRenderPipelineStateWithDescriptor:renderPipelineDescriptor error:&error];
+}
+
+id<MTLDepthStencilState> CubismShader_Metal::MakeDepthStencilState(id<MTLDevice> device)
+{
+    MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
+
+    depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
+    depthStencilDescriptor.depthWriteEnabled = YES;
+
+    return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+}
+
+id<MTLSamplerState> CubismShader_Metal::MakeSamplerState(id<MTLDevice> device)
+{
+    MTLSamplerDescriptor* samplerDescriptor = [MTLSamplerDescriptor new];
+
+    samplerDescriptor.rAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.sAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.tAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.minFilter = MTLSamplerMinMagFilterLinear;
+    samplerDescriptor.magFilter = MTLSamplerMinMagFilterLinear;
+    samplerDescriptor.mipFilter = MTLSamplerMipFilterNotMipmapped;
+
+    return [device newSamplerStateWithDescriptor:samplerDescriptor];
+}
+
+/*********************************************************************************************************************
+ *                                      CubismRenderer_Metal
+ ********************************************************************************************************************/
+
+id<MTLCommandBuffer> CubismRenderer_Metal::s_commandBuffer = nil;
+id<MTLDevice> CubismRenderer_Metal::s_device = nil;
+id<MTLTexture> CubismRenderer_Metal::s_renderTarget = nil;
+id<MTLTexture> CubismRenderer_Metal::s_depthTarget = nil;
+
+CubismRenderer* CubismRenderer::Create()
+{
+    return CSM_NEW CubismRenderer_Metal();
+}
+
+void CubismRenderer::StaticRelease()
+{
+    CubismRenderer_Metal::DoStaticRelease();
+}
+
+CubismRenderer_Metal::CubismRenderer_Metal() : _clippingManager(NULL)
+                                                     , _clippingContextBufferForMask(NULL)
+                                                     , _clippingContextBufferForDraw(NULL)
+{
+    // テクスチャ対応マップの容量を確保しておく.
+    _textures.PrepareCapacity(32, true);
+}
+
+CubismRenderer_Metal::~CubismRenderer_Metal()
+{
+    CSM_DELETE_SELF(CubismClippingManager_Metal, _clippingManager);
+}
+
+void CubismRenderer_Metal::DoStaticRelease()
+{
+    s_commandBuffer = nil;
+    CubismShader_Metal::DeleteInstance();
+}
+
+void CubismRenderer_Metal::Initialize(CubismModel* model)
+{
+
+    CubismRenderingInstanceSingleton_Metal *single = [CubismRenderingInstanceSingleton_Metal sharedManager];
+    id <MTLDevice> device = [single getMTLDevice];
+    CAMetalLayer* metalLayer = [single getMetalLayer];
+
+    if (model->IsUsingMasking())
+    {
+        _clippingManager = CSM_NEW CubismClippingManager_Metal();  //クリッピングマスク・バッファ前処理方式を初期化
+        _clippingManager->Initialize(
+            *model,
+            model->GetDrawableCount(),
+            model->GetDrawableMasks(),
+            model->GetDrawableMaskCounts()
+        );
+
+        _offscreenFrameBuffer.CreateOffscreenFrame(_clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
+    }
+
+    _sortedDrawableIndexList.Resize(model->GetDrawableCount(), 0);
+
+    _drawableDrawCommandBuffer.Resize(model->GetDrawableCount());
+
+    for (csmInt32 i = 0; i < _drawableDrawCommandBuffer.GetSize(); ++i)
+    {
+        const csmInt32 drawableVertexCount = model->GetDrawableVertexCount(i);
+        const csmInt32 drawableVertexIndexCount = model->GetDrawableVertexIndexCount(i);
+        const csmSizeInt vertexSize = sizeof(csmFloat32) * 2;
+
+        _drawableDrawCommandBuffer[i] = CSM_NEW CubismCommandBuffer_Metal::DrawCommandBuffer();
+
+//        ここで頂点情報のメモリを確保する
+        _drawableDrawCommandBuffer[i]->CreateVertexBuffer(device, vertexSize, drawableVertexCount);
+
+        if (drawableVertexIndexCount > 0)
+        {
+            _drawableDrawCommandBuffer[i]->CreateIndexBuffer(device, drawableVertexIndexCount);
+        }
+    }
+
+    CubismRenderer::Initialize(model);  //親クラスの処理を呼ぶ
+}
+
+void CubismRenderer_Metal::StartFrame(id<MTLDevice> device, id<MTLCommandBuffer> commandBuffer, id<MTLTexture> renderTarget, id<MTLTexture> depthTarget)
+{
+    s_commandBuffer = commandBuffer;
+    s_device = device;
+    s_renderTarget = renderTarget;
+    s_depthTarget = depthTarget;
+}
+
+id <MTLRenderCommandEncoder> CubismRenderer_Metal::PreDraw(id <MTLCommandBuffer> commandBuffer, MTLRenderPassDescriptor* drawableRenderDescriptor)
+{
+    //異方性フィルタリング
+    if (GetAnisotropy() > 0.0f)
+    {
+        // TODO:異方性フィルタリング、今後対応を行う。
+    }
+
+    id <MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:drawableRenderDescriptor];
+    return renderEncoder;
+}
+
+void CubismRenderer_Metal::PostDraw(id <MTLRenderCommandEncoder> renderEncoder)
+{
+    [renderEncoder endEncoding];
+}
+
+void CubismRenderer_Metal::DoDrawModel()
+{
+    // If the current drawable is nil, skip rendering this frame
+    if(s_renderTarget == nil)
+    {
+        return;
+    }
+
+    //------------ クリッピングマスク・バッファ前処理方式の場合 ------------
+    if (_clippingManager != NULL)
+    {
+        // サイズが違う場合はここで作成しなおし
+        if (_offscreenFrameBuffer.GetBufferWidth() != _clippingManager->GetClippingMaskBufferSize().X ||
+            _offscreenFrameBuffer.GetBufferHeight() != _clippingManager->GetClippingMaskBufferSize().Y)
+        {
+            _offscreenFrameBuffer.DestroyOffscreenFrame();
+            _offscreenFrameBuffer.CreateOffscreenFrame(
+                _clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
+        }
+
+        _clippingManager->SetupClippingContext(*GetModel(), this, _rendererProfile._lastColorBuffer, _rendererProfile._lastViewport);
+    }
+
+    id <MTLRenderCommandEncoder> renderEncoder = nil;
+
+    if(!IsUsingHighPrecisionMask())
+    {
+        CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* drawCommandDraw = _drawableDrawCommandBuffer[0]->GetCommandDraw();
+        MTLRenderPassDescriptor* drawableRenderDescriptor = drawCommandDraw->GetRenderPassDescriptor();
+        // レンダーターゲット
+        drawableRenderDescriptor.colorAttachments[0].texture = s_renderTarget;
+        drawableRenderDescriptor.colorAttachments[0].loadAction = MTLLoadActionLoad;
+        drawableRenderDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+        drawableRenderDescriptor.depthAttachment.texture = s_depthTarget;
+        drawableRenderDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
+        drawableRenderDescriptor.depthAttachment.storeAction = MTLStoreActionDontCare;
+        drawableRenderDescriptor.depthAttachment.clearDepth = 1.0;
+
+        renderEncoder = PreDraw(s_commandBuffer, drawableRenderDescriptor);
+    }
+
+    const csmInt32 drawableCount = GetModel()->GetDrawableCount();
+    const csmInt32* renderOrder = GetModel()->GetDrawableRenderOrders();
+
+    // インデックスを描画順でソート
+    for (csmInt32 i = 0; i < drawableCount; ++i)
+    {
+        const csmInt32 order = renderOrder[i];
+        _sortedDrawableIndexList[order] = i;
+    }
+
+    // Update Vertex / Index buffer.
+    for (csmInt32 i = 0; i < drawableCount; ++i)
+    {
+        csmFloat32* vertices = const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(i));
+        Core::csmVector2* uvs = const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(i));
+        csmUint16* vertexIndices = const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(i));
+        const csmUint32 vertexCount = GetModel()->GetDrawableVertexCount(i);
+        const csmUint32 vertexIndexCount = GetModel()->GetDrawableVertexIndexCount(i);
+
+        _drawableDrawCommandBuffer[i]->UpdateVertexBuffer(vertices, uvs, vertexCount);
+        if (vertexIndexCount > 0)
+        {
+            _drawableDrawCommandBuffer[i]->UpdateIndexBuffer(vertexIndices, vertexIndexCount);
+        }
+    }
+
+    // 描画
+    for (csmInt32 i = 0; i < drawableCount; ++i)
+    {
+        const csmInt32 drawableIndex = _sortedDrawableIndexList[i];
+
+        // Drawableが表示状態でなければ処理をパスする
+        if (!GetModel()->GetDrawableDynamicFlagIsVisible(drawableIndex))
+        {
+            continue;
+        }
+
+        // クリッピングマスク
+        CubismClippingContext* clipContext = (_clippingManager != NULL)
+            ? (*_clippingManager->GetClippingContextListForDraw())[drawableIndex]
+            : NULL;
+
+        if (clipContext != NULL && IsUsingHighPrecisionMask()) // マスクを書く必要がある
+        {
+            // 生成したFrameBufferと同じサイズでビューポートを設定
+            MTLViewport clipVp = {0, 0, _clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y, 0.0, 1.0};
+            if(clipContext->_isUsing) // 書くことになっていた
+            {
+                renderEncoder = PreDraw(s_commandBuffer, _offscreenFrameBuffer.GetRenderPassDescriptor());
+                [renderEncoder setViewport:clipVp];
+            }
+
+            {
+                const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
+                for (csmInt32 index = 0; index < clipDrawCount; index++)
+                {
+                    const csmInt32 clipDrawIndex = clipContext->_clippingIdList[index];
+                    CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* drawCommandMask = clipContext->_clippingCommandBufferList->At(index)->GetCommandDraw();
+
+                    // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
+                    if (!GetModel()->GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
+                    {
+                        continue;
+                    }
+
+                    IsCulling(GetModel()->GetDrawableCulling(clipDrawIndex) != 0);
+
+                    // Update Vertex / Index buffer.
+                    {
+                        csmFloat32* vertices = const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(clipDrawIndex));
+                        Core::csmVector2* uvs = const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(clipDrawIndex));
+                        csmUint16* vertexIndices = const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex));
+                        const csmUint32 vertexCount = GetModel()->GetDrawableVertexCount(clipDrawIndex);
+                        const csmUint32 vertexIndexCount = GetModel()->GetDrawableVertexIndexCount(clipDrawIndex);
+
+                        CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBufferMask = clipContext->_clippingCommandBufferList->At(index);
+                        drawCommandBufferMask->UpdateVertexBuffer(vertices, uvs, vertexCount);
+                        if (vertexIndexCount > 0)
+                        {
+                            drawCommandBufferMask->UpdateIndexBuffer(vertexIndices, vertexIndexCount);
+                        }
+
+                        if (vertexCount <= 0)
+                        {
+                            continue;
+                        }
+                    }
+
+                    // 今回専用の変換を適用して描く
+                    // チャンネルも切り替える必要がある(A,R,G,B)
+                    SetClippingContextBufferForMask(clipContext);
+                    DrawMeshMetal(
+                        clipContext->_clippingCommandBufferList->At(index),
+                        GetModel()->GetDrawableTextureIndices(clipDrawIndex),
+                        GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
+                        GetModel()->GetDrawableVertexCount(clipDrawIndex),
+                        const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
+                        const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(clipDrawIndex)),
+                        reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(clipDrawIndex))),
+                        GetModel()->GetDrawableOpacity(clipDrawIndex),
+                        CubismRenderer::CubismBlendMode_Normal,   //クリッピングは通常描画を強制
+                        false, // マスク生成時はクリッピングの反転使用は全く関係がない
+                        clipDrawIndex,
+                        renderEncoder
+                    );
+                }
+            }
+
+            {
+                // --- 後処理 ---
+                PostDraw(renderEncoder);
+            }
+        }
+
+        CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* drawCommandDraw = _drawableDrawCommandBuffer[drawableIndex]->GetCommandDraw();
+        _drawableDrawCommandBuffer[drawableIndex]->SetCommandBuffer(s_commandBuffer);
+
+        // クリッピングマスクをセットする
+        SetClippingContextBufferForDraw(clipContext);
+
+        IsCulling(GetModel()->GetDrawableCulling(drawableIndex) != 0);
+
+        if (GetModel()->GetDrawableVertexIndexCount(drawableIndex) <= 0)
+        {
+            continue;
+        }
+
+        if(IsUsingHighPrecisionMask())
+        {
+            CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* drawCommandDraw = _drawableDrawCommandBuffer[0]->GetCommandDraw();
+            MTLRenderPassDescriptor* drawableRenderDescriptor = drawCommandDraw->GetRenderPassDescriptor();
+            // レンダーターゲット
+            drawableRenderDescriptor.colorAttachments[0].texture = s_renderTarget;
+            drawableRenderDescriptor.colorAttachments[0].loadAction = MTLLoadActionLoad;
+            drawableRenderDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+            drawableRenderDescriptor.depthAttachment.texture = s_depthTarget;
+            drawableRenderDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
+            drawableRenderDescriptor.depthAttachment.storeAction = MTLStoreActionDontCare;
+            drawableRenderDescriptor.depthAttachment.clearDepth = 1.0;
+
+            renderEncoder = PreDraw(s_commandBuffer, drawableRenderDescriptor);
+        }
+
+        DrawMeshMetal(
+            _drawableDrawCommandBuffer[drawableIndex],
+            GetModel()->GetDrawableTextureIndices(drawableIndex),
+            GetModel()->GetDrawableVertexIndexCount(drawableIndex),
+            GetModel()->GetDrawableVertexCount(drawableIndex),
+            const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),
+            const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(drawableIndex)),
+            reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(drawableIndex))),
+            GetModel()->GetDrawableOpacity(drawableIndex),
+            GetModel()->GetDrawableBlendMode(drawableIndex),
+            GetModel()->GetDrawableInvertedMask(drawableIndex), // マスクを反転使用するか
+            drawableIndex,
+            renderEncoder
+        );
+        if(IsUsingHighPrecisionMask())
+        {
+            PostDraw(renderEncoder);
+        }
+    }
+
+    if(!IsUsingHighPrecisionMask())
+    {
+        PostDraw(renderEncoder);
+    }
+}
+
+void CubismRenderer_Metal::DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount,
+    csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray, csmFloat32 opacity,
+    CubismBlendMode colorBlendMode, csmBool invertedMask)
+{
+}
+
+void CubismRenderer_Metal::DrawMeshMetal(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
+                                        , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+                                        , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask, csmInt32 drawableIndex
+                                        , id <MTLRenderCommandEncoder> renderEncoder)
+{
+#ifndef CSM_DEBUG
+    if (_textures[textureNo] == 0) return;    // モデルが参照するテクスチャがバインドされていない場合は描画をスキップする
+#endif
+
+    // 裏面描画の有効・無効
+    if (IsCulling())
+    {
+        [renderEncoder setCullMode:MTLCullModeBack];
+    }
+    else
+    {
+        [renderEncoder setCullMode:MTLCullModeNone];
+    }
+
+    CubismTextureColor modelColorRGBA = GetModelColor();
+
+    if (GetClippingContextBufferForMask() == NULL) // マスク生成時以外
+    {
+        modelColorRGBA.A *= opacity;
+        if (IsPremultipliedAlpha())
+        {
+            modelColorRGBA.R *= modelColorRGBA.A;
+            modelColorRGBA.G *= modelColorRGBA.A;
+            modelColorRGBA.B *= modelColorRGBA.A;
+        }
+    }
+
+    id <MTLTexture> drawTexture;   // シェーダに渡すテクスチャ
+
+    // テクスチャマップからバインド済みテクスチャIDを取得
+    // バインドされていなければダミーのテクスチャIDをセットする
+    if(_textures[textureNo] != NULL)
+    {
+        drawTexture = _textures[textureNo];
+    }
+    else
+    {
+        drawTexture = NULL;
+    }
+
+    CubismShader_Metal::GetInstance()->SetupShaderProgram(
+        drawCommandBuffer, this, drawTexture
+        , opacity, colorBlendMode, modelColorRGBA, IsPremultipliedAlpha()
+        , GetMvpMatrix(), invertedMask, renderEncoder
+    );
+
+    CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand* drawCommand =  drawCommandBuffer->GetCommandDraw();
+
+    id <MTLRenderPipelineState> pipelineState = drawCommand->GetRenderPipelineState();
+
+    // パイプライン状態オブジェクトを設定する
+    [renderEncoder setRenderPipelineState:pipelineState];
+
+    id <MTLBuffer> indexBuffer = drawCommandBuffer->GetIndexBuffer();
+    [renderEncoder drawIndexedPrimitives:MTLPrimitiveTypeTriangle indexCount:indexCount indexType:MTLIndexTypeUInt16
+                             indexBuffer:indexBuffer indexBufferOffset:0];
+    // 後処理
+    SetClippingContextBufferForDraw(NULL);
+    SetClippingContextBufferForMask(NULL);
+}
+
+CubismCommandBuffer_Metal::DrawCommandBuffer* CubismRenderer_Metal::GetDrawCommandBufferData(csmInt32 drawableIndex)
+{
+    return _drawableDrawCommandBuffer[drawableIndex];
+}
+
+void CubismRenderer_Metal::SaveProfile()
+{
+}
+
+void CubismRenderer_Metal::RestoreProfile()
+{
+}
+
+void CubismRenderer_Metal::BindTexture(csmUint32 modelTextureNo, id <MTLTexture> texture)
+{
+    _textures[modelTextureNo] = texture;
+}
+
+const csmMap<csmInt32, id <MTLTexture>>& CubismRenderer_Metal::GetBindedTextures() const
+{
+    return _textures;
+}
+
+void CubismRenderer_Metal::SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height)
+{
+    //FrameBufferのサイズを変更するためにインスタンスを破棄・再作成する
+    CSM_DELETE_SELF(CubismClippingManager_Metal, _clippingManager);
+
+    _clippingManager = CSM_NEW CubismClippingManager_Metal();
+
+    _clippingManager->SetClippingMaskBufferSize(width, height);
+
+    _clippingManager->Initialize(
+        *GetModel(),
+        GetModel()->GetDrawableCount(),
+        GetModel()->GetDrawableMasks(),
+        GetModel()->GetDrawableMaskCounts()
+    );
+}
+
+CubismVector2 CubismRenderer_Metal::GetClippingMaskBufferSize() const
+{
+    return _clippingManager->GetClippingMaskBufferSize();
+}
+
+void CubismRenderer_Metal::SetClippingContextBufferForMask(CubismClippingContext* clip)
+{
+    _clippingContextBufferForMask = clip;
+}
+
+CubismClippingContext* CubismRenderer_Metal::GetClippingContextBufferForMask() const
+{
+    return _clippingContextBufferForMask;
+}
+
+void CubismRenderer_Metal::SetClippingContextBufferForDraw(CubismClippingContext* clip)
+{
+    _clippingContextBufferForDraw = clip;
+}
+
+CubismClippingContext* CubismRenderer_Metal::GetClippingContextBufferForDraw() const
+{
+    return _clippingContextBufferForDraw;
+}
+
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Metal/CubismRenderingInstanceSingleton_Metal.h
+++ b/src/Rendering/Metal/CubismRenderingInstanceSingleton_Metal.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#import <UIKit/UIKit.h>
+#import <MetalKit/MetalKit.h>
+
+//Framework側で保持しなければいけない値
+@interface CubismRenderingInstanceSingleton_Metal : NSObject {
+    id <MTLDevice> mtlDevice;
+    CAMetalLayer* metalLayer;
+}
++ (id)sharedManager;
+- (void)setMTLDevice:(id <MTLDevice>)param;
+- (id <MTLDevice>)getMTLDevice;
+
+- (void)setMetalLayer:(CAMetalLayer*)param;
+- (CAMetalLayer*)getMetalLayer;
+
+@end

--- a/src/Rendering/Metal/CubismRenderingInstanceSingleton_Metal.m
+++ b/src/Rendering/Metal/CubismRenderingInstanceSingleton_Metal.m
@@ -1,0 +1,47 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#import "CubismRenderingInstanceSingleton_Metal.h"
+
+static id theSharedManager = nil;
+
+@implementation CubismRenderingInstanceSingleton_Metal
+
++ (id)sharedManager {
+    if (theSharedManager == nil) {
+        theSharedManager = [[self alloc] init];
+    }
+    return theSharedManager;
+}
+
+- (void)setMTLDevice:(id <MTLDevice>)param {
+    mtlDevice = param;
+}
+
+- (id <MTLDevice>)getMTLDevice {
+    return mtlDevice;
+}
+
+- (void)setMetalLayer:(CAMetalLayer*)param {
+    metalLayer = param;
+}
+
+- (CAMetalLayer*)getMetalLayer {
+    return metalLayer;
+}
+
+- (id)init {
+    [self setMTLDevice:nil];
+    [self setMetalLayer:nil];
+    return self;
+}
+
+- (void)dealloc {
+    [super dealloc];
+}
+
+@end

--- a/src/Rendering/Metal/MetalShaderTypes.h
+++ b/src/Rendering/Metal/MetalShaderTypes.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#ifndef MetalShaderTypes_h
+#define MetalShaderTypes_h
+
+#include <simd/simd.h>
+
+typedef enum MetalVertexInputIndex
+{
+    MetalVertexInputIndexVertices = 0,
+    MetalVertexInputUVs = 1,
+    MetalVertexInputIndexUniforms = 2,
+} MetalVertexInputIndex;
+
+typedef struct
+{
+    simd::float4x4 matrix;
+    vector_float4 baseColor;
+
+} CubismNormalShaderUniforms;
+
+typedef struct
+{
+    simd::float4x4 matrix;
+    simd::float4x4 clipMatrix;
+    vector_float4 baseColor;
+
+} CubismMaskedShaderUniforms;
+
+typedef struct
+{
+    simd::float4x4 clipMatrix;
+    vector_float4 channelFlag;
+    vector_float4 baseColor;
+
+} CubismSetupMaskedShaderUniforms;
+
+typedef struct
+{
+    vector_float4 channelFlag;
+    vector_float4 baseColor;
+
+} CubismFragMaskedShaderUniforms;
+
+#endif /* MetalShaderTypes_h */

--- a/src/Rendering/Metal/MetalShaders.metal
+++ b/src/Rendering/Metal/MetalShaders.metal
@@ -1,0 +1,198 @@
+/*
+See LICENSE folder for this sample’s licensing information.
+
+Abstract:
+Metal shaders used for this sample
+*/
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+// Include header shared between this Metal shader code and C code executing Metal API commands
+#include "MetalShaderTypes.h"
+
+//
+struct NormalRasterizerData
+{
+    float4 position [[ position ]];
+    float2 texCoord; //v2f.texcoord
+};
+
+//
+struct MaskedRasterizerData
+{
+    float4 position [[ position ]];
+    float2 texCoord; //v2f.texcoord
+    float4 myPos;
+};
+
+vertex MaskedRasterizerData
+VertShaderSrcSetupMask(uint vertexID [[ vertex_id ]],
+             constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+             constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
+             constant CubismSetupMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]])
+{
+    MaskedRasterizerData out;
+    float2 vert = vertexArray[vertexID];
+    float2 uv = uvArray[vertexID];
+
+    float4 pos = float4(vert.x, vert.y, 0.0, 1.0);
+    out.position = uniforms.clipMatrix * pos;
+    out.myPos = uniforms.clipMatrix * pos;
+    out.texCoord = uv;
+    out.texCoord.y = 1.0 - out.texCoord.y;
+
+    return out;
+}
+
+fragment float4
+FragShaderSrcSetupMask(MaskedRasterizerData in [[stage_in]],
+                       texture2d<float> texture [[ texture(0) ]],
+                       constant CubismSetupMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+                       sampler smp [[sampler(0)]])
+{
+    float isInside =
+        step(uniforms.baseColor.x, in.myPos.x/in.myPos.w)
+        * step(uniforms.baseColor.y, in.myPos.y/in.myPos.w)
+        * step(in.myPos.x/in.myPos.w, uniforms.baseColor.z)
+        * step(in.myPos.y/in.myPos.w, uniforms.baseColor.w);
+
+    float4 gl_FragColor = float4(uniforms.channelFlag * texture.sample(smp, in.texCoord).a * isInside);
+    return gl_FragColor;
+}
+
+////----- バーテックスシェーダプログラム -----
+//// Normal & Add & Mult 共通
+vertex NormalRasterizerData
+VertShaderSrc(uint vertexID [[ vertex_id ]],
+              constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+              constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
+             constant CubismNormalShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]])
+
+{
+    NormalRasterizerData out;
+    float2 vert = vertexArray[vertexID];
+    float2 uv = uvArray[vertexID];
+
+    float4 pos = float4(vert.x, vert.y, 0.0, 1.0);
+    out.position = uniforms.matrix * pos;
+    out.texCoord = uv;
+    out.texCoord.y = 1.0 - out.texCoord.y;
+
+    return out;
+}
+
+//// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+vertex MaskedRasterizerData
+VertShaderSrcMasked(uint vertexID [[ vertex_id ]],
+            constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+            constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
+            constant CubismMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]])
+{
+    MaskedRasterizerData out;
+    float2 vert = vertexArray[vertexID];
+    float2 uv = uvArray[vertexID];
+
+    float4 pos = float4(vert.x, vert.y, 0.0, 1.0);
+    out.position = uniforms.matrix * pos;
+    out.myPos = uniforms.clipMatrix * pos;
+    out.myPos = float4(out.myPos.x, 1.0 - out.myPos.y, out.myPos.zw);
+    out.texCoord = uv;
+    out.texCoord.y = 1.0 - out.texCoord.y;
+
+    return out;
+}
+
+////----- フラグメントシェーダプログラム -----
+//// Normal & Add & Mult 共通
+fragment float4
+FragShaderSrc(NormalRasterizerData in [[stage_in]],
+              texture2d<float> texture [[ texture(0) ]],
+              constant CubismNormalShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+              sampler smp [[sampler(0)]])
+{
+    float4 color = texture.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 gl_FragColor = float4(color.rgb * color.a,  color.a);
+
+    return gl_FragColor;
+}
+
+//// Normal & Add & Mult 共通 （PremultipliedAlpha）
+fragment float4
+FragShaderSrcPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
+                        texture2d<float> texture [[ texture(0) ]],
+                        constant CubismNormalShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+                        sampler smp [[sampler(0)]])
+{
+    float4 gl_FragColor = texture.sample(smp, in.texCoord) * uniforms.baseColor;
+
+    return gl_FragColor;
+}
+
+//// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+fragment float4
+FragShaderSrcMask(MaskedRasterizerData in [[stage_in]],
+                    texture2d<float> texture0 [[ texture(0) ]],
+                    texture2d<float> texture1 [[ texture(1) ]],
+                    constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+                    sampler smp [[sampler(0)]])
+{
+    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    float4 gl_FragColor = col_formask;
+    return gl_FragColor;
+}
+
+//// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
+fragment float4
+FragShaderSrcMaskInverted(MaskedRasterizerData in [[stage_in]],
+                    texture2d<float> texture0 [[ texture(0) ]],
+                    texture2d<float> texture1 [[ texture(1) ]],
+                    constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+                    sampler smp [[sampler(0)]])
+{
+    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    float4 gl_FragColor = col_formask;
+    return gl_FragColor;
+}
+
+//// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
+fragment float4
+FragShaderSrcMaskPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
+                    texture2d<float> texture0 [[ texture(0) ]],
+                    texture2d<float> texture1 [[ texture(1) ]],
+                                    constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+                                    sampler smp [[sampler(0)]])
+{
+    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    float4 gl_FragColor = col_formask;
+    return gl_FragColor;
+}
+
+//// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
+fragment float4
+FragShaderSrcMaskInvertedPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
+                    texture2d<float> texture0 [[ texture(0) ]],
+                    texture2d<float> texture1 [[ texture(1) ]],
+                    constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
+                    sampler smp [[sampler(0)]])
+{
+    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    float4 gl_FragColor = col_formask;
+    return gl_FragColor;
+}


### PR DESCRIPTION
### Added

* Add a function to parse the opacity from `.motion3.json`.
* Add a Renderer for Metal API in iOS.
  * There are some restrictions, see [NOTICE.md](NOTICE.md).

### Fixed

* Fix return correct error values for out-of-index arguments in cubismjson by [@cocor-au-lait](https://github.com/cocor-au-lait).
* Fix a warning when `SegmentType` could not be obtained when loading motion.
* Fix renderer for Cocos2d-x v4.0.
  * Rendering didn't work when using `USE_RENDER_TARGET` and high precision masking.