### PR TITLE
Update to Cubism 4 SDK for Native R5_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.5.1] - 2022-09-15
+
+### Fixed
+
+* Fix a bug that caused a crash if an empty array existed in json.
+
+
 ## [4-r.5] - 2022-09-08
 
 ### Added
@@ -219,6 +226,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.5.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5...4-r.5.1
 [4-r.5]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.5...4-r.5
 [4-r.5-beta.5]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.4.1...4-r.5-beta.5
 [4-r.5-beta.4.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.4...4-r.5-beta.4.1

--- a/src/Type/csmVector.hpp
+++ b/src/Type/csmVector.hpp
@@ -524,13 +524,14 @@ private:
      */
     void Copy(const csmVector& c)
     {
-        if (c._capacity == 0)
-        {
-            return;
-        }
-
         _size = c._size;
         _capacity = c._capacity;
+
+        if (c._capacity == 0)
+        {
+            _ptr = NULL;
+            return;
+        }
 
         _ptr = (T*)CSM_MALLOC(_capacity * sizeof(T));
 
@@ -641,12 +642,15 @@ void csmVector<T>::PrepareCapacity(csmInt32 newSize)
 template<class T>
 void csmVector<T>::Clear()
 {
-    for (csmInt32 i = 0; i < _size; i++)
+    if (_ptr != NULL)
     {
-        _ptr[i].~T();
-    }
+        for (csmInt32 i = 0; i < _size; i++)
+        {
+            _ptr[i].~T();
+        }
 
-    CSM_FREE(_ptr);
+        CSM_FREE(_ptr);
+    }
 
     _ptr = NULL;
     _size = 0;


### PR DESCRIPTION
### Fixed

* Fix a bug that caused a crash if an empty array existed in json.