### PR TITLE
Update to Cubism 4 SDK for Native R6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.6] - 2023-02-21
+
+### Added
+
+* Add API to allow users to configure culling.
+* The number of render textures used can now be increased arbitrarily.
+  * The maximum number of masks when using multiple render textures has been increased to "number of render textures * 32".
+
+### Fixed
+
+* Fix a bug that models with culling were not rendered correctly in Metal.
+* Fix a bug that caused some masks to be rendered incorrectly when using 17 or more masks in DirectX systems.
+
+### Removed
+
+* Remove unnecessary variable `modelToWorldF` in renderer.
+
+
 ## [4-r.5.1] - 2022-09-15
 
 ### Fixed
@@ -226,6 +244,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.6]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5.1...4-r.6
 [4-r.5.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5...4-r.5.1
 [4-r.5]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.5...4-r.5
 [4-r.5-beta.5]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5-beta.4.1...4-r.5-beta.5

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -57,6 +57,35 @@ public:
     };  // DrawableColorData
 
     /**
+     * @brief テクスチャのカリング設定を管理するための構造体
+    */
+    struct DrawableCullingData
+    {
+        /**
+         * @brief   コンストラクタ
+         */
+        DrawableCullingData()
+            : IsOverwritten(false)
+            , IsCulling(0) {};
+
+        /**
+         * @brief   コンストラクタ
+         */
+        DrawableCullingData(csmBool isOverwritten, csmInt32 isCulling)
+            : IsOverwritten(isOverwritten)
+            , IsCulling(isCulling) {};
+
+        /**
+         * @brief   デストラクタ
+         */
+        virtual ~DrawableCullingData() {};
+
+        csmBool IsOverwritten;
+        csmInt32 IsCulling;
+
+    };  // DrawableCullingData
+
+    /**
      * @brief モデルのパラメータの更新
      *
      * モデルのパラメータを更新する。
@@ -474,16 +503,6 @@ public:
     csmInt32 GetDrawableParentPartIndex(csmUint32 drawableIndex) const;
 
     /**
-     * @brief Drawableのカリング情報の取得
-     *
-     * Drawableのカリング情報を取得する。
-     *
-     * @param[in]   drawableIndex   Drawableのインデックス
-     * @return  Drawableのカリング情報
-     */
-    csmInt32                    GetDrawableCulling(csmInt32 drawableIndex) const;
-
-    /**
      * @brief Drawableのブレンドモードの取得
      *
      * Drawableのブレンドモードを取得する。
@@ -710,6 +729,49 @@ public:
      */
     void SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
 
+    /**
+     * @brief Drawableのカリング情報の取得
+     *
+     * Drawableのカリング情報を取得する。
+     *
+     * @param[in]   drawableIndex   Drawableのインデックス
+     * @return  Drawableのカリング情報
+     */
+    csmInt32 GetDrawableCulling(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief   Drawableのカリング情報を設定する
+     */
+    void SetDrawableCulling(csmInt32 drawableIndex, csmInt32 isCulling);
+
+    /**
+     * @brief SDKからモデル全体のカリング設定を上書きするか。
+     *
+     * @retval  true    ->  SDK上のカリング設定を使用
+     * @retval  false   ->  モデルのカリング設定を使用
+     */
+    csmBool GetOverwriteFlagForModelCullings() const;
+
+    /**
+     * @brief SDKからモデル全体のカリング設定を上書きするかをセットする
+     *        SDK上のカリング設定を使うならtrue、モデルのカリング設定を使うならfalse
+     */
+    void SetOverwriteFlagForModelCullings(csmBool value);
+
+    /**
+     * @brief SDKからdrawableのカリング設定を上書きするか。
+     *
+     * @retval  true    ->  SDK上のカリング設定を使用
+     * @retval  false   ->  モデルのカリング設定を使用
+     */
+    csmBool GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex) const;
+
+    /**
+     * @brief SDKからdrawableのカリング設定を上書きするかをセットする
+     *        SDK上のカリング設定を使うならtrue、モデルのカリング設定を使うならfalse
+     */
+    void SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value);
+
     Core::csmModel*     GetModel() const;
 
 private:
@@ -761,8 +823,10 @@ private:
     csmVector<CubismIdHandle> _drawableIds;
     csmVector<DrawableColorData> _userScreenColors; ///< 乗算色の配列
     csmVector<DrawableColorData> _userMultiplyColors; ///< スクリーン色の配列
+    csmVector<DrawableCullingData> _userCullings; ///< カリング設定の配列
     csmBool _isOverwrittenModelMultiplyColors; ///< 乗算色を全て上書きするか？
     csmBool _isOverwrittenModelScreenColors; ///< スクリーン色を全て上書きするか？
+    csmBool _isOverwrittenCullings; ///< モデルのカリング設定をすべて上書きするか？
 };
 
 }}}

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -217,7 +217,7 @@ CubismModel* CubismUserModel::GetModel() const
     return _model;
 }
 
-void CubismUserModel::CreateRenderer()
+void CubismUserModel::CreateRenderer(csmInt32 maskBufferCount)
 {
     if (_renderer)
     {
@@ -225,7 +225,7 @@ void CubismUserModel::CreateRenderer()
     }
     _renderer = Rendering::CubismRenderer::Create();
 
-    _renderer->Initialize(_model);
+    _renderer->Initialize(_model, maskBufferCount);
 }
 
 void CubismUserModel::DeleteRenderer()

--- a/src/Model/CubismUserModel.hpp
+++ b/src/Model/CubismUserModel.hpp
@@ -231,7 +231,7 @@ public:
      *  レンダラを生成して初期化を実行する。
      *
      */
-    void CreateRenderer();
+    void CreateRenderer(csmInt32 maskBufferCount = 1);
 
     /**
      *  @brief  レンダラの解放

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
@@ -92,8 +92,9 @@ private:
      * @param[in]   drawableCount   ->  描画オブジェクトの数
      * @param[in]   drawableMasks   ->  描画オブジェクトをマスクする描画オブジェクトのインデックスのリスト
      * @param[in]   drawableMaskCounts   ->  描画オブジェクトをマスクする描画オブジェクトの数
+     * @param[in]   maskBufferCount ->  バッファの生成数
      */
-    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts);
+    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts, const csmInt32 maskBufferCount);
 
     /**
      * @brief   クリッピングコンテキストを作成する。モデル描画時に実行する。
@@ -141,19 +142,28 @@ private:
     void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
 
     /**
-     *@brief  クリッピングマスクバッファのサイズを取得する
+     * @brief  クリッピングマスクバッファのサイズを取得する
      *
-     *@return クリッピングマスクバッファのサイズ
+     * @return クリッピングマスクバッファのサイズ
      *
      */
     CubismVector2 GetClippingMaskBufferSize() const;
 
-    csmInt32    _currentFrameNo;         ///< マスクテクスチャに与えるフレーム番号
+    /**
+     * このバッファのレンダーテクスチャの枚数を取得する。
+     *
+     * @return このバッファのレンダーテクスチャの枚数
+     */
+    csmInt32 GetRenderTextureCount() const;
+
+    CubismOffscreenFrame_Cocos2dx* _currentOffscreenFrameBuffer;   ///< レンダーターゲットとなるオフスクリーンフレームバッファを保持する
+    csmVector<csmBool> _clearedFrameBufferFlags; /// マスクのクリアフラグの配列
 
     csmVector<CubismRenderer::CubismTextureColor*>  _channelColors;
     csmVector<CubismClippingContext*>               _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
     csmVector<CubismClippingContext*>               _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
     CubismVector2                                   _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
+    csmInt32                                        _renderTextureCount;           ///< 生成するレンダーテクスチャの枚数
 
     CubismMatrix44  _tmpMatrix;              ///< マスク計算用の行列
     CubismMatrix44  _tmpMatrixForMask;       ///< マスク計算用の行列
@@ -207,6 +217,7 @@ private:
     CubismMatrix44 _matrixForDraw;                   ///< 描画オブジェクトの位置計算結果を保持する行列
     csmVector<csmInt32>* _clippedDrawableIndexList;  ///< このマスクにクリップされる描画オブジェクトのリスト
     csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*>* _clippingCommandBufferList;
+    csmInt32 _bufferIndex;                           ///< このマスクが割り当てられるレンダーテクスチャ（フレームバッファ）やカラーバッファのインデックス
 
     CubismClippingManager_Cocos2dx* _owner;        ///< このマスクを管理しているマネージャのインスタンス
 };
