### PR TITLE
Cubism 4 SDK for Native R5 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.5-beta.3] - 2022-06-16
+
+### Fixed
+
+* `GetDrawableTextureIndices` function in `CubismModel` has been renamed to `GetDrawableTextureIndex` because the name was not correct.
+  * `GetDrawableTextureIndices` function is marked as deprecated.
+* Fix physics system behaviour when exists Physics Fps Setting in .physics3.json.
+* Fix force close problem when invalid `physics3.json` is read.
+* Fixed memory leak in Cocos2d-x.
+
 
 ## [4-r.5-beta.2] - 2022-06-02
 
@@ -163,6 +173,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.5-beta.3]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.2...4-r.5-beta.3
 [4-r.5-beta.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.1...4-r.5-beta.2
 [4-r.5-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.4...4-r.5-beta.1
 [4-r.4]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.4-beta.1...4-r.4

--- a/src/Model/CubismModel.cpp
+++ b/src/Model/CubismModel.cpp
@@ -446,6 +446,11 @@ csmInt32 CubismModel::GetDrawableCount() const
 
 csmInt32 CubismModel::GetDrawableTextureIndices(csmInt32 drawableIndex) const
 {
+    return GetDrawableTextureIndex(drawableIndex);
+}
+
+csmInt32 CubismModel::GetDrawableTextureIndex(csmInt32 drawableIndex) const
+{
     const csmInt32* textureIndices = Core::csmGetDrawableTextureIndices(_model);
     return textureIndices[drawableIndex];
 }

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -341,6 +341,9 @@ public:
     const csmInt32*     GetDrawableRenderOrders() const;
 
     /**
+     * @deprecated
+     * 関数名が誤っていたため、代替となる getDrawableTextureIndex を追加し、この関数は非推奨となりました。
+     *
      * @brief Drawableのテクスチャインデックスリストの取得
      *
      * Drawableのテクスチャインデックスリストを取得する。
@@ -349,6 +352,16 @@ public:
      * @return  Drawableのテクスチャインデックスリスト
      */
     csmInt32            GetDrawableTextureIndices(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief Drawableのテクスチャインデックスリストの取得
+     *
+     * Drawableのテクスチャインデックスを取得する。
+     *
+     * @param[in]   drawableIndex   Drawableのインデックス
+     * @return  Drawableのテクスチャインデックス
+     */
+    csmInt32            GetDrawableTextureIndex(csmInt32 drawableIndex) const;
 
     /**
      * @brief Drawableの頂点インデックスの個数の取得

--- a/src/Physics/CubismPhysics.hpp
+++ b/src/Physics/CubismPhysics.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "Math/CubismVector2.hpp"
+#include "CubismPhysicsInternal.hpp"
 
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -29,8 +30,18 @@ public:
      */
     struct Options
     {
-        CubismVector2 Gravity;          ///< 重力方向
-        CubismVector2 Wind;             ///< 風の方向
+        CubismVector2 Gravity; ///< 重力方向
+        CubismVector2 Wind; ///< 風の方向
+    };
+
+    /**
+     * @brief 物理演算出力結果
+     *
+     * パラメータに適用する前の物理演算の出力結果
+     */
+    struct PhysicsOutput
+    {
+        csmVector<csmFloat32> output;
     };
 
     /**
@@ -58,7 +69,7 @@ public:
      *
      * パラメータをリセットする。
      */
-     void Reset();
+    void Reset();
 
     /**
      * @brief 物理演算の評価
@@ -88,7 +99,6 @@ public:
      */
     const Options& GetOptions() const;
 
-
 private:
     /**
      * @brief コンストラクタ
@@ -113,7 +123,7 @@ private:
      *
      * physics3.jsonをパースする。
      *
-     * @param[in]   physicsJson     physics3.jsonが読み込まれいるバッファ
+     * @param[in]   physicsJson     physics3.jsonが読み込まれているバッファ
      * @param[in]   size            バッファのサイズ
      */
     void Parse(const csmByte* physicsJson, csmSizeInt size);
@@ -125,8 +135,27 @@ private:
      */
     void Initialize();
 
-    CubismPhysicsRig*   _physicsRig;          ///< 物理演算のデータ
-    Options             _options;             ///< オプション
+    /**
+     * @brief 物理演算結果の適用
+     *
+     * 振り子演算の最新の結果と一つ前の結果から指定した重みで適用する。
+     *
+     * @param model 物理演算の結果を適用するモデル
+     * @param weight 最新結果の重み
+     */
+    void Interpolate(CubismModel* model, csmFloat32 weight);
+
+    CubismPhysicsRig* _physicsRig; ///< 物理演算のデータ
+    Options _options; ///< オプション
+
+    csmVector<PhysicsOutput> _currentRigOutputs; ///< 最新の振り子計算の結果
+    csmVector<PhysicsOutput> _previousRigOutputs; ///< 一つ前の振り子計算の結果
+
+    csmFloat32 _currentRemainTime; ///< 物理演算が処理していない時間
+
+    csmVector<csmFloat32> _parameterCache; ///< Evaluateで利用するパラメータのキャッシュ
+
+    csmBool _isJsonValid; ///< 正しくJsonデータが取得出来たか
 };
 
 }}}

