### PR TITLE
Cubism 4 SDK for Native R5 beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.5-beta.4] - 2022-07-07
+
+### Added
+
+* Add a function to get the latest .moc3 Version and the .moc3 Version of the loaded model.
+* Add a function to get the type of parameters of the model.
+* Add a function to get the parent part of the model's Drawable.
+
+### Changed
+
+* Disable ARC in Metal renderer.
+
+### Fixed
+
+* Fix dangling pointer in `GetRenderPassDescriptor` function for Metal.
+
+
+
 ## [4-r.5-beta.3] - 2022-06-16
 
 ### Fixed
@@ -173,6 +191,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.5-beta.4]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.3...4-r.5-beta.4
 [4-r.5-beta.3]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.2...4-r.5-beta.3
 [4-r.5-beta.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.1...4-r.5-beta.2
 [4-r.5-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.4...4-r.5-beta.1

--- a/src/Model/CubismMoc.cpp
+++ b/src/Model/CubismMoc.cpp
@@ -18,10 +18,12 @@ CubismMoc* CubismMoc::Create(const csmByte* mocBytes, csmSizeInt size)
     memcpy(alignedBuffer, mocBytes, size);
 
     Core::csmMoc* moc = Core::csmReviveMocInPlace(alignedBuffer, size);
+    const Core::csmMocVersion version = Core::csmGetMocVersion(alignedBuffer, size);
 
     if (moc)
     {
         cubismMoc = CSM_NEW CubismMoc(moc);
+        cubismMoc->_mocVersion = version;
     }
 
     return cubismMoc;
@@ -35,6 +37,7 @@ void CubismMoc::Delete(CubismMoc* moc)
 CubismMoc::CubismMoc(Core::csmMoc* moc)
                         : _moc(moc)
                         , _modelCount(0)
+                        , _mocVersion(0)
 { }
 
 CubismMoc::~CubismMoc()
@@ -67,6 +70,16 @@ void CubismMoc::DeleteModel(CubismModel* model)
 {
     CSM_DELETE_SELF(CubismModel, model);
     --_modelCount;
+}
+
+Core::csmMocVersion CubismMoc::GetLatestMocVersion()
+{
+    return Core::csmGetLatestMocVersion();
+}
+
+Core::csmMocVersion CubismMoc::GetMocVersion()
+{
+    return _mocVersion;
 }
 
 }}}

--- a/src/Model/CubismMoc.hpp
+++ b/src/Model/CubismMoc.hpp
@@ -57,6 +57,24 @@ public:
      */
     void DeleteModel(CubismModel* model);
 
