### PR TITLE
Update to Cubism SDK for Native R4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.4] - 2021-12-09
+
+### Added
+
+* Add the rendering options on Metal:
+  * `USE_RENDER_TARGET`
+  * `USE_MODEL_RENDER_TARGET`
+
+* Add anisotropic filtering to Metal.
+* Add a macro to toggle the precision of floating point numbers in OpenGL fragment shaders.
+* Add a function to check `.cdi3.json` exists from `.model3.json`.
+* Add `CubismJsonHolder`, a common class used to instantiate and check the validity of `CubismJson`.
+  * Each Json parser will now warn if an class of `CubismJson` is invalid.
+
+### Changed
+
+* Change each Json parser inherits a common class `CubismJsonHolder`.
+
+### Fixed
+
+* Fix renderer for Cocos2d-x v4.0.
+   * `RenderTexture` was empty when using `USE_MODEL_RENDER_TARGET`.
+* Fix motions with different fade times from switching properly.
+* Fix a bug that motions currently played do not fade out when play a motion.
+
 
 ## [4-r.4-beta.1] - 2021-10-07
 
@@ -11,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Add a function to parse the opacity from `.motion3.json`.
 * Add a Renderer for Metal API in iOS.
-  * There are some restrictions, see [NOTICE.md](NOTICE.md).
+  * There are some restrictions, see [NOTICE.md](https://github.com/Live2D/CubismNativeSamples/blob/e4144053d1546473d2e76d30779e26d84b00d9f9/NOTICE.md).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,11 @@ JSON パーサーやログ出力などのユーティリティ機能を提供し
 ## 変更履歴
 
 当リポジトリの変更履歴については [CHANGELOG.md](CHANGELOG.md) を参照ください。
+
+
+## コミュニティ
+
+ユーザー同士でCubism SDKの活用方法の提案や質問をしたい場合は、是非コミュニティをご活用ください。
+
+- [Live2D 公式コミュニティ](https://creatorsforum.live2d.com/)
+- [Live2D community(English)](http://community.live2d.com/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismFrameworkConfig.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelSettingJson.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelSettingJson.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismJsonHolder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ICubismAllocator.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ICubismModelSetting.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Live2DCubismCore.hpp

--- a/src/CubismCdiJson.cpp
+++ b/src/CubismCdiJson.cpp
@@ -23,12 +23,12 @@ const csmChar* Name = "Name";
 
 CubismCdiJson::CubismCdiJson(const csmByte* buffer, csmSizeInt size)
 {
-    _json = Utils::CubismJson::Create(buffer, size);
+    CreateCubismJson(buffer, size);
 }
 
 CubismCdiJson::~CubismCdiJson()
 {
-    Utils::CubismJson::Delete(_json);
+    DeleteCubismJson();
 }
 
 // キーが存在するかどうかのチェック

--- a/src/CubismCdiJson.hpp
+++ b/src/CubismCdiJson.hpp
@@ -7,12 +7,13 @@
 
 #pragma once
 
+#include "CubismJsonHolder.hpp"
 #include "Utils/CubismJson.hpp"
 
 //--------- LIVE2D NAMESPACE ------------
 namespace Live2D {  namespace Cubism {  namespace Framework {
 
-class CubismCdiJson
+class CubismCdiJson : public CubismJsonHolder
 {
 public:
     /**
@@ -85,8 +86,6 @@ private:
      * @retval       false -> キーが存在しない
      */
     csmBool IsExistParts() const;
-
-    Utils::CubismJson* _json;
 };
 
 }}}

--- a/src/CubismJsonHolder.hpp
+++ b/src/CubismJsonHolder.hpp
@@ -1,0 +1,85 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "Utils/CubismJson.hpp"
+
+//--------- LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework {
+    /**
+     * @brief CubismJsonのインスタンス生成や有効性のチェック処理を抽象化したクラス
+     *
+     * 各JsonパーサにおいてCubismJsonのインスタンス生成や
+     * 有効性のチェック処理を共通化するためのインターフェース。
+     *
+     */
+    class CubismJsonHolder
+    {
+    public:
+        /**
+         * @brief コンストラクタ
+         *
+         * コンストラクタ。
+         */
+        CubismJsonHolder()
+            : _json(NULL)
+        { }
+
+        /**
+         * @brief デストラクタ
+         *
+         * デストラクタ。
+         */
+        virtual ~CubismJsonHolder()
+        { }
+
+        /**
+         * @brief CubismJsonの有効性チェック
+         *
+         * @retval       true  -> Jsonファイルが正常に読み込めた
+         * @retval       false -> Jsonファイルが読み込めなかった。もしくは、存在しない
+         */
+        csmBool IsValid()
+        {
+            return _json;
+        }
+
+    protected:
+        /**
+         * @brief CubismJsonのインスタンスを生成する
+         *
+         * Util:CubismJsonクラスのCreate関数を呼んで
+         * CubismJsonのインスタンスを生成する。
+         *
+         */
+        void CreateCubismJson(const csmByte* buffer, csmSizeInt size)
+        {
+            _json = Utils::CubismJson::Create(buffer, size);
+
+            if (!IsValid())
+            {
+                CubismLogError("[CubismJsonHolder] Invalid Json document.");
+            }
+        };
+
+        /**
+         * @brief CubismJsonのインスタンスを破棄する
+         *
+         * Util:CubismJsonクラスのDelete関数を呼んで
+         * CubismJsonのインスタンスを破棄する。
+         *
+         */
+        void DeleteCubismJson()
+        {
+            Utils::CubismJson::Delete(_json);
+            _json = NULL;
+        }
+
+        Utils::CubismJson* _json;   /// CubismJsonの実体
+    };
+}}}