--- a/src/Physics/CubismPhysicsInternal.hpp
+++ b/src/Physics/CubismPhysicsInternal.hpp
@@ -215,6 +215,7 @@ struct CubismPhysicsRig
     csmVector<CubismPhysicsParticle> Particles;     ///< 物理演算の物理点のリスト
     CubismVector2 Gravity;                          ///< 重力
     CubismVector2 Wind;                             ///< 風
+    csmFloat32 Fps;                                 ///< 物理演算動作FPS
 };
 
 }}}

--- a/src/Physics/CubismPhysicsJson.cpp
+++ b/src/Physics/CubismPhysicsJson.cpp
@@ -29,6 +29,7 @@ const csmChar* PhysicsSettingCount = "PhysicsSettingCount";
 const csmChar* Gravity = "Gravity";
 const csmChar* Wind = "Wind";
 const csmChar* VertexCount = "VertexCount";
+const csmChar* Fps = "Fps";
 
 // PhysicsSettings
 const csmChar* PhysicsSettings = "PhysicsSettings";
@@ -81,6 +82,12 @@ CubismVector2 CubismPhysicsJson::GetWind() const
     ret.X = _json->GetRoot()[Meta][EffectiveForces][Wind][X].ToFloat();
     ret.Y = _json->GetRoot()[Meta][EffectiveForces][Wind][Y].ToFloat();
     return ret;
+}
+
+csmFloat32 CubismPhysicsJson::GetFps() const
+{
+    // if FPS information does not exist in physics3.json, 0.0f is returned.
+    return _json->GetRoot()[Meta][Fps].ToFloat(0.0f);
 }
 
 csmInt32 CubismPhysicsJson::GetSubRigCount() const

