### PR TITLE
Update to Cubism 4 SDK for Native R6_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.6.2] - 2023-03-16
+
+### Fixed
+
+* Fix a bug that caused double and triple buffering to be disabled on DirectX systems due to multiple render textures in 4-r.6.
+* Fix the condition of splitting the mask buffer according to the number of masks used to be in accordance with the specification.
+* Fix some problems related to Cubism Core.
+  * See `CHANGELOG.md` in Core.
+
+
 ## [4-r.6.1] - 2023-03-10
 
 ### Added
@@ -251,6 +261,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.6.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6...4-r.6.1
 [4-r.6]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5.1...4-r.6
 [4-r.5.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5...4-r.5.1

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
@@ -474,8 +474,8 @@ void CubismClippingManager_Cocos2dx::SetupLayoutBounds(csmInt32 usingClipCount) 
         {
             // マスクの制限数の警告を出す
             csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-            CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : %d"
-                , usingClipCount - useClippingMaskMaxCount, _renderTextureCount, usingClipCount);
+            CubismLogError("not supported mask count : %d\n[Details] render texture count : %d\n, mask count : %d"
+                , count, _renderTextureCount, usingClipCount);
         }
 
         // この場合は一つのマスクターゲットを毎回クリアして使用する
@@ -572,7 +572,7 @@ void CubismClippingManager_Cocos2dx::SetupLayoutBounds(csmInt32 usingClipCount) 
                     cc->_bufferIndex = renderTextureNo;
                 }
             }
-            else if (layoutCount <= 9)
+            else if (layoutCount <= layoutCountMaxValue)
             {
                 //9分割して使う
                 for (csmInt32 i = 0; i < layoutCount; i++)

--- a/src/Rendering/Metal/CubismRenderer_Metal.mm
+++ b/src/Rendering/Metal/CubismRenderer_Metal.mm
@@ -464,8 +464,8 @@ void CubismClippingManager_Metal::SetupLayoutBounds(csmInt32 usingClipCount) con
         {
             // マスクの制限数の警告を出す
             csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-            CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : %d"
-                , usingClipCount - useClippingMaskMaxCount, _renderTextureCount, usingClipCount);
+            CubismLogError("not supported mask count : %d\n[Details] render texture count : %d\n, mask count : %d"
+                , count, _renderTextureCount, usingClipCount);
         }
 
         // この場合は一つのマスクターゲットを毎回クリアして使用する
@@ -562,7 +562,7 @@ void CubismClippingManager_Metal::SetupLayoutBounds(csmInt32 usingClipCount) con
                     cc->_bufferIndex = renderTextureNo;
                 }
             }
-            else if (layoutCount <= 9)
+            else if (layoutCount <= layoutCountMaxValue)
             {
                 //9分割して使う
                 for (csmInt32 i = 0; i < layoutCount; i++)

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -452,8 +452,8 @@ void CubismClippingManager_OpenGLES2::SetupLayoutBounds(csmInt32 usingClipCount)
         {
             // マスクの制限数の警告を出す
             csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-            CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : "
-                , usingClipCount - useClippingMaskMaxCount, _renderTextureCount, usingClipCount);
+            CubismLogError("not supported mask count : %d\n[Details] render texture count : %d\n, mask count : %d"
+                , count, _renderTextureCount, usingClipCount);
         }
 
         // この場合は一つのマスクターゲットを毎回クリアして使用する
@@ -550,7 +550,7 @@ void CubismClippingManager_OpenGLES2::SetupLayoutBounds(csmInt32 usingClipCount)
                     cc->_bufferIndex = renderTextureNo;
                 }
             }
-            else if (layoutCount <= 9)
+            else if (layoutCount <= layoutCountMaxValue)
             {
                 //9分割して使う
                 for (csmInt32 i = 0; i < layoutCount; i++)


### PR DESCRIPTION
### Fixed

* Fix a bug that caused double and triple buffering to be disabled on DirectX systems due to multiple render textures in 4-r.6.
* Fix the condition of splitting the mask buffer according to the number of masks used to be in accordance with the specification.
* Fix some problems related to Cubism Core.
  * See `CHANGELOG.md` in Core.