--- a/src/CubismModelSettingJson.cpp
+++ b/src/CubismModelSettingJson.cpp
@@ -34,6 +34,7 @@ const csmChar* HitAreas = "HitAreas";
 const csmChar* Moc = "Moc";
 const csmChar* Textures = "Textures";
 const csmChar* Physics = "Physics";
+const csmChar* DisplayInfo = "DisplayInfo";
 const csmChar* Pose = "Pose";
 const csmChar* Expressions = "Expressions";
 const csmChar* Motions = "Motions";
@@ -102,6 +103,11 @@ csmBool CubismModelSettingJson::IsExistPhysicsFile() const
 csmBool CubismModelSettingJson::IsExistPoseFile() const
 {
     Utils::Value& node = (*_jsonValue[FrequentNode_Pose]);
+    return !node.IsNull() && !node.IsError();
+}
+csmBool CubismModelSettingJson::IsExistDisplayInfoFile() const
+{
+    Utils::Value& node = (*_jsonValue[FrequentNode_DisplayInfo]);
     return !node.IsNull() && !node.IsError();
 }
 csmBool CubismModelSettingJson::IsExistExpressionFile() const
@@ -173,7 +179,7 @@ csmBool CubismModelSettingJson::IsExistLipSyncParameters() const
 
 CubismModelSettingJson::CubismModelSettingJson(const csmByte* buffer, csmSizeInt size)
 {
-    _json = Utils::CubismJson::Create(buffer, size);
+    CreateCubismJson(buffer, size);
 
     if (_json)
     {
@@ -183,6 +189,7 @@ CubismModelSettingJson::CubismModelSettingJson(const csmByte* buffer, csmSizeInt
         _jsonValue.PushBack(&(_json->GetRoot()[Groups]));
         _jsonValue.PushBack(&(_json->GetRoot()[FileReferences][Moc]));
         _jsonValue.PushBack(&(_json->GetRoot()[FileReferences][Motions]));
+        _jsonValue.PushBack(&(_json->GetRoot()[FileReferences][DisplayInfo]));
         _jsonValue.PushBack(&(_json->GetRoot()[FileReferences][Expressions]));
         _jsonValue.PushBack(&(_json->GetRoot()[FileReferences][Textures]));
         _jsonValue.PushBack(&(_json->GetRoot()[FileReferences][Physics]));
@@ -193,7 +200,7 @@ CubismModelSettingJson::CubismModelSettingJson(const csmByte* buffer, csmSizeInt
 
 CubismModelSettingJson::~CubismModelSettingJson()
 {
-    Utils::CubismJson::Delete( _json);
+    DeleteCubismJson();
 }
 
 Utils::CubismJson* CubismModelSettingJson::GetJsonPointer() const
@@ -241,7 +248,7 @@ const csmChar* CubismModelSettingJson::GetHitAreaName(csmInt32 index)
     return (*_jsonValue[FrequentNode_HitAreas])[index][Name].GetRawString();
 }
 
-// 物理演算、パーツ切り替え、表情ファイルについて
+// 物理演算、表示名称、パーツ切り替え、表情ファイルについて
 const csmChar* CubismModelSettingJson::GetPhysicsFileName()
 {
     if (!IsExistPhysicsFile())return "";
@@ -252,6 +259,12 @@ const csmChar* CubismModelSettingJson::GetPoseFileName()
 {
     if (!IsExistPoseFile())return "";
     return (*_jsonValue[FrequentNode_Pose]).GetRawString();
+}
+
+const csmChar* CubismModelSettingJson::GetDisplayInfoFileName()
+{
+    if (!IsExistDisplayInfoFile())return "";
+    return (*_jsonValue[FrequentNode_DisplayInfo]).GetRawString();
 }
 
 csmInt32 CubismModelSettingJson::GetExpressionCount()

--- a/src/CubismModelSettingJson.hpp
+++ b/src/CubismModelSettingJson.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "ICubismModelSetting.hpp"
+#include "CubismJsonHolder.hpp"
 #include "Utils/CubismJson.hpp"
 #include "Id/CubismId.hpp"
 
@@ -19,7 +20,7 @@ namespace Live2D { namespace Cubism { namespace Framework {
  * model3.jsonファイルをパースして値を取得する。
  *
  */
-class CubismModelSettingJson : public ICubismModelSetting
+class CubismModelSettingJson : public ICubismModelSetting, public CubismJsonHolder
 {
 public:
 
@@ -67,6 +68,8 @@ public:
 
     const csmChar* GetPoseFileName();
 
+    const csmChar* GetDisplayInfoFileName();
+
     csmInt32 GetExpressionCount();
 
     const csmChar* GetExpressionName(csmInt32 index);
@@ -106,6 +109,7 @@ private:
         FrequentNode_Groups,        ///< GetRoot()[Groups]
         FrequentNode_Moc,           ///< GetRoot()[FileReferences][Moc]
         FrequentNode_Motions,       ///< GetRoot()[FileReferences][Motions]
+        FrequentNode_DisplayInfo,   ///< GetRoot()[FileReferences][DisplayInfo]
         FrequentNode_Expressions,   ///< GetRoot()[FileReferences][Expressions]
         FrequentNode_Textures,      ///< GetRoot()[FileReferences][Textures]
         FrequentNode_Physics,       ///< GetRoot()[FileReferences][Physics]
@@ -152,6 +156,14 @@ private:
      * @retval       false -> キーが存在しない
      */
     csmBool IsExistPoseFile() const;
+
+    /**
+     * @brief        表示名称設定ファイルのキーが存在するかどうかを確認する
+     *
+     * @retval       true  -> キーが存在する
+     * @retval       false -> キーが存在しない
+     */
+    csmBool IsExistDisplayInfoFile() const;
 
     /**
      * @brief        表情設定ファイルのキーが存在するかどうかを確認する
@@ -232,7 +244,6 @@ private:
      */
     csmBool IsExistLipSyncParameters() const;
 
-    Utils::CubismJson*          _json;       ///< モデルデータjson
-    csmVector<Utils::Value*>    _jsonValue;  ///< 上jsonの頻出ノード
+    csmVector<Utils::Value*>    _jsonValue;  ///< モデルデータjsonの頻出ノード
 };
 }}}

--- a/src/ICubismModelSetting.hpp
+++ b/src/ICubismModelSetting.hpp
@@ -97,6 +97,13 @@ public:
     virtual const csmChar* GetPoseFileName() = 0;
 
     /**
+     * @brief        表示名称設定ファイルの名前を取得する
+     *
+     * @return       表示名称設定ファイルの名前
+     */
+    virtual const csmChar* GetDisplayInfoFileName() = 0;
+
+    /**
      * @brief        表情設定ファイルの数を取得する
      *
      * @return       表情設定ファイルの数

--- a/src/Model/CubismModelUserDataJson.cpp
+++ b/src/Model/CubismModelUserDataJson.cpp
@@ -22,12 +22,12 @@ const csmChar* Value = "Value";
 }
 CubismModelUserDataJson::CubismModelUserDataJson(const csmByte* buffer, csmSizeInt size)
 {
-    _json = Utils::CubismJson::Create(buffer, size);
+    CreateCubismJson(buffer, size);
 }
 
 CubismModelUserDataJson::~CubismModelUserDataJson()
 {
-    Utils::CubismJson::Delete(_json);
+    DeleteCubismJson();
 }
 
 csmInt32 CubismModelUserDataJson::GetUserDataCount() const

--- a/src/Model/CubismModelUserDataJson.hpp
+++ b/src/Model/CubismModelUserDataJson.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "CubismJsonHolder.hpp"
 #include "Utils/CubismJson.hpp"
 #include "Model/CubismModel.hpp"
 #include "Id/CubismIdManager.hpp"
@@ -14,7 +15,7 @@
 //--------- LIVE2D NAMESPACE ------------
 namespace Live2D {  namespace Cubism {  namespace Framework {
 
-class CubismModelUserDataJson
+class CubismModelUserDataJson : public CubismJsonHolder
 {
 public:
     /**
@@ -84,9 +85,6 @@ public:
     * @return      ユーザデータ
     */
     const csmChar* GetUserDataValue(csmInt32 i) const;
-
-private:
-    Utils::CubismJson* _json;
 };
 
 }}}

