### PR TITLE
Cubism 4 SDK for Native R5 beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.5-beta.1] - 2022-05-19
+
+### Added
+
+* Add processing related to multiply colors and screen colors added in Cubism 4.2.
+* Add a function to reset the physics states.
+
+### Fixed
+
+* Fix GetTextureDirectory() to return the directory name of the 0th texture path.
+
+
 ## [4-r.4] - 2021-12-09
 
 ### Added
@@ -141,6 +153,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.5-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.4...4-r.5-beta.1
+[4-r.4]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.4-beta.1...4-r.4
 [4-r.4-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.3...4-r.4-beta.1
 [4-r.3]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.3-beta.1...4-r.3
 [4-r.3-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.2...4-r.3-beta.1

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ JSON パーサーやログ出力などのユーティリティ機能を提供し
 ユーザー同士でCubism SDKの活用方法の提案や質問をしたい場合は、是非コミュニティをご活用ください。
 
 - [Live2D 公式コミュニティ](https://creatorsforum.live2d.com/)
-- [Live2D community(English)](http://community.live2d.com/)
+- [Live2D community(English)](https://community.live2d.com/)

--- a/src/CubismModelSettingJson.cpp
+++ b/src/CubismModelSettingJson.cpp
@@ -223,7 +223,43 @@ csmInt32 CubismModelSettingJson::GetTextureCount()
 
 const csmChar* CubismModelSettingJson::GetTextureDirectory()
 {
-    return (*_jsonValue[FrequentNode_Textures]).GetRawString();
+    if (!IsExistTextureFiles())
+    {
+        return "";
+    }
+
+    csmVector<csmString> splitPathBuffer;
+    csmVector<csmChar> charBuffer;
+    const csmChar* rawString = (*_jsonValue[FrequentNode_Textures])[0].GetRawString();
+    csmInt32 rawStringSize = (*_jsonValue[FrequentNode_Textures])[0].GetString().GetLength();
+    for (csmInt32 i = 0; i < rawStringSize; i++)
+    {
+        // /を含んでいる場合splitする
+        if (rawString[i] == '/')
+        {
+            csmString str = csmString(charBuffer.GetPtr());
+            splitPathBuffer.PushBack(str);
+            charBuffer.Clear();
+        }
+        // 一文字ずつVector配列に格納する
+        else
+        {
+            charBuffer.PushBack(static_cast<csmChar>(rawString[i] & 0xFF));
+        }
+    }
+
+    csmInt32 arrayLength = splitPathBuffer.GetSize();
+    csmString textureDirectoryStr = csmString();
+    for(csmInt32 i = 0; i < arrayLength; i++)
+    {
+        textureDirectoryStr = textureDirectoryStr + splitPathBuffer[i];
+        if(i < arrayLength - 1)
+        {
+            textureDirectoryStr = textureDirectoryStr + "/";
+        }
+    }
+
+    return textureDirectoryStr.GetRawString();
 }
 
 const csmChar* CubismModelSettingJson::GetTextureFileName(csmInt32 index)

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -26,6 +26,36 @@ class CubismModel
 {
     friend class CubismMoc;
 public:
+
+    /**
+    * @brief テクスチャの色をRGBAで扱うための構造体
+    */
+    struct DrawableColorData
+    {
+        /**
+         * @brief   コンストラクタ
+         */
+        DrawableColorData()
+            : IsOverwritten(false)
+            , Color() {};
+
+        /**
+         * @brief   コンストラクタ
+         */
+        DrawableColorData(csmBool isOverwritten, Rendering::CubismRenderer::CubismTextureColor color)
+            : IsOverwritten(isOverwritten)
+            , Color(color) {};
+
+        /**
+         * @brief   デストラクタ
+         */
+        virtual ~DrawableColorData() {};
+
+        csmBool IsOverwritten;
+        Rendering::CubismRenderer::CubismTextureColor Color;
+
+    };  // DrawableColorData
+
     /**
      * @brief モデルのパラメータの更新
      *
@@ -391,6 +421,26 @@ public:
     csmFloat32                  GetDrawableOpacity(csmInt32 drawableIndex) const;
 
     /**
+     * @brief Drawableの乗算色の取得
+     *
+     * Drawableの乗算色を取得する。
+     *
+     * @param[in]   drawableIndex   Drawableのインデックス
+     * @return  Drawableの乗算色
+     */
+    Core::csmVector4 GetDrawableMultiplyColor(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief Drawableのスクリーン色の取得
+     *
+     * Drawableのスクリーン色を取得する。
+     *
+     * @param[in]   drawableIndex   Drawableのインデックス
+     * @return  Drawableのスクリーン色
+     */
+    Core::csmVector4 GetDrawableScreenColor(csmInt32 drawableIndex) const;
+
+    /**
      * @brief Drawableのカリング情報の取得
      *
      * Drawableのカリング情報を取得する。
@@ -489,6 +539,17 @@ public:
     csmBool                  GetDrawableDynamicFlagVertexPositionsDidChange(csmInt32 drawableIndex) const;
 
     /**
+    * @brief Drawableの乗算色・スクリーン色の変化情報の取得
+    *
+    * 直近のCubismModel::Update関数でDrawableの乗算色・スクリーン色が変化したかを取得する。
+    *
+    * @param[in]   drawableIndex   Drawableのインデックス
+    * @retval  true    Drawableの乗算色・スクリーン色が直近のCubismModel::Update関数で変化した
+    * @retval  false   Drawableの乗算色・スクリーン色が直近のCubismModel::Update関数で変化していない
+    */
+    csmBool                  GetDrawableDynamicFlagBlendColorDidChange(csmInt32 drawableIndex) const;
+
+    /**
      * @brief Drawableのクリッピングマスクリストの取得
      *
      * Drawableのクリッピングマスクリストを取得する。
@@ -529,6 +590,92 @@ public:
      * パラメータを保存する。
      */
     void    SaveParameters();
+
+    /**
+     * @brief   リストから乗算色を取得する
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetMultiplyColor(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief   リストからスクリーン色を取得する
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetScreenColor(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief   乗算色を設定する
+     */
+    void SetMultiplyColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * @brief   乗算色を設定する
+     */
+    void SetMultiplyColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * @brief   スクリーン色を設定する
+     */
+    void SetScreenColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * @brief   スクリーン色を設定する
+     */
+    void SetScreenColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * @brief SDKからモデル全体の乗算色を上書きするか。
+     *
+     * @retval  true    ->  SDK上の色情報を使用
+     * @retval  false   ->  モデルの色情報を使用
+     */
+    csmBool GetOverwriteFlagForModelMultiplyColors() const;
+
+    /**
+     * @brief SDKからモデル全体のスクリーン色を上書きするか。
+     *
+     * @retval  true    ->  SDK上の色情報を使用
+     * @retval  false   ->  モデルの色情報を使用
+     */
+    csmBool GetOverwriteFlagForModelScreenColors() const;
+
+    /**
+     * @brief SDKからモデル全体の乗算色を上書きするかをセットする
+     *        SDK上の色情報を使うならtrue、モデルの色情報を使うならfalse
+     */
+    void SetOverwriteFlagForModelMultiplyColors(csmBool value);
+
+    /**
+     * @brief SDKからモデル全体のスクリーン色を上書きするかをセットする
+     *        SDK上の色情報を使うならtrue、モデルの色情報を使うならfalse
+     */
+    void SetOverwriteFlagForModelScreenColors(csmBool value);
+
+    /**
+     * @brief SDKからdrawableの乗算色を上書きするか。
+     *
+     * @retval  true    ->  SDK上の色情報を使用
+     * @retval  false   ->  モデルの色情報を使用
+     */
+    csmBool GetOverwriteFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief SDKからdrawableのスクリーン色を上書きするか。
+     *
+     * @retval  true    ->  SDK上の色情報を使用
+     * @retval  false   ->  モデルの色情報を使用
+     */
+    csmBool GetOverwriteFlagForDrawableScreenColors(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief SDKからdrawableの乗算色を上書きするかをセットする
+     *        SDK上の色情報を使うならtrue、モデルの色情報を使うならfalse
+     */
+    void SetOverwriteFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value);
+
+    /**
+     * @brief SDKからdrawableのスクリーン色を上書きするかをセットする
+     *        SDK上の色情報を使うならtrue、モデルの色情報を使うならfalse
+     */
+    void SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
 
     Core::csmModel*     GetModel() const;
 
@@ -579,6 +726,10 @@ private:
     csmVector<CubismIdHandle> _parameterIds;
     csmVector<CubismIdHandle> _partIds;
     csmVector<CubismIdHandle> _drawableIds;
+    csmVector<DrawableColorData> _userScreenColors; ///< 乗算色の配列
+    csmVector<DrawableColorData> _userMultiplyColors; ///< スクリーン色の配列
+    csmBool _isOverwrittenModelMultiplyColors; ///< 乗算色を全て上書きするか？
+    csmBool _isOverwrittenModelScreenColors; ///< スクリーン色を全て上書きするか？
 };
 
 }}}

--- a/src/Physics/CubismPhysics.cpp
+++ b/src/Physics/CubismPhysics.cpp
@@ -446,6 +446,23 @@ void CubismPhysics::Initialize()
     }
 }
 
+/// Reset the physics states.
+void CubismPhysics::Reset()
+{
+    // set default options.
+    _options.Gravity.Y = -1.0f;
+    _options.Gravity.X = 0.0f;
+    _options.Wind.X = 0.0f;
+    _options.Wind.Y = 0.0f;
+
+    _physicsRig->Gravity.X = 0.0f;
+    _physicsRig->Gravity.Y = 0.0f;
+    _physicsRig->Wind.X = 0.0f;
+    _physicsRig->Wind.Y = 0.0f;
+
+    Initialize();
+}
+
 CubismPhysics* CubismPhysics::Create(const csmByte* buffer, csmSizeInt size)
 {
     CubismPhysics* ret = CSM_NEW CubismPhysics();

--- a/src/Physics/CubismPhysics.hpp
+++ b/src/Physics/CubismPhysics.hpp
@@ -54,6 +54,13 @@ public:
     static void Delete(CubismPhysics* physics);
 
     /**
+     * @brief パラメータのリセット
+     *
+     * パラメータをリセットする。
+     */
+     void Reset();
+
+    /**
      * @brief 物理演算の評価
      *
      * 物理演算を評価する。

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
@@ -247,6 +247,8 @@ private:
         cocos2d::backend::UniformLocation SamplerTexture0Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture0)
         cocos2d::backend::UniformLocation SamplerTexture1Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture1)
         cocos2d::backend::UniformLocation UniformBaseColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(BaseColor)
+        cocos2d::backend::UniformLocation UniformMultiplyColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(MultiplyColor)
+        cocos2d::backend::UniformLocation UniformScreenColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(ScreenColor)
         cocos2d::backend::UniformLocation UnifromChannelFlagLocation;   ///< シェーダプログラムに渡す変数のアドレス(ChannelFlag)
     };
 
@@ -280,6 +282,8 @@ private:
                             , csmFloat32* uvArray, csmFloat32 opacity
                             , CubismRenderer::CubismBlendMode colorBlendMode
                             , CubismRenderer::CubismTextureColor baseColor
+                            , CubismRenderer::CubismTextureColor multiplyColor
+                            , CubismRenderer::CubismTextureColor screenColor
                             , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
                             , csmBool invertedMask);
 
@@ -464,6 +468,7 @@ protected:
 
     void DrawMeshCocos2d(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
                   , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+                  , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
                   , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
 
     CubismCommandBuffer_Cocos2dx::DrawCommandBuffer* GetDrawCommandBufferData(csmInt32 drawableIndex);

--- a/src/Rendering/CubismRenderer.hpp
+++ b/src/Rendering/CubismRenderer.hpp
@@ -53,6 +53,15 @@ public:
             , A(1.0f) {};
 
         /**
+         * @brief   コンストラクタ
+         */
+        CubismTextureColor(csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
+            : R(r)
+            , G(g)
+            , B(b)
+            , A(a) {};
+
+        /**
          * @brief   デストラクタ
          */
         virtual ~CubismTextureColor() {};

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
@@ -333,6 +333,8 @@ public:
      * @param[in]  device          -> 使用デバイス
      * @param[in]  textureNo        -> 使用テクスチャ番号。基本的にCubismModel::GetDrawableTextureIndicesで返されたもの
      * @param[in]  modelColorRGBA   -> 描画カラー
+     * @param[in]  multiplyColor   -> 乗算色
+     * @param[in]  screenColor   -> スクリーン色
      * @param[in]  colorBlendMode   -> ブレンドモード
      * @param[in]  invertedMask      -> マスク使用時のマスクの反転使用
      *
@@ -340,7 +342,7 @@ public:
     void ExecuteDraw(ID3D11Device* device, ID3D11DeviceContext* renderContext,
         ID3D11Buffer* vertexBuffer, ID3D11Buffer* indexBuffer, ID3D11Buffer* constantBuffer,
         const csmInt32 indexCount,
-        const csmInt32 textureNo, CubismTextureColor& modelColorRGBA, CubismBlendMode colorBlendMode, csmBool invertedMask);
+        const csmInt32 textureNo, CubismTextureColor& modelColorRGBA, const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor, CubismBlendMode colorBlendMode, csmBool invertedMask);
 
 protected:
     /**
@@ -383,6 +385,7 @@ protected:
     void DrawMeshDX11(csmInt32 drawableIndex
         , csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
         , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+        , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
         , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
 
 

--- a/src/Rendering/D3D11/CubismShader_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismShader_D3D11.cpp
@@ -18,6 +18,8 @@ static const csmChar* CubismShaderEffectSrc =
         "float4x4 projectMatrix;"\
         "float4x4 clipMatrix;"\
         "float4 baseColor;"\
+        "float4 multiplyColor;"\
+        "float4 screenColor;"\
         "float4 channelFlag;"\
     "}"\
     "Texture2D mainTexture : register(t0);"\
@@ -74,20 +76,29 @@ static const csmChar* CubismShaderEffectSrc =
 "/* Pixel Shader */"\
     "/* normal */"\
     "float4 PixelNormal(VS_OUT In) : SV_Target{"\
-        "float4 color = mainTexture.Sample(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "color.xyz *= color.w;"\
         "return color;"\
     "}"\
     \
     "/* normal premult alpha */"\
     "float4 PixelNormalPremult(VS_OUT In) : SV_Target{"\
-        "float4 color = mainTexture.Sample(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "return color;"\
     "}"\
     \
     "/* masked */\n"\
     "float4 PixelMasked(VS_OUT In) : SV_Target{\n"\
-        "float4 color = mainTexture.Sample(mainSampler, In.uv) * baseColor;\n"\
+        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "color.xyz *= color.w;\n"\
         "float4 clipMask = (1.0 - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
@@ -96,7 +107,10 @@ static const csmChar* CubismShaderEffectSrc =
     "}"\
     "/* masked inverted*/\n"\
     "float4 PixelMaskedInverted(VS_OUT In) : SV_Target{\n"\
-        "float4 color = mainTexture.Sample(mainSampler, In.uv) * baseColor;\n"\
+        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "color.xyz *= color.w;\n"\
         "float4 clipMask = (1.0 - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
@@ -105,7 +119,10 @@ static const csmChar* CubismShaderEffectSrc =
     "}"\
     "/* masked premult alpha */\n"\
     "float4 PixelMaskedPremult(VS_OUT In) : SV_Target{\n"\
-        "float4 color = mainTexture.Sample(mainSampler, In.uv) * baseColor;\n"\
+        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;\n"\
         "float4 clipMask = (1.0 - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
         "color = color * maskVal;\n"\
@@ -113,7 +130,10 @@ static const csmChar* CubismShaderEffectSrc =
     "}"\
     "/* masked inverted premult alpha */\n"\
     "float4 PixelMaskedInvertedPremult(VS_OUT In) : SV_Target{\n"\
-        "float4 color = mainTexture.Sample(mainSampler, In.uv) * baseColor;\n"\
+        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;\n"\
         "float4 clipMask = (1.0 - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
         "color = color * (1.0 - maskVal);\n"\

--- a/src/Rendering/D3D11/CubismType_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismType_D3D11.hpp
@@ -28,6 +28,8 @@ struct CubismConstantBufferD3D11
     DirectX::XMFLOAT4X4 projectMatrix;
     DirectX::XMFLOAT4X4 clipMatrix;
     DirectX::XMFLOAT4 baseColor;
+    DirectX::XMFLOAT4 multiplyColor;
+    DirectX::XMFLOAT4 screenColor;
     DirectX::XMFLOAT4 channelFlag;
 };
 

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
@@ -335,13 +335,15 @@ public:
      * @param[in]  device          -> 使用デバイス
      * @param[in]  textureNo        -> 使用テクスチャ番号。基本的にCubismModel::GetDrawableTextureIndicesで返されたもの
      * @param[in]  modelColorRGBA   -> 描画カラー
+     * @param[in]  multiplyColor   -> 乗算色
+     * @param[in]  screenColor   -> スクリーン色
      * @param[in]  colorBlendMode   -> ブレンドモード
      * @param[in]  invertedMask      -> マスク使用時のマスクの反転設定
      *
      */
     void ExecuteDraw(LPDIRECT3DDEVICE9 device, CubismVertexD3D9* vertexArray, csmUint16* indexArray,
         const csmInt32 vertexCount, const csmInt32 triangleCount,
-        const csmInt32 textureNo, CubismTextureColor& modelColorRGBA, CubismBlendMode colorBlendMode, csmBool invertedMask);
+        const csmInt32 textureNo, CubismTextureColor& modelColorRGBA, const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor, CubismBlendMode colorBlendMode, csmBool invertedMask);
 
 protected:
     /**
@@ -379,8 +381,8 @@ protected:
     void DrawMeshDX9(csmInt32 drawableIndex
         , csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
         , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+        , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
         , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
-
 
 private:
 

--- a/src/Rendering/D3D9/CubismShader_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismShader_D3D9.cpp
@@ -16,6 +16,8 @@ static const csmChar* CubismShaderEffectSrc =
     "float4x4 projectMatrix;"\
     "float4x4 clipMatrix;"\
     "float4 baseColor;"\
+    "float4 multiplyColor;"\
+    "float4 screenColor;"\
     "float4 channelFlag;"\
     "texture mainTexture;"\
     "texture maskTexture;"\
@@ -77,20 +79,29 @@ static const csmChar* CubismShaderEffectSrc =
 "/* Pixel Shader */"\
     "/* normal */"\
     "float4 PixelNormal(VS_OUT In) : COLOR0{"\
-        "float4 color = tex2D(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = tex2D(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "color.xyz *= color.w;"\
         "return color;"\
     "}"\
     \
     "/* normal premult alpha */"\
     "float4 PixelNormalPremult(VS_OUT In) : COLOR0{"\
-        "float4 color = tex2D(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = tex2D(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "return color;"\
     "}"\
     \
     "/* masked */"\
     "float4 PixelMasked(VS_OUT In) : COLOR0{"\
-        "float4 color = tex2D(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = tex2D(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "color.xyz *= color.w;"\
         "float4 clipMask = (1.0 - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
@@ -99,7 +110,10 @@ static const csmChar* CubismShaderEffectSrc =
     "}"\
     "/* masked inverted */"
     "float4 PixelMaskedInverted(VS_OUT In) : COLOR0{"\
-        "float4 color = tex2D(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = tex2D(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "color.xyz *= color.w;"\
         "float4 clipMask = (1.0 - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
@@ -108,7 +122,10 @@ static const csmChar* CubismShaderEffectSrc =
     "}"\
     "/* masked premult alpha */"\
     "float4 PixelMaskedPremult(VS_OUT In) : COLOR0{"\
-        "float4 color = tex2D(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = tex2D(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "float4 clipMask = (1.0 - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
         "color = color * maskVal;"\
@@ -116,7 +133,10 @@ static const csmChar* CubismShaderEffectSrc =
     "}"\
     "/* masked inverted premult alpha */"\
     "float4 PixelMaskedInvertedPremult(VS_OUT In) : COLOR0{"\
-        "float4 color = tex2D(mainSampler, In.uv) * baseColor;"\
+        "float4 texColor = tex2D(mainSampler, In.uv);"\
+        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
+        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
+        "float4 color = texColor * baseColor;"\
         "float4 clipMask = (1.0 - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
         "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
         "color = color * (1.0 - maskVal);"\

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
@@ -94,18 +94,16 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
 
 void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
 {
-    if(!_isInheritedRenderTexture)
+    if (!_isInheritedRenderTexture)
     {
         _colorBuffer = NULL;
     }
-
 }
 
 id <MTLTexture> CubismOffscreenFrame_Metal::GetColorBuffer() const
 {
     return _colorBuffer;
 }
-
 
 void CubismOffscreenFrame_Metal::SetClearColor(float r, float g, float b, float a)
 {

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -257,6 +257,8 @@ private:
                             , csmFloat32 opacity
                             , CubismRenderer::CubismBlendMode colorBlendMode
                             , CubismRenderer::CubismTextureColor baseColor
+                            , CubismRenderer::CubismTextureColor multiplyColor
+                            , CubismRenderer::CubismTextureColor screenColor
                             , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
                             , csmBool invertedMask
                             , id <MTLRenderCommandEncoder> renderEncoder);
@@ -415,6 +417,7 @@ protected:
 
     void DrawMeshMetal(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
                   , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+                  , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
                   , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask
                   , csmInt32 drawableIndex
                   , id <MTLRenderCommandEncoder> renderEncoder);

--- a/src/Rendering/Metal/MetalShaderTypes.h
+++ b/src/Rendering/Metal/MetalShaderTypes.h
@@ -23,6 +23,8 @@ typedef struct
 {
     simd::float4x4 matrix;
     vector_float4 baseColor;
+    vector_float4 multiplyColor;
+    vector_float4 screenColor;
 
 } CubismNormalShaderUniforms;
 
@@ -46,6 +48,8 @@ typedef struct
 {
     vector_float4 channelFlag;
     vector_float4 baseColor;
+    vector_float4 multiplyColor;
+    vector_float4 screenColor;
 
 } CubismFragMaskedShaderUniforms;
 

--- a/src/Rendering/Metal/MetalShaders.metal
+++ b/src/Rendering/Metal/MetalShaders.metal
@@ -113,7 +113,10 @@ FragShaderSrc(NormalRasterizerData in [[stage_in]],
               constant CubismNormalShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
               sampler smp [[sampler(0)]])
 {
-    float4 color = texture.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture.sample(smp, in.texCoord);
+    texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
+    float4 color = texColor * uniforms.baseColor;
     float4 gl_FragColor = float4(color.rgb * color.a,  color.a);
 
     return gl_FragColor;
@@ -126,7 +129,10 @@ FragShaderSrcPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
                         constant CubismNormalShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
                         sampler smp [[sampler(0)]])
 {
-    float4 gl_FragColor = texture.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture.sample(smp, in.texCoord);
+    texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
+    float4 gl_FragColor = texColor * uniforms.baseColor;
 
     return gl_FragColor;
 }
@@ -139,7 +145,10 @@ FragShaderSrcMask(MaskedRasterizerData in [[stage_in]],
                     constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
                     sampler smp [[sampler(0)]])
 {
-    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture0.sample(smp, in.texCoord);
+    texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
+    float4 col_formask = texColor * uniforms.baseColor;
     col_formask.rgb = col_formask.rgb  * col_formask.a ;
     float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
@@ -156,7 +165,10 @@ FragShaderSrcMaskInverted(MaskedRasterizerData in [[stage_in]],
                     constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
                     sampler smp [[sampler(0)]])
 {
-    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture0.sample(smp, in.texCoord);
+    texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
+    float4 col_formask = texColor * uniforms.baseColor;
     col_formask.rgb = col_formask.rgb  * col_formask.a ;
     float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
@@ -173,7 +185,10 @@ FragShaderSrcMaskPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
                                     constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
                                     sampler smp [[sampler(0)]])
 {
-    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture0.sample(smp, in.texCoord);
+    texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
+    float4 col_formask = texColor * uniforms.baseColor;
     float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     col_formask = col_formask * maskVal;
@@ -189,7 +204,10 @@ FragShaderSrcMaskInvertedPremultipliedAlpha(MaskedRasterizerData in [[stage_in]]
                     constant CubismFragMaskedShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
                     sampler smp [[sampler(0)]])
 {
-    float4 col_formask = texture0.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture0.sample(smp, in.texCoord);
+    texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
+    float4 col_formask = texColor * uniforms.baseColor;
     float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     col_formask = col_formask * (1.0 - maskVal);

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp
@@ -244,6 +244,8 @@ private:
         GLint SamplerTexture0Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture0)
         GLint SamplerTexture1Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture1)
         GLint UniformBaseColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(BaseColor)
+        GLint UniformMultiplyColorLocation; ///< シェーダプログラムに渡す変数のアドレス(MultiplyColor)
+        GLint UniformScreenColorLocation;   ///< シェーダプログラムに渡す変数のアドレス(ScreenColor)
         GLint UnifromChannelFlagLocation;   ///< シェーダプログラムに渡す変数のアドレス(ChannelFlag)
     };
 
@@ -277,6 +279,8 @@ private:
                             , csmFloat32* uvArray, csmFloat32 opacity
                             , CubismRenderer::CubismBlendMode colorBlendMode
                             , CubismRenderer::CubismTextureColor baseColor
+                            , CubismRenderer::CubismTextureColor multiplyColor
+                            , CubismRenderer::CubismTextureColor screenColor
                             , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
                             , csmBool invertedMask);
 
@@ -476,6 +480,7 @@ public:
      *
      */
     const CubismOffscreenFrame_OpenGLES2* GetMaskBuffer() const;
+
 protected:
     /**
      * @brief   コンストラクタ
@@ -491,7 +496,11 @@ protected:
      * @brief   モデルを描画する実際の処理
      *
      */
-    void DoDrawModel();
+    virtual void DoDrawModel() override;
+
+    void DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
+            , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+            , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask) override;
 
     /**
      * @brief   [オーバーライド]<br>
@@ -504,13 +513,16 @@ protected:
      * @param[in]   indexArray      ->  ポリゴンメッシュのインデックス配列
      * @param[in]   vertexArray     ->  ポリゴンメッシュの頂点配列
      * @param[in]   uvArray         ->  uv配列
+     * @param[in]   multiplyColor    ->  乗算色
+     * @param[in]   screenColor         ->  スクリーン色
      * @param[in]   opacity         ->  不透明度
      * @param[in]   colorBlendMode  ->  カラー合成タイプ
      * @param[in]   invertedMask     ->  マスク使用時のマスクの反転使用
      *
      */
-    void DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
+    void DrawMeshOpenGL(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
                   , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
+                  , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
                   , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
 
 


### PR DESCRIPTION
### Added

* Add processing related to multiply colors and screen colors added in Cubism 4.2.
* Add a function to reset the physics states.

### Fixed

* Fix GetTextureDirectory() to return the directory name of the 0th texture path.