@@ -388,6 +399,8 @@ public:
      */
     void Initialize(Framework::CubismModel* model);
 
+    void Initialize(Framework::CubismModel* model, csmInt32 maskBufferCount);
+
     /**
      * @brief   OpenGLテクスチャのバインド処理<br>
      *           CubismRendererにテクスチャを設定し、CubismRenderer中でその画像を参照するためのIndex値を戻り値とする
@@ -416,6 +429,14 @@ public:
     void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
 
     /**
+     * @brief  レンダーテクスチャの枚数を取得する。
+     *
+     * @return  レンダーテクスチャの枚数
+     *
+     */
+    csmInt32 GetRenderTextureCount() const;
+
+    /**
      * @brief  クリッピングマスクバッファのサイズを取得する
      *
      * @return クリッピングマスクバッファのサイズ
@@ -423,6 +444,13 @@ public:
      */
     CubismVector2 GetClippingMaskBufferSize() const;
 
+    /**
+     * @brief  オフスクリーンフレームバッファを取得する
+     *
+     * @return オフスクリーンフレームバッファへの参照
+     *
+     */
+    CubismOffscreenFrame_Cocos2dx* GetOffScreenFrameBuffer(csmInt32 index);
 
     static CubismCommandBuffer_Cocos2dx* GetCommandBuffer();
 
@@ -554,7 +582,7 @@ private:
     CubismClippingContext*              _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
     CubismClippingContext*              _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
 
-    CubismOffscreenFrame_Cocos2dx      _offscreenFrameBuffer;          ///< マスク描画用のフレームバッファ
+    csmVector<CubismOffscreenFrame_Cocos2dx>   _offscreenFrameBuffers;          ///< マスク描画用のフレームバッファ
     csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*>  _drawableDrawCommandBuffer;
 };
 

--- a/src/Rendering/CubismRenderer.cpp
+++ b/src/Rendering/CubismRenderer.cpp
@@ -33,6 +33,11 @@ CubismRenderer::~CubismRenderer()
 
 void CubismRenderer::Initialize(Framework::CubismModel* model)
 {
+    Initialize(model, 1);
+}
+
+void CubismRenderer::Initialize(Framework::CubismModel* model, csmInt32 maskBufferCount)
+{
     _model = model;
 }
 

--- a/src/Rendering/CubismRenderer.hpp
+++ b/src/Rendering/CubismRenderer.hpp
@@ -98,6 +98,14 @@ public:
      */
     virtual void Initialize(Framework::CubismModel* model);
 
+    /**
+    * @brief   レンダラの初期化処理を実行する<br>
+    *           引数に渡したモデルからレンダラの初期化処理に必要な情報を取り出すことができる
+    *
+    * @param[in]  model -> モデルのインスタンス
+    * @param[in]  maskBufferCount -> バッファの生成数
+    */
+    virtual void Initialize(Framework::CubismModel* model, csmInt32 maskBufferCount);
 
     /**
      * @brief   モデルを描画する

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -69,7 +69,7 @@ private:
      * @param[in]   drawableMasks   ->  描画オブジェクトをマスクする描画オブジェクトのインデックスのリスト
      * @param[in]   drawableMaskCounts   ->  描画オブジェクトをマスクする描画オブジェクトの数
      */
-    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts);
+    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts, const csmInt32 maskBufferCount);
 
     /**
      * @brief   クリッピングコンテキストを作成する。モデル描画時に実行する。
@@ -124,12 +124,21 @@ private:
      */
     CubismVector2 GetClippingMaskBufferSize() const;
 
-    csmInt32    _currentFrameNo;         ///< マスクテクスチャに与えるフレーム番号
+    /**
+     * このバッファのレンダーテクスチャの枚数を取得する。
+     *
+     * @return このバッファのレンダーテクスチャの枚数
+     */
+    csmInt32 GetRenderTextureCount() const;
+
+    CubismOffscreenFrame_Metal* _currentOffscreenFrameBuffer;   ///< レンダーターゲットとなるオフスクリーンフレームバッファを保持する
+    csmVector<csmBool> _clearedFrameBufferFlags; /// マスクのクリアフラグの配列
 
     csmVector<CubismRenderer::CubismTextureColor*>  _channelColors;
     csmVector<CubismClippingContext*>               _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
     csmVector<CubismClippingContext*>               _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
     CubismVector2                                   _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