--- a/src/Motion/CubismMotionJson.cpp
+++ b/src/Motion/CubismMotionJson.cpp
@@ -36,12 +36,12 @@ const csmChar* Value = "Value";
 
 CubismMotionJson::CubismMotionJson(const csmByte* buffer, csmSizeInt size)
 {
-    _json = Utils::CubismJson::Create(buffer, size);
+    CreateCubismJson(buffer, size);
 }
 
 CubismMotionJson::~CubismMotionJson()
 {
-    Utils::CubismJson::Delete(_json);
+    DeleteCubismJson();
 }
 
 csmFloat32 CubismMotionJson::GetMotionDuration() const

--- a/src/Motion/CubismMotionJson.hpp
+++ b/src/Motion/CubismMotionJson.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "CubismJsonHolder.hpp"
 #include "Utils/CubismJson.hpp"
 #include "Id/CubismId.hpp"
 
@@ -26,7 +27,7 @@ enum EvaluationOptionFlag
  *
  * motion3.jsonのコンテナ。
  */
-class CubismMotionJson
+class CubismMotionJson : public CubismJsonHolder
 {
 public:
     /**
@@ -272,9 +273,6 @@ public:
     * @return  イベントの文字列
     */
     const csmChar* GetEventValue(csmInt32 userDataIndex) const;
-
-private:
-    Utils::CubismJson* _json;       ///< motion3.jsonデータ
 };
 
 }}}