+    /**
+     * @brief 最新の.moc3 Versionを取得
+     *
+     * 最新の.moc3 Versionを取得する。
+     *
+     * @return  最新の.moc3 Version
+     */
+    static Core::csmMocVersion GetLatestMocVersion();
+
+    /**
+     * @brief 読み込んだモデルの.moc3 Versionを取得
+     *
+     * 読み込んだモデルの.moc3 Versionを取得する。
+     *
+     * @return  読み込んだモデルの.moc3 Version
+     */
+    Core::csmMocVersion GetMocVersion();
+
 private:
     /**
      * @brief コンストラクタ
@@ -74,6 +92,7 @@ private:
 
     Core::csmMoc*     _moc;             ///< Mocデータ
     csmInt32          _modelCount;      ///< Mocデータから作られたモデルの個数
+    csmUint32         _mocVersion;      ///< 読み込んだモデルの.moc3 Version
 };
 
 }}}

--- a/src/Model/CubismModel.cpp
+++ b/src/Model/CubismModel.cpp
@@ -135,6 +135,11 @@ csmInt32 CubismModel::GetParameterCount() const
     return Core::csmGetParameterCount(_model);
 }
 
+Core::csmParameterType CubismModel::GetParameterType(csmUint32 parameterIndex) const
+{
+    return Core::csmGetParameterTypes(_model)[parameterIndex];
+}
+
 csmFloat32 CubismModel::GetParameterDefaultValue(csmUint32 parameterIndex) const
 {
     return Core::csmGetParameterDefaultValues(_model)[parameterIndex];
@@ -501,6 +506,11 @@ Core::csmVector4 CubismModel::GetDrawableScreenColor(csmInt32 drawableIndex) con
 {
     const Core::csmVector4* screenColors = Core::csmGetDrawableScreenColors(_model);
     return screenColors[drawableIndex];
+}
+
+csmInt32 CubismModel::GetDrawableParentPartIndex(csmUint32 parameterIndex) const
+{
+    return Core::csmGetPartParentPartIndices(_model)[parameterIndex];
 }
 
 csmInt32 CubismModel::GetDrawableCulling(csmInt32 drawableIndex) const

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -28,7 +28,7 @@ class CubismModel
 public:
 
     /**
-    * @brief テクスチャの色をRGBAで扱うための構造体
+     * @brief テクスチャの色をRGBAで扱うための構造体
     */
     struct DrawableColorData
     {
@@ -185,6 +185,16 @@ public:
      * @return パラメータの個数
      */
     csmInt32    GetParameterCount() const;
+
+    /**
+     * @brief パラメータの種類の取得
+     *
+     * パラメータの種類を取得する。
+     *
+     * @return Core::csmParameterType_Normal -> 通常のパラメータ
+     *         Core::csmParameterType_BlendShape -> ブレンドシェイプパラメータ
+     */
+    Core::csmParameterType GetParameterType(csmUint32 parameterIndex) const;
 
     /**
      * @brief パラメータの最大値の取得
@@ -452,6 +462,15 @@ public:
      * @return  Drawableのスクリーン色
      */
     Core::csmVector4 GetDrawableScreenColor(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief Drawableの親パーツのインデックスの取得
+     *
+     * Drawableの親パーツのインデックスを取得する。
+     *
+     * @return drawableの親パーツのインデックス
+     */
+    csmInt32 GetDrawableParentPartIndex(csmUint32 parameterIndex) const;
 
     /**
      * @brief Drawableのカリング情報の取得

--- a/src/Motion/CubismMotionManager.hpp
+++ b/src/Motion/CubismMotionManager.hpp
@@ -68,7 +68,7 @@ public:
      * 優先度を設定してモーションを開始する。
      *
      * @param[in]   motion          モーション
-     * @param[in]   autoDelete      再生が狩猟したモーションのインスタンスを削除するならtrue
+     * @param[in]   autoDelete      再生が終了したモーションのインスタンスを削除するならtrue
      * @param[in]   priority        優先度
      * @return                      開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判定するIsFinished()の引数で使用する。開始できない時は「-1」
      */

--- a/src/Rendering/Metal/CMakeLists.txt
+++ b/src/Rendering/Metal/CMakeLists.txt
@@ -11,8 +11,10 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/MetalShaderTypes.h
 )
 
-set_source_files_properties(
-  CubismRenderingInstanceSingleton_Metal.m
-  TARGET_DIRECTORY ${LIB_NAME}
-  PROPERTIES COMPILE_FLAGS "-fno-objc-arc"
+# Disable ARC
+set_target_properties(
+    ${LIB_NAME}
+    PROPERTIES
+    MACOSX_BUNDLE YES
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC NO
 )

--- a/src/Rendering/Metal/CubismCommandBuffer_Metal.mm
+++ b/src/Rendering/Metal/CubismCommandBuffer_Metal.mm
@@ -14,11 +14,26 @@ namespace Cubism {
 namespace Framework {
 namespace Rendering {
 CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::DrawCommand()
+: _mtlCommandBuffer(NULL)
+, _pipelineState(NULL)
+, _renderPassDescriptor(NULL)
 {
 }
 
 CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::~DrawCommand()
 {
+    if (_mtlCommandBuffer != NULL)
+    {
+        _mtlCommandBuffer = NULL;
+    }
+    if (_pipelineState != NULL)
+    {
+        _pipelineState = NULL;
+    }
+    if (_renderPassDescriptor != NULL)
+    {
+        _renderPassDescriptor = NULL;
+    }
 }
 
 id <MTLCommandBuffer> CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommand::GetMTLCommandBuffer()
@@ -45,11 +60,26 @@ CubismCommandBuffer_Metal::DrawCommandBuffer::DrawCommandBuffer()
     : _vbStride(0)
     , _vbCount(0)
     , _ibCount(0)
+    , _vertices(NULL)
+    , _uvs(NULL)
+    , _indices(NULL)
 {
 }
 
 CubismCommandBuffer_Metal::DrawCommandBuffer::~DrawCommandBuffer()
 {
+    if (_vertices != NULL)
+    {
+        [_vertices release];
+    }
+    if (_uvs != NULL)
+    {
+        [_uvs release];
+    }
+    if (_indices != NULL)
+    {
+        [_indices release];
+    }
 }
 
 void CubismCommandBuffer_Metal::DrawCommandBuffer::CreateVertexBuffer(id<MTLDevice> device, csmSizeInt stride, csmSizeInt count)

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
@@ -77,7 +77,6 @@ public:
 
 private:
     id <MTLTexture>  _colorBuffer; ///レンダーテクスチャ
-    csmBool _isInheritedRenderTexture;
     MTLRenderPassDescriptor *_renderPassDescriptor;
     csmUint32   _bufferWidth;           ///< Create時に指定された幅
     csmUint32   _bufferHeight;          ///< Create時に指定された高さ

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
@@ -14,7 +14,6 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 CubismOffscreenFrame_Metal::CubismOffscreenFrame_Metal()
     : _colorBuffer(NULL)
     , _renderPassDescriptor(NULL)
-    , _isInheritedRenderTexture(false)
     , _bufferWidth(0)
     , _bufferHeight(0)
     , _pixelFormat(MTLPixelFormatRGBA8Unorm)
@@ -32,11 +31,11 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
 
     do
     {
-        if (colorBuffer == nil)
+        if (colorBuffer == NULL)
         {
             csmBool initResult = false;
 
-            _renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+            _renderPassDescriptor = [[MTLRenderPassDescriptor alloc] init];
             _renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
             _renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
             _renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(_clearColorR, _clearColorG, _clearColorB, _clearColorA);
@@ -47,10 +46,9 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
 
             _renderPassDescriptor.renderTargetWidth = displayBufferWidth;
             _renderPassDescriptor.renderTargetHeight = displayBufferHeight;
-            _isInheritedRenderTexture = false;
 
             // Set up a texture for rendering to and sampling from
-            MTLTextureDescriptor *texDescriptor = [[MTLTextureDescriptor alloc] init];
+            MTLTextureDescriptor *texDescriptor = [[[MTLTextureDescriptor alloc] init] autorelease];
             texDescriptor.textureType = MTLTextureType2D;
             texDescriptor.width = displayBufferWidth;
             texDescriptor.height = displayBufferHeight;
@@ -65,7 +63,6 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
         else
         {
             _colorBuffer = colorBuffer;
-            _isInheritedRenderTexture = true;
         }
 
         if (_colorBuffer)
@@ -94,9 +91,16 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
 
 void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
 {
-    if (!_isInheritedRenderTexture)
+    if (_colorBuffer != NULL)
     {
+        [_colorBuffer release];
         _colorBuffer = NULL;
+    }
+
+    if (_renderPassDescriptor != NULL)
+    {
+        [_renderPassDescriptor release];
+        _renderPassDescriptor = NULL;
     }
 }
 

--- a/src/Rendering/Metal/CubismRenderer_Metal.mm
+++ b/src/Rendering/Metal/CubismRenderer_Metal.mm
@@ -610,8 +610,11 @@ CubismClippingContext::~CubismClippingContext()
     {
         for (csmUint32 i = 0; i < _clippingCommandBufferList->GetSize(); ++i)
         {
-            CSM_DELETE(_clippingCommandBufferList->At(i));
-            _clippingCommandBufferList->At(i) = NULL;
+            if (_clippingCommandBufferList->At(i) != NULL)
+            {
+                CSM_DELETE(_clippingCommandBufferList->At(i));
+                _clippingCommandBufferList->At(i) = NULL;
+            }
         }
 
         CSM_DELETE(_clippingCommandBufferList);
@@ -1026,7 +1029,7 @@ CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgram(const c
 
 id<MTLRenderPipelineState> CubismShader_Metal::MakeRenderPipelineState(id<MTLDevice> device, CubismShader_Metal::ShaderProgram* shaderProgram, int blendMode)
 {
-    MTLRenderPipelineDescriptor* renderPipelineDescriptor = [MTLRenderPipelineDescriptor new];
+    MTLRenderPipelineDescriptor* renderPipelineDescriptor = [[[MTLRenderPipelineDescriptor alloc] init] autorelease];
     NSError *error;
 
     renderPipelineDescriptor.vertexFunction = shaderProgram->vertexFunction;
@@ -1080,7 +1083,7 @@ id<MTLRenderPipelineState> CubismShader_Metal::MakeRenderPipelineState(id<MTLDev
 
 id<MTLDepthStencilState> CubismShader_Metal::MakeDepthStencilState(id<MTLDevice> device)
 {
-    MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
+    MTLDepthStencilDescriptor* depthStencilDescriptor = [[[MTLDepthStencilDescriptor alloc] init] autorelease];
 
     depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
     depthStencilDescriptor.depthWriteEnabled = YES;
@@ -1090,7 +1093,7 @@ id<MTLDepthStencilState> CubismShader_Metal::MakeDepthStencilState(id<MTLDevice>
 
 id<MTLSamplerState> CubismShader_Metal::MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer)
 {
-    MTLSamplerDescriptor* samplerDescriptor = [MTLSamplerDescriptor new];
+    MTLSamplerDescriptor* samplerDescriptor = [[[MTLSamplerDescriptor alloc] init] autorelease];
 
     samplerDescriptor.rAddressMode = MTLSamplerAddressModeRepeat;
     samplerDescriptor.sAddressMode = MTLSamplerAddressModeRepeat;
@@ -1138,9 +1141,26 @@ CubismRenderer_Metal::~CubismRenderer_Metal()
 {
     CSM_DELETE_SELF(CubismClippingManager_Metal, _clippingManager);
 
-    for (csmInt32 i = 0; i < _drawableDrawCommandBuffer.GetSize(); ++i)
+    if (_drawableDrawCommandBuffer.GetSize() > 0)
     {
-        CSM_DELETE(_drawableDrawCommandBuffer[i]);
+        for (csmInt32 i = 0; i < _drawableDrawCommandBuffer.GetSize(); ++i)
+        {
+            if (_drawableDrawCommandBuffer[i] != NULL)
+            {
+                CSM_DELETE(_drawableDrawCommandBuffer[i]);
+            }
+        }
+
+        _drawableDrawCommandBuffer.Clear();
+    }
+
+    if (_textures.GetSize() > 0)
+    {
+        _textures.Clear();
+    }
+    if (_offscreenFrameBuffer.IsValid())
+    {
+        _offscreenFrameBuffer.DestroyOffscreenFrame();
     }
 }
 


### PR DESCRIPTION
### Added

* Add a function to get the latest .moc3 Version and the .moc3 Version of the loaded model.
* Add a function to get the type of parameters of the model.
* Add a function to get the parent part of the model's Drawable.

### Changed

* Disable ARC in Metal renderer.

### Fixed

* Fix dangling pointer in `GetRenderPassDescriptor` function for Metal.