--- a/src/Physics/CubismPhysicsJson.hpp
+++ b/src/Physics/CubismPhysicsJson.hpp
@@ -58,6 +58,16 @@ public:
     CubismVector2 GetWind() const;
 
     /**
+     * @brief 物理演算設定FPSの取得
+     *
+     * 物理演算の想定FPSを取得する。
+     * physics3.jsonにFPS情報が存在しない場合、0.0fを返す。
+     *
+     * @return 物理演算設定FPS
+     */
+    csmFloat32 GetFps() const;
+
+    /**
      * @brief 物理点の管理の個数の取得
      *
      * 物理点の管理の個数を取得する。

--- a/src/Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.cpp
@@ -17,6 +17,10 @@ CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand::DrawCommand()
 
 CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand::~DrawCommand()
 {
+    if (_command.getPipelineDescriptor().programState != NULL)
+    {
+        _command.getPipelineDescriptor().programState->release();
+    }
 }
 
 cocos2d::backend::BlendDescriptor* CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand::GetBlendDescriptor()
@@ -43,7 +47,10 @@ CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommandBuffer()
 
 CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::~DrawCommandBuffer()
 {
-    CSM_FREE(_drawBuffer);
+    if (_drawBuffer != NULL)
+    {
+        CSM_FREE(_drawBuffer);
+    }
 }
 
 void CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::CreateVertexBuffer(csmSizeInt stride, csmSizeInt count)

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
@@ -323,7 +323,7 @@ void CubismClippingManager_Cocos2dx::SetupClippingContext(CubismModel& model, Cu
 
                     renderer->DrawMeshCocos2d(
                         drawCommandBufferData->GetCommandDraw(),
-                        model.GetDrawableTextureIndices(clipDrawIndex),
+                        model.GetDrawableTextureIndex(clipDrawIndex),
                         model.GetDrawableVertexIndexCount(clipDrawIndex),
                         model.GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
@@ -1617,6 +1617,31 @@ CubismRenderer_Cocos2dx::CubismRenderer_Cocos2dx() : _clippingManager(NULL)
 CubismRenderer_Cocos2dx::~CubismRenderer_Cocos2dx()
 {
     CSM_DELETE_SELF(CubismClippingManager_Cocos2dx, _clippingManager);
+
+    if (_drawableDrawCommandBuffer.GetSize() > 0)
+    {
+        for (csmInt32 i = 0 ; i < _drawableDrawCommandBuffer.GetSize() ; i++)
+        {
+            if (_drawableDrawCommandBuffer[i] != NULL)
+            {
+                CSM_DELETE(_drawableDrawCommandBuffer[i]);
+            }
+        }
+    }
+
+    if (_drawableDrawCommandBuffer.GetSize() > 0)
+    {
+        _drawableDrawCommandBuffer.Clear();
+    }
+
+    if (_textures.GetSize() > 0)
+    {
+        _textures.Clear();
+    }
+    if (_offscreenFrameBuffer.IsValid())
+    {
+        _offscreenFrameBuffer.DestroyOffscreenFrame();
+    }
 }
 
 void CubismRenderer_Cocos2dx::DoStaticRelease()
@@ -1812,7 +1837,7 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
                     SetClippingContextBufferForMask(clipContext);
                     DrawMeshCocos2d(
                         drawCommandBufferMask->GetCommandDraw(),
-                        GetModel()->GetDrawableTextureIndices(clipDrawIndex),
+                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
                         GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
                         GetModel()->GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
@@ -1851,7 +1876,7 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
 
         DrawMeshCocos2d(
             drawCommandDraw,
-            GetModel()->GetDrawableTextureIndices(drawableIndex),
+            GetModel()->GetDrawableTextureIndex(drawableIndex),
             GetModel()->GetDrawableVertexIndexCount(drawableIndex),
             GetModel()->GetDrawableVertexCount(drawableIndex),
             const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
@@ -322,7 +322,7 @@ void CubismClippingManager_D3D11::SetupClippingContext(ID3D11DeviceContext* rend
                     // チャンネルも切り替える必要がある(A,R,G,B)
                     renderer->SetClippingContextBufferForMask(clipContext);
                     renderer->DrawMeshDX11(clipDrawIndex,
-                        model.GetDrawableTextureIndices(clipDrawIndex),
+                        model.GetDrawableTextureIndex(clipDrawIndex),
                         model.GetDrawableVertexIndexCount(clipDrawIndex),
                         model.GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
@@ -1028,7 +1028,7 @@ void CubismRenderer_D3D11::DoDrawModel()
                     // チャンネルも切り替える必要がある(A,R,G,B)
                     SetClippingContextBufferForMask(clipContext);
                     DrawMeshDX11(clipDrawIndex,
-                        GetModel()->GetDrawableTextureIndices(clipDrawIndex),
+                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
                         GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
                         GetModel()->GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
@@ -1061,7 +1061,7 @@ void CubismRenderer_D3D11::DoDrawModel()
         IsCulling(GetModel()->GetDrawableCulling(drawableIndex) != 0);
 
         DrawMeshDX11(drawableIndex,
-            GetModel()->GetDrawableTextureIndices(drawableIndex),
+            GetModel()->GetDrawableTextureIndex(drawableIndex),
             GetModel()->GetDrawableVertexIndexCount(drawableIndex),
             GetModel()->GetDrawableVertexCount(drawableIndex),
             const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
@@ -331,7 +331,7 @@ public:
      * @brief  使用するシェーダの設定・コンスタントバッファの設定などを行い、描画を実行
      *
      * @param[in]  device          -> 使用デバイス
-     * @param[in]  textureNo        -> 使用テクスチャ番号。基本的にCubismModel::GetDrawableTextureIndicesで返されたもの
+     * @param[in]  textureNo        -> 使用テクスチャ番号。基本的にCubismModel::GetDrawableTextureIndexで返されたもの
      * @param[in]  modelColorRGBA   -> 描画カラー
      * @param[in]  multiplyColor   -> 乗算色
      * @param[in]  screenColor   -> スクリーン色

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
@@ -323,7 +323,7 @@ void CubismClippingManager_DX9::SetupClippingContext(LPDIRECT3DDEVICE9 device, C
                     // チャンネルも切り替える必要がある(A,R,G,B)
                     renderer->SetClippingContextBufferForMask(clipContext);
                     renderer->DrawMeshDX9(clipDrawIndex,
-                        model.GetDrawableTextureIndices(clipDrawIndex),
+                        model.GetDrawableTextureIndex(clipDrawIndex),
                         model.GetDrawableVertexIndexCount(clipDrawIndex),
                         model.GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
@@ -957,7 +957,7 @@ void CubismRenderer_D3D9::DoDrawModel()
                     // チャンネルも切り替える必要がある(A,R,G,B)
                     SetClippingContextBufferForMask(clipContext);
                     DrawMeshDX9(clipDrawIndex,
-                        GetModel()->GetDrawableTextureIndices(clipDrawIndex),
+                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
                         GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
                         GetModel()->GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
@@ -990,7 +990,7 @@ void CubismRenderer_D3D9::DoDrawModel()
         IsCulling(GetModel()->GetDrawableCulling(drawableIndex) != 0);
 
         DrawMeshDX9(drawableIndex,
-            GetModel()->GetDrawableTextureIndices(drawableIndex),
+            GetModel()->GetDrawableTextureIndex(drawableIndex),
             GetModel()->GetDrawableVertexIndexCount(drawableIndex),
             GetModel()->GetDrawableVertexCount(drawableIndex),
             const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
@@ -333,7 +333,7 @@ public:
      * @brief  使用するシェーダの設定・コンスタントバッファの設定などを行い、描画を実行
      *
      * @param[in]  device          -> 使用デバイス
-     * @param[in]  textureNo        -> 使用テクスチャ番号。基本的にCubismModel::GetDrawableTextureIndicesで返されたもの
+     * @param[in]  textureNo        -> 使用テクスチャ番号。基本的にCubismModel::GetDrawableTextureIndexで返されたもの
      * @param[in]  modelColorRGBA   -> 描画カラー
      * @param[in]  multiplyColor   -> 乗算色
      * @param[in]  screenColor   -> スクリーン色

--- a/src/Rendering/Metal/CubismRenderer_Metal.mm
+++ b/src/Rendering/Metal/CubismRenderer_Metal.mm
@@ -316,7 +316,7 @@ void CubismClippingManager_Metal::SetupClippingContext(CubismModel& model, Cubis
 
                     renderer->DrawMeshMetal(
                         drawCommandBufferData,
-                        model.GetDrawableTextureIndices(clipDrawIndex),
+                        model.GetDrawableTextureIndex(clipDrawIndex),
                         model.GetDrawableVertexIndexCount(clipDrawIndex),
                         model.GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
@@ -1329,7 +1329,7 @@ void CubismRenderer_Metal::DoDrawModel()
                     SetClippingContextBufferForMask(clipContext);
                     DrawMeshMetal(
                         clipContext->_clippingCommandBufferList->At(index),
-                        GetModel()->GetDrawableTextureIndices(clipDrawIndex),
+                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
                         GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
                         GetModel()->GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
@@ -1372,7 +1372,7 @@ void CubismRenderer_Metal::DoDrawModel()
 
         DrawMeshMetal(
             _drawableDrawCommandBuffer[drawableIndex],
-            GetModel()->GetDrawableTextureIndices(drawableIndex),
+            GetModel()->GetDrawableTextureIndex(drawableIndex),
             GetModel()->GetDrawableVertexIndexCount(drawableIndex),
             GetModel()->GetDrawableVertexCount(drawableIndex),
             const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -304,7 +304,7 @@ void CubismClippingManager_OpenGLES2::SetupClippingContext(CubismModel& model, C
                     renderer->SetClippingContextBufferForMask(clipContext);
 
                     renderer->DrawMeshOpenGL(
-                        model.GetDrawableTextureIndices(clipDrawIndex),
+                        model.GetDrawableTextureIndex(clipDrawIndex),
                         model.GetDrawableVertexIndexCount(clipDrawIndex),
                         model.GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
@@ -2047,7 +2047,7 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
                     SetClippingContextBufferForMask(clipContext);
 
                     DrawMeshOpenGL(
-                        GetModel()->GetDrawableTextureIndices(clipDrawIndex),
+                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
                         GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
                         GetModel()->GetDrawableVertexCount(clipDrawIndex),
                         const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
@@ -2078,7 +2078,7 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
         IsCulling(GetModel()->GetDrawableCulling(drawableIndex) != 0);
 
         DrawMeshOpenGL(
-            GetModel()->GetDrawableTextureIndices(drawableIndex),
+            GetModel()->GetDrawableTextureIndex(drawableIndex),
             GetModel()->GetDrawableVertexIndexCount(drawableIndex),
             GetModel()->GetDrawableVertexCount(drawableIndex),
             const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),


### PR DESCRIPTION
### Fixed

* `GetDrawableTextureIndices` function in `CubismModel` has been renamed to `GetDrawableTextureIndex` because the name was not correct.
  * `GetDrawableTextureIndices` function is marked as deprecated.
* Fix physics system behaviour when exists Physics Fps Setting in .physics3.json.
* Fix force close problem when invalid `physics3.json` is read.
* Fixed memory leak in Cocos2d-x.