--- a/src/Motion/CubismMotionManager.hpp
+++ b/src/Motion/CubismMotionManager.hpp
@@ -85,7 +85,7 @@ public:
      * @retval  true    更新されている
      * @retval  false   更新されていない
      */
-    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds, csmFloat32* opacity = nullptr);
+    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds, csmFloat32* opacity = NULL);
 
     /**
      * @brief モーションの予約

--- a/src/Motion/CubismMotionQueueEntry.cpp
+++ b/src/Motion/CubismMotionQueueEntry.cpp
@@ -143,10 +143,10 @@ void CubismMotionQueueEntry::SetLastCheckEventTime(csmFloat32 checkTime)
 
 csmBool CubismMotionQueueEntry::IsTriggeredFadeOut()
 {
-    return this->_IsTriggeredFadeOut && _endTimeSeconds < 0.0f;
+    return this->_IsTriggeredFadeOut;
 }
 
-csmBool CubismMotionQueueEntry::GetFadeOutSeconds()
+csmFloat32 CubismMotionQueueEntry::GetFadeOutSeconds()
 {
     return this->_fadeOutSeconds;
 }

--- a/src/Motion/CubismMotionQueueEntry.hpp
+++ b/src/Motion/CubismMotionQueueEntry.hpp
@@ -233,7 +233,7 @@ public:
     *
     * @return    フェードアウト開始[秒]
     */