+    csmInt32                                        _renderTextureCount;           ///< 生成するレンダーテクスチャの枚数
 
     CubismMatrix44  _tmpMatrix;              ///< マスク計算用の行列
     CubismMatrix44  _tmpMatrixForMask;       ///< マスク計算用の行列
@@ -183,6 +192,7 @@ private:
     CubismMatrix44 _matrixForDraw;                   ///< 描画オブジェクトの位置計算結果を保持する行列
     csmVector<csmInt32>* _clippedDrawableIndexList;  ///< このマスクにクリップされる描画オブジェクトのリスト
     csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>* _clippingCommandBufferList;
+    csmInt32 _bufferIndex;                           ///< このマスクが割り当てられるレンダーテクスチャ（フレームバッファ）やカラーバッファのインデックス
 
     CubismClippingManager_Metal* _owner;        ///< このマスクを管理しているマネージャのインスタンス
 };
@@ -338,6 +348,8 @@ public:
      */
     void Initialize(Framework::CubismModel* model);
 
+    void Initialize(Framework::CubismModel* model, csmInt32 maskBufferCount);
+
     /**
      * @brief   テクスチャのバインド処理<br>
      *           CubismRendererにテクスチャを設定し、CubismRenderer中でその画像を参照するためのIndex値を戻り値とする
@@ -365,12 +377,28 @@ public:
     void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
 
     /**
+     * @brief  レンダーテクスチャの枚数を取得する。
+     *
+     * @return  レンダーテクスチャの枚数
+     *
+     */
+    csmInt32 GetRenderTextureCount() const;
+
+    /**
      * @brief  クリッピングマスクバッファのサイズを取得する
      *
      * @return クリッピングマスクバッファのサイズ
      *
      */
     CubismVector2 GetClippingMaskBufferSize() const;
+
+    /**
+     * @brief  オフスクリーンフレームバッファを取得する
+     *
+     * @return オフスクリーンフレームバッファへの参照
+     *
+     */
+    CubismOffscreenFrame_Metal* GetOffScreenFrameBuffer(csmInt32 index);
 
     CubismCommandBuffer_Metal* GetCommandBuffer()
     {
@@ -494,7 +522,7 @@ private:
     CubismClippingContext*              _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
     CubismClippingContext*              _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
 
-    CubismOffscreenFrame_Metal      _offscreenFrameBuffer;          ///< マスク描画用のフレームバッファ
+    csmVector<CubismOffscreenFrame_Metal>   _offscreenFrameBuffers;          ///< マスク描画用のフレームバッファ
     CubismCommandBuffer_Metal       _commandBuffer;
     csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>  _drawableDrawCommandBuffer;
 };

--- a/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.cpp
@@ -130,6 +130,11 @@ void CubismOffscreenFrame_OpenGLES2::DestroyOffscreenFrame()
     }
 }
 
+GLuint CubismOffscreenFrame_OpenGLES2::GetRenderTexture() const
+{
+    return _renderTexture;
+}
+
 GLuint CubismOffscreenFrame_OpenGLES2::GetColorBuffer() const
 {
     return _colorBuffer;

--- a/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp
@@ -87,6 +87,11 @@ public:
     void DestroyOffscreenFrame();
 
     /**
+     * @brief   レンダーテクスチャメンバーへのアクセッサ
+     */
+    GLuint GetRenderTexture() const;
+
+    /**
      * @brief   カラーバッファメンバーへのアクセッサ
      */
     GLuint GetColorBuffer() const;


### PR DESCRIPTION
### Added

* Add API to allow users to configure culling.
* The number of render textures used can now be increased arbitrarily.
  * The maximum number of masks when using multiple render textures has been increased to "number of render textures * 32".

### Fixed

* Fix a bug that models with culling were not rendered correctly in Metal.
* Fix a bug that caused some masks to be rendered incorrectly when using 17 or more masks in DirectX systems.

### Removed

* Remove unnecessary variable `modelToWorldF` in renderer.