-    csmBool     GetFadeOutSeconds();
+    csmFloat32     GetFadeOutSeconds();
 
 private:
     csmBool         _autoDelete;                    ///< 自動削除

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -93,7 +93,10 @@ csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 
         updated = true;
 
         // ------ 不透明度の値が存在すれば反映する ------
-        opacity = new csmFloat32(motion->GetOpacityValue(userTimeSeconds - motionQueueEntry->GetStartTime()));
+        if (opacity)
+        {
+            *opacity = motion->GetOpacityValue(userTimeSeconds - motionQueueEntry->GetStartTime());
+        }
 
         // ------ ユーザトリガーイベントを検査する ----
         const csmVector<const csmString*>& firedList = motion->GetFiredEvent(

--- a/src/Motion/CubismMotionQueueManager.hpp
+++ b/src/Motion/CubismMotionQueueManager.hpp
@@ -135,7 +135,7 @@ protected:
     * @retval  true    モデルへパラメータ値の反映あり
     * @retval  false   モデルへパラメータ値の反映なし(モーションの変化なし)
     */
-    virtual csmBool     DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32* opacity = nullptr);
+    virtual csmBool     DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32* opacity = NULL);
 
 
     csmFloat32 _userTimeSeconds;        ///< デルタ時間の積算値[秒]

--- a/src/Physics/CubismPhysicsJson.cpp
+++ b/src/Physics/CubismPhysicsJson.cpp
@@ -59,12 +59,12 @@ const csmChar* Acceleration = "Acceleration";
 
 CubismPhysicsJson::CubismPhysicsJson(const csmByte* buffer, csmSizeInt size)
 {
-    _json = Utils::CubismJson::Create(buffer, size);
+    CreateCubismJson(buffer, size);
 }
 
 CubismPhysicsJson::~CubismPhysicsJson()
 {
-    Utils::CubismJson::Delete(_json);
+    DeleteCubismJson();
 }
 
 CubismVector2 CubismPhysicsJson::GetGravity() const

--- a/src/Physics/CubismPhysicsJson.hpp
+++ b/src/Physics/CubismPhysicsJson.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "CubismJsonHolder.hpp"
 #include "Utils/CubismJson.hpp"
 #include "Math/CubismVector2.hpp"
 #include "Id/CubismId.hpp"
@@ -18,7 +19,7 @@ namespace Live2D { namespace Cubism { namespace Framework {
  *
  * physics3.jsonのコンテナ。
  */
-class CubismPhysicsJson
+class CubismPhysicsJson : public CubismJsonHolder
 {
 public:
     /**
@@ -346,10 +347,6 @@ public:
     * @return 物理点の位置
     */
     CubismVector2 GetParticlePosition(csmInt32 physicsSettingIndex, csmInt32 vertexIndex) const;
-
-private:
-    Utils::CubismJson* _json;           ///< physics3.jsonデータ
-
 };
 
 }}}

--- a/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.cpp
@@ -63,14 +63,14 @@ void CubismOffscreenFrame_Cocos2dx::Clear(CubismCommandBuffer_Cocos2dx* commandB
     commandBuffer->Clear(r, g, b, a);
 }
 
-csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::Texture2D* colorBuffer)
+csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::RenderTexture* renderTexture)
 {
     // 一旦削除
     DestroyOffscreenFrame();
 
     do
     {
-        if (colorBuffer == 0)
+        if (!renderTexture)
         {
             // The inherited RenderTexture is nothing.
             // Make a RenderTexture.
@@ -104,7 +104,8 @@ csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBuf
         else
         {
             // Use the inherited RenderTexture.
-            _colorBuffer = colorBuffer;
+            _renderTexture = renderTexture;
+            _colorBuffer = _renderTexture->getSprite()->getTexture();
 
 
             _isInheritedRenderTexture = true;

--- a/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp
@@ -79,7 +79,7 @@ public:
      *  @param  displayBufferHeight    作成するバッファ高さ
      *  @param  colorBuffer            0以外の場合、ピクセル格納領域としてcolorBufferを使用する
      */
-    csmBool CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::Texture2D* colorBuffer = NULL);
+    csmBool CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::RenderTexture* renderTexture = NULL);
 
     /**
      * @brief   CubismOffscreenFrameの削除

--- a/src/Rendering/Metal/CubismCommandBuffer_Metal.hpp
+++ b/src/Rendering/Metal/CubismCommandBuffer_Metal.hpp
@@ -30,10 +30,6 @@ public:
             id <MTLCommandBuffer> GetMTLCommandBuffer();
             void SetMTLCommandBuffer(id <MTLCommandBuffer> commandBuffer);
 
-            /**
-             * @brief   MTLRenderPassDescriptor生成・取得
-             */
-            MTLRenderPassDescriptor* GetRenderPassDescriptor();
             id <MTLRenderPipelineState> GetRenderPipelineState();
             void SetRenderPipelineState(id <MTLRenderPipelineState> renderPipelineState);
 

--- a/src/Rendering/Metal/CubismCommandBuffer_Metal.mm
+++ b/src/Rendering/Metal/CubismCommandBuffer_Metal.mm
@@ -31,14 +31,6 @@ void CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::SetMTLCommandBuf
     _mtlCommandBuffer = commandBuffer;
 }
 
-MTLRenderPassDescriptor* CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::GetRenderPassDescriptor()
-{
-    if (_renderPassDescriptor == NULL) {
-        _renderPassDescriptor = [MTLRenderPassDescriptor new];
-    }
-    return _renderPassDescriptor;
-}
-
 id <MTLRenderPipelineState> CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::GetRenderPipelineState()
 {
     return _pipelineState;

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
@@ -41,6 +41,11 @@ public:
     id <MTLTexture> GetColorBuffer() const;
 
     /**
+     * @brief   カラー設定
+     */
+    void SetClearColor(float r, float g, float b, float a);
+
+    /**
      * @brief   バッファ幅取得
      */
     csmUint32 GetBufferWidth() const;
@@ -49,6 +54,11 @@ public:
      * @brief   バッファ高さ取得
      */
     csmUint32 GetBufferHeight() const;
+
+    /**
+     * @brief   現在有効かどうか
+     */
+    csmBool IsValid() const;
 
     /**
      * @brief   MTLViewport取得
@@ -60,6 +70,11 @@ public:
      */
     MTLRenderPassDescriptor* GetRenderPassDescriptor() const;
 
+    /**
+     * @brief   MTLPixelFormat指定
+     */
+    void SetMTLPixelFormat(MTLPixelFormat pixelFormat);
+
 private:
     id <MTLTexture>  _colorBuffer; ///レンダーテクスチャ
     csmBool _isInheritedRenderTexture;
@@ -67,6 +82,11 @@ private:
     csmUint32   _bufferWidth;           ///< Create時に指定された幅
     csmUint32   _bufferHeight;          ///< Create時に指定された高さ
     MTLViewport _viewPort;
+    MTLPixelFormat _pixelFormat;
+    float _clearColorR;
+    float _clearColorG;
+    float _clearColorB;
+    float _clearColorA;
 };
 
 }}}}

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
@@ -12,11 +12,16 @@
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
 CubismOffscreenFrame_Metal::CubismOffscreenFrame_Metal()
-    :
-     _colorBuffer(NULL)
+    : _colorBuffer(NULL)
+    , _renderPassDescriptor(NULL)
     , _isInheritedRenderTexture(false)
     , _bufferWidth(0)
     , _bufferHeight(0)
+    , _pixelFormat(MTLPixelFormatRGBA8Unorm)
+    , _clearColorR(1.0)
+    , _clearColorG(1.0)
+    , _clearColorB(1.0)
+    , _clearColorA(1.0)
 {
 }
 
@@ -34,7 +39,7 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
             _renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
             _renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
             _renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
-            _renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(1.0, 1.0, 1.0, 1.0);
+            _renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(_clearColorR, _clearColorG, _clearColorB, _clearColorA);
 
             _renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
             _renderPassDescriptor.depthAttachment.storeAction = MTLStoreActionDontCare;
@@ -49,7 +54,7 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
             texDescriptor.textureType = MTLTextureType2D;
             texDescriptor.width = displayBufferWidth;
             texDescriptor.height = displayBufferHeight;
-            texDescriptor.pixelFormat = MTLPixelFormatRGBA8Unorm;
+            texDescriptor.pixelFormat = _pixelFormat;
             texDescriptor.usage = MTLTextureUsageRenderTarget |
                                   MTLTextureUsageShaderRead;
             CubismRenderingInstanceSingleton_Metal *single = [CubismRenderingInstanceSingleton_Metal sharedManager];
@@ -89,7 +94,7 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
 
 void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
 {
-    if((_renderPassDescriptor != NULL) && !_isInheritedRenderTexture)
+    if(!_isInheritedRenderTexture)
     {
         _colorBuffer = NULL;
     }
@@ -99,6 +104,15 @@ void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
 id <MTLTexture> CubismOffscreenFrame_Metal::GetColorBuffer() const
 {
     return _colorBuffer;
+}
+
+
+void CubismOffscreenFrame_Metal::SetClearColor(float r, float g, float b, float a)
+{
+    _clearColorR = r;
+    _clearColorG = g;
+    _clearColorB = b;
+    _clearColorA = a;
 }
 
 csmUint32 CubismOffscreenFrame_Metal::GetBufferWidth() const
@@ -111,6 +125,11 @@ csmUint32 CubismOffscreenFrame_Metal::GetBufferHeight() const
     return _bufferHeight;
 }
 
+csmBool CubismOffscreenFrame_Metal::IsValid() const
+{
+    return _renderPassDescriptor != NULL;
+}
+
 const MTLViewport* CubismOffscreenFrame_Metal::GetViewport() const
 {
     return &_viewPort;
@@ -119,6 +138,11 @@ const MTLViewport* CubismOffscreenFrame_Metal::GetViewport() const
 MTLRenderPassDescriptor* CubismOffscreenFrame_Metal::GetRenderPassDescriptor() const
 {
     return _renderPassDescriptor;
+}
+
+void CubismOffscreenFrame_Metal::SetMTLPixelFormat(MTLPixelFormat pixelFormat)
+{
+    _pixelFormat = pixelFormat;
 }
 
 }}}}

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -264,7 +264,7 @@ private:
     /**
      * @brief   シェーダプログラムを初期化する
      */
-    void GenerateShaders();
+    void GenerateShaders(CubismRenderer_Metal* renderer);
 
     /**
      * @brief   シェーダプログラムをロードしてアドレス返す。
@@ -277,7 +277,7 @@ private:
     ShaderProgram* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
     id<MTLRenderPipelineState> MakeRenderPipelineState(id<MTLDevice> device, ShaderProgram* shaderProgram, int blendMode);
     id<MTLDepthStencilState> MakeDepthStencilState(id<MTLDevice> device);
-    id<MTLSamplerState> MakeSamplerState(id<MTLDevice> device);
+    id<MTLSamplerState> MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer);
 
     id<MTLLibrary> _shaderLib;
 
@@ -326,7 +326,7 @@ class CubismRenderer_Metal : public CubismRenderer
 
 public:
 
-    static void StartFrame(id<MTLDevice> device, id<MTLCommandBuffer> commandBuffer, id<MTLTexture> renderTarget, id<MTLTexture> depthTarget);
+    static void StartFrame(id<MTLDevice> device, id<MTLCommandBuffer> commandBuffer, MTLRenderPassDescriptor* renderPassDescriptor);
 
     /**
      * @brief    レンダラの初期化処理を実行する<br>
@@ -429,8 +429,7 @@ private:
 
     static id<MTLCommandBuffer> s_commandBuffer;
     static id<MTLDevice> s_device;
-    static id<MTLTexture> s_renderTarget;
-    static id<MTLTexture> s_depthTarget;
+    static MTLRenderPassDescriptor* s_renderPassDescriptor;
 
     /**
      * @brief   レンダラが保持する静的なリソースを解放する<br>

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -15,6 +15,12 @@
 #include <Windows.h>
 #endif
 
+#define CSM_FRAGMENT_SHADER_FP_PRECISION_HIGH "highp"
+#define CSM_FRAGMENT_SHADER_FP_PRECISION_MID "mediump"
+#define CSM_FRAGMENT_SHADER_FP_PRECISION_LOW "lowp"
+
+#define CSM_FRAGMENT_SHADER_FP_PRECISION CSM_FRAGMENT_SHADER_FP_PRECISION_HIGH
+
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
@@ -738,7 +744,7 @@ static const csmChar* VertShaderSrcSetupMask =
 static const csmChar* FragShaderSrcSetupMask =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -761,7 +767,7 @@ static const csmChar* FragShaderSrcSetupMask =
 static const csmChar* FragShaderSrcSetupMaskTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;"
         "varying vec4 v_myPos;"
         "uniform sampler2D s_texture0;"
@@ -824,7 +830,7 @@ static const csmChar* VertShaderSrcMasked =
 static const csmChar* FragShaderSrc =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -840,7 +846,7 @@ static const csmChar* FragShaderSrc =
 static const csmChar* FragShaderSrcTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;" //v2f.texcoord
         "uniform sampler2D s_texture0;" //_MainTex
         "uniform vec4 u_baseColor;" //v2f.color
@@ -855,7 +861,7 @@ static const csmChar* FragShaderSrcTegra =
 static const csmChar* FragShaderSrcPremultipliedAlpha =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -870,7 +876,7 @@ static const csmChar* FragShaderSrcPremultipliedAlpha =
 static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;" //v2f.texcoord
         "uniform sampler2D s_texture0;" //_MainTex
         "uniform vec4 u_baseColor;" //v2f.color
@@ -884,7 +890,7 @@ static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
 static const csmChar* FragShaderSrcMask =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -907,7 +913,7 @@ static const csmChar* FragShaderSrcMask =
 static const csmChar* FragShaderSrcMaskTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;"
         "varying vec4 v_clipPos;"
         "uniform sampler2D s_texture0;"
@@ -929,7 +935,7 @@ static const csmChar* FragShaderSrcMaskTegra =
 static const csmChar* FragShaderSrcMaskInverted =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -952,7 +958,7 @@ static const csmChar* FragShaderSrcMaskInverted =
 static const csmChar* FragShaderSrcMaskInvertedTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;"
         "varying vec4 v_clipPos;"
         "uniform sampler2D s_texture0;"
@@ -974,7 +980,7 @@ static const csmChar* FragShaderSrcMaskInvertedTegra =
 static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -996,7 +1002,7 @@ static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
 static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;"
         "varying vec4 v_clipPos;"
         "uniform sampler2D s_texture0;"
@@ -1017,7 +1023,7 @@ static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
 static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
 #if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
         "#version 100\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
 #else
         "#version 120\n"
 #endif
@@ -1039,7 +1045,7 @@ static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
 static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
         "#version 100\n"
         "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision mediump float;"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
         "varying vec2 v_texCoord;"
         "varying vec4 v_clipPos;"
         "uniform sampler2D s_texture0;"


### PR DESCRIPTION
### Added

* Add the rendering options on Metal:
  * `USE_RENDER_TARGET`
  * `USE_MODEL_RENDER_TARGET`

* Add anisotropic filtering to Metal.
* Add a macro to toggle the precision of floating point numbers in OpenGL fragment shaders.
* Add a function to check `.cdi3.json` exists from `.model3.json`.
* Add `CubismJsonHolder`, a common class used to instantiate and check the validity of `CubismJson`.
  * Each Json parser will now warn if an class of `CubismJson` is invalid.

### Changed

* Change each Json parser inherits a common class `CubismJsonHolder`.

### Fixed

* Fix renderer for Cocos2d-x v4.0.
   * `RenderTexture` was empty when using `USE_MODEL_RENDER_TARGET`.
* Fix motions with different fade times from switching properly.
* Fix a bug that motions currently played do not fade out when play a motion.