### PR TITLE
Update to Cubism 4 SDK for Native R7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.7] - 2023-05-25
+
+### Added
+
+* Add some function for checking consistency of MOC3.
+  * Add the function of checking consistency on reviving a MOC3. (`CubismMoc::Create`)
+  * Add the function of checking consistency from unrevived MOC3. (`CubismMoc::HasMocConsistencyFromUnrevivedMoc`)
+* Add some functions to change Multiply and Screen colors on a per part basis.
+
+### Changed
+
+* Change access specifier for `CubismExpressionMotion`.
+* Change to get opacity according to the current time of the motion.
+
+
 ## [4-r.6.2] - 2023-03-16
 
 ### Fixed
@@ -261,6 +276,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[4-r.7]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6.2...4-r.7
 [4-r.6.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6...4-r.6.1
 [4-r.6]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.5.1...4-r.6

--- a/src/Model/CubismMoc.hpp
+++ b/src/Model/CubismMoc.hpp
@@ -29,8 +29,9 @@ public:
      *
      * @param[in]   mocBytes    Mocファイルのバッファ
      * @param[in]   size        バッファのサイズ
+     * @param[in]   shouldCheckMocConsistency MOCの整合性チェックフラグ(初期値 : false)
      */
-    static CubismMoc* Create(const csmByte* mocBytes, csmSizeInt size);
+    static CubismMoc* Create(const csmByte* mocBytes, csmSizeInt size, csmBool shouldCheckMocConsistency = false);
 
     /**
      * @brief Mocデータを削除
@@ -84,6 +85,16 @@ public:
      * @return  '1' if Moc is valid; '0' otherwise.
      */
     static csmBool HasMocConsistency(void* address, const csmUint32 size);
+
+    /**
+     * @brief Checks consistency of a moc.
+     *
+     * @param  mocBytes Mocファイルのバッファ
+     * @param  size     バッファのサイズ
+     *
+     * @return  'true' if Moc is valid; 'false' otherwise.
+     */
+    static csmBool HasMocConsistencyFromUnrevivedMoc(const csmByte* mocBytes, csmSizeInt size);
 
 private:
     /**

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -86,6 +86,35 @@ public:
     };  // DrawableCullingData
 
     /**
+     * @brief テクスチャの色をRGBAで扱うための構造体
+    */
+    struct PartColorData
+    {
+        /**
+         * @brief   コンストラクタ
+         */
+        PartColorData()
+            : IsOverwritten(false)
+            , Color() {};
+
+        /**
+         * @brief   コンストラクタ
+         */
+        PartColorData(csmBool isOverwritten, Rendering::CubismRenderer::CubismTextureColor color)
+            : IsOverwritten(isOverwritten)
+            , Color(color) {};
+
+        /**
+         * @brief   デストラクタ
+         */
+        virtual ~PartColorData() {};
+
+        csmBool IsOverwritten;
+        Rendering::CubismRenderer::CubismTextureColor Color;
+
+    };  // PartColorData
+
+    /**
      * @brief モデルのパラメータの更新
      *
      * モデルのパラメータを更新する。
@@ -146,6 +175,16 @@ public:
      * @return  パーツのインデックス
      */
     csmInt32    GetPartIndex(CubismIdHandle partId);
+
+    /**
+     * @brief パーツのIDの取得
+     *
+     * パーツのIDを取得する。
+     *
+     * @param[in]   partIndex  パーツのIndex
+     * @return  パーツのID
+     */
+    CubismIdHandle    GetPartId(csmUint32 partIndex);
 
     /**
      * @brief パーツの個数の取得
@@ -644,34 +683,64 @@ public:
     void    SaveParameters();
 
     /**
-     * @brief   リストから乗算色を取得する
+     * @brief   drawableの乗算色を取得する
      */
     Rendering::CubismRenderer::CubismTextureColor GetMultiplyColor(csmInt32 drawableIndex) const;
 
     /**
-     * @brief   リストからスクリーン色を取得する
+     * @brief   drawableのスクリーン色を取得する
      */
     Rendering::CubismRenderer::CubismTextureColor GetScreenColor(csmInt32 drawableIndex) const;
 
     /**
-     * @brief   乗算色を設定する
+     * @brief   drawableの乗算色を設定する
      */
     void SetMultiplyColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
 
     /**
-     * @brief   乗算色を設定する
+     * @brief   drawableの乗算色を設定する
      */
     void SetMultiplyColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
 
     /**
-     * @brief   スクリーン色を設定する
+     * @brief   drawableのスクリーン色を設定する
      */
     void SetScreenColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
 
     /**
-     * @brief   スクリーン色を設定する
+     * @brief   drawableのスクリーン色を設定する
      */
     void SetScreenColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * @brief   partの乗算色を取得する
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetPartMultiplyColor(csmInt32 partIndex) const;
+
+    /**
+     * @brief   partの乗算色を取得する
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetPartScreenColor(csmInt32 partIndex) const;
+
+    /**
+     * @brief   partのスクリーン色を設定する
+     */
+    void SetPartMultiplyColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * @brief   partの乗算色を設定する
+     */
+    void SetPartMultiplyColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * @brief   partのスクリーン色を設定する
+     */
+    void SetPartScreenColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * @brief   partのスクリーン色を設定する
+     */
+    void SetPartScreenColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
 
     /**
      * @brief SDKからモデル全体の乗算色を上書きするか。
@@ -730,6 +799,34 @@ public:
     void SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
 
     /**
+     * @brief SDKからpartの乗算色を上書きするか。
+     *
+     * @retval  true    ->  SDK上の色情報を使用
+     * @retval  false   ->  モデルの色情報を使用
+     */
+    csmBool GetOverwriteColorForPartMultiplyColors(csmInt32 partIndex) const;
+
+    /**
+     * @brief SDKからpartのスクリーン色を上書きするか。
+     *
+     * @retval  true    ->  SDK上の色情報を使用
+     * @retval  false   ->  モデルの色情報を使用
+     */
+    csmBool GetOverwriteColorForPartScreenColors(csmInt32 partIndex) const;
+
+    /**
+     * @brief SDKからpartの乗算色を上書きするかをセットする
+     *        SDK上の色情報を使うならtrue、モデルの色情報を使うならfalse
+     */
+    void SetOverwriteColorForPartMultiplyColors(csmUint32 partIndex, csmBool value);
+
+    /**
+     * @brief SDKからpartのスクリーン色を上書きするかをセットする
+     *        SDK上の色情報を使うならtrue、モデルの色情報を使うならfalse
+     */
+    void SetOverwriteColorForPartScreenColors(csmUint32 partIndex, csmBool value);
+
+    /**
      * @brief Drawableのカリング情報の取得
      *
      * Drawableのカリング情報を取得する。
@@ -772,6 +869,20 @@ public:
      */
     void SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value);
 
+    /**
+     * @brief モデルの不透明度を取得する
+     *
+     * @return 不透明度の値
+     */
+    csmFloat32 GetModelOpacity();
+
+    /**
+     * @brief モデルの不透明度を設定する
+     *
+     * @param[in] value 不透明度の値
+     */
+    void SetModelOpacity(csmFloat32 value);
+
     Core::csmModel*     GetModel() const;
 
 private:
@@ -802,6 +913,24 @@ private:
      */
     void Initialize();
 
+    /**
+     * @brief partのOverwriteColor Set関数
+     */
+    void SetPartColor(
+        csmUint32 partIndex,
+        csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a,
+        csmVector<PartColorData>& partColors,
+        csmVector <DrawableColorData>& drawableColors);
+
+    /**
+     * @brief partのOverwriteFlag Set関数
+     */
+    void SetOverwriteColorForPartColors(
+        csmUint32 partIndex,
+        csmBool value,
+        csmVector<CubismModel::PartColorData>& partColors,
+        csmVector <CubismModel::DrawableColorData>& drawableColors);
+
     csmMap<csmInt32, csmFloat32>        _notExistPartOpacities;             ///< 存在していないパーツの不透明度のリスト
     csmMap<CubismIdHandle, csmInt32>   _notExistPartId;                    ///< 存在していないパーツIDのリスト
 
@@ -818,12 +947,17 @@ private:
 
     csmFloat32*         _partOpacities;                         ///< パーツの不透明度のリスト
 
+    csmFloat32 _modelOpacity;                         ///< モデルの不透明度
+
     csmVector<CubismIdHandle> _parameterIds;
     csmVector<CubismIdHandle> _partIds;
     csmVector<CubismIdHandle> _drawableIds;
-    csmVector<DrawableColorData> _userScreenColors; ///< 乗算色の配列
-    csmVector<DrawableColorData> _userMultiplyColors; ///< スクリーン色の配列
+    csmVector<DrawableColorData> _userScreenColors; ///< Drawable 乗算色の配列
+    csmVector<DrawableColorData> _userMultiplyColors; ///< Drawable スクリーン色の配列
     csmVector<DrawableCullingData> _userCullings; ///< カリング設定の配列
+    csmVector<PartColorData> _userPartScreenColors; ///< Part 乗算色の配列
+    csmVector<PartColorData> _userPartMultiplyColors; ///< Part スクリーン色の配列
+    csmVector<csmVector<csmUint32> > _partChildDrawables; ///< Partの子DrawableIndexの配列
     csmBool _isOverwrittenModelMultiplyColors; ///< 乗算色を全て上書きするか？
     csmBool _isOverwrittenModelScreenColors; ///< スクリーン色を全て上書きするか？
     csmBool _isOverwrittenCullings; ///< モデルのカリング設定をすべて上書きするか？

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -33,6 +33,7 @@ CubismUserModel::CubismUserModel()
     , _accelerationX(0.0f)
     , _accelerationY(0.0f)
     , _accelerationZ(0.0f)
+    , _mocConsistency(false)
     , _debugMode(false)
     , _renderer(NULL)
 {
@@ -76,9 +77,9 @@ void CubismUserModel::SetAcceleration(csmFloat32 x, csmFloat32 y, csmFloat32 z)
     _accelerationZ = z;
 }
 
-void CubismUserModel::LoadModel(const csmByte* buffer, csmSizeInt size)
+void CubismUserModel::LoadModel(const csmByte* buffer, csmSizeInt size, csmBool shouldCheckMocConsistency)
 {
-    _moc = CubismMoc::Create(buffer, size);
+    _moc = CubismMoc::Create(buffer, size, shouldCheckMocConsistency);
 
     if (_moc == NULL)
     {

--- a/src/Model/CubismUserModel.hpp
+++ b/src/Model/CubismUserModel.hpp
@@ -137,8 +137,9 @@ public:
      *
      * @param[in]   buffer  moc3ファイルが読み込まれているバッファ
      * @param[in]   size    バッファのサイズ
+     * @param[in]   shouldCheckMocConsistency MOCの整合性チェックフラグ(初期値 : false)
      */
-    virtual void            LoadModel(const csmByte* buffer, csmSizeInt size);
+    virtual void            LoadModel(const csmByte* buffer, csmSizeInt size, csmBool shouldCheckMocConsistency = false);
 
     /**
      * @brief モーションデータの読み込み
@@ -287,6 +288,7 @@ protected:
     csmFloat32  _accelerationX;                 ///< X軸方向の加速度
     csmFloat32  _accelerationY;                 ///< Y軸方向の加速度
     csmFloat32  _accelerationZ;                 ///< Z軸方向の加速度
+    csmBool     _mocConsistency;                ///< MOC3整合性検証するかどうか
     csmBool     _debugMode;                     ///< デバッグモードかどうか
 
 private:

--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -143,22 +143,22 @@ ACubismMotion::FinishedMotionCallback ACubismMotion::GetFinishedMotionHandler()
     return this->_onFinishedMotion;
 }
 
-csmBool ACubismMotion::IsExistOpacity() const
+csmBool ACubismMotion::IsExistModelOpacity() const
 {
     return false;
 }
 
-csmInt32 ACubismMotion::GetOpacityIndex() const
+csmInt32 ACubismMotion::GetModelOpacityIndex() const
 {
     return -1;
 }
 
-CubismIdHandle ACubismMotion::GetOpacityId(csmInt32 index)
+CubismIdHandle ACubismMotion::GetModelOpacityId(csmInt32 index)
 {
     return NULL;
 }
 
-csmFloat32 ACubismMotion::GetOpacityValue(csmFloat32 motionTimeSeconds) const
+csmFloat32 ACubismMotion::GetModelOpacityValue() const
 {
     return 1.0f;
 }

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -180,12 +180,12 @@ public:
     FinishedMotionCallback GetFinishedMotionHandler();
 
     /**
-    * @brief        透明度のカーブが存在するかどうかを確認する
-    *
-    * @retval       true  -> キーが存在する
-    * @retval       false -> キーが存在しない
-    */
-    virtual csmBool IsExistOpacity() const;
+     * @brief        透明度のカーブが存在するかどうかを確認する
+     *
+     * @retval       true  -> キーが存在する
+     * @retval       false -> キーが存在しない
+     */
+    virtual csmBool IsExistModelOpacity() const;
 
     /**
     * @brief 透明度のカーブのインデックスを返す
@@ -193,24 +193,28 @@ public:
     *
     * @return  success：透明度のカーブのインデックス
     */
-    virtual csmInt32 GetOpacityIndex() const;
+    virtual csmInt32 GetModelOpacityIndex() const;
 
     /**
-    * @brief 透明度のIdを返す
-    *
-    *
-    * @return  success：透明度のId
-    */
-    virtual CubismIdHandle GetOpacityId(csmInt32 index);
+     * @brief 透明度のIdを返す
+     *
+     *
+     * @return  success：透明度のId
+     */
+    virtual CubismIdHandle GetModelOpacityId(csmInt32 index);
 
+protected:
     /**
-    * @brief 指定時間の透明度の値を返す
-    *
-    * @param[in]   motionTimeSeconds        現在の再生時間[秒]
-    *
-    * @return  success：モーションの当該時間におけるOpacityの値
-    */
-    virtual csmFloat32 GetOpacityValue(csmFloat32 motionTimeSeconds) const;
+     *
+     * @brief 指定時間の透明度の値を返す
+     *
+     * @param[in]   motionTimeSeconds        現在の再生時間[秒]
+     *
+     * @return  success：モーションの当該時間におけるOpacityの値
+     *
+     * @note  更新後の値を取るにはUpdateParameters() の後に呼び出す。
+     */
+    virtual csmFloat32 GetModelOpacityValue() const;
 
 private:
     // Prevention of copy Constructor

--- a/src/Motion/CubismExpressionMotion.cpp
+++ b/src/Motion/CubismExpressionMotion.cpp
@@ -33,22 +33,54 @@ CubismExpressionMotion::~CubismExpressionMotion()
 CubismExpressionMotion* CubismExpressionMotion::Create(const csmByte* buffer, csmSizeInt size)
 {
     CubismExpressionMotion* expression = CSM_NEW CubismExpressionMotion();
+    expression->Parse(buffer, size);
+    return expression;
+}
 
+void CubismExpressionMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 weight, CubismMotionQueueEntry* motionQueueEntry)
+{
+    for (csmUint32 i = 0; i < _parameters.GetSize(); ++i)
+    {
+        ExpressionParameter& parameter = _parameters[i];
+
+        switch (parameter.BlendType)
+        {
+        case ExpressionBlendType_Add: {
+            model->AddParameterValue(parameter.ParameterId, parameter.Value, weight);            // 相対変化 加算
+            break;
+        }
+        case ExpressionBlendType_Multiply: {
+            model->MultiplyParameterValue(parameter.ParameterId, parameter.Value, weight);       // 相対変化 乗算
+            break;
+        }
+        case ExpressionBlendType_Overwrite: {
+            model->SetParameterValue(parameter.ParameterId, parameter.Value, weight);            // 絶対変化 上書き
+            break;
+        }
+        default:
+            // 仕様にない値を設定したときは既に加算モードになっている
+            break;
+        }
+    }
+}
+
+void CubismExpressionMotion::Parse(const csmByte* buffer, csmSizeInt size)
+{
     Utils::CubismJson* json = Utils::CubismJson::Create(buffer, size);
     Utils::Value& root = json->GetRoot();
 
-    expression->SetFadeInTime(root[ExpressionKeyFadeIn].ToFloat(DefaultFadeTime));   // フェードイン
-    expression->SetFadeOutTime(root[ExpressionKeyFadeOut].ToFloat(DefaultFadeTime)); // フェードアウト
+    SetFadeInTime(root[ExpressionKeyFadeIn].ToFloat(DefaultFadeTime));   // フェードイン
+    SetFadeOutTime(root[ExpressionKeyFadeOut].ToFloat(DefaultFadeTime)); // フェードアウト
 
     // 各パラメータについて
     const csmInt32 parameterCount = root[ExpressionKeyParameters].GetSize();
-    expression->_parameters.PrepareCapacity(parameterCount);
+    _parameters.PrepareCapacity(parameterCount);
 
     for (csmInt32 i = 0; i < parameterCount; ++i)
     {
         Utils::Value& param = root[ExpressionKeyParameters][i];
         const CubismIdHandle parameterId = CubismFramework::GetIdManager()->GetId(param[ExpressionKeyId].GetRawString()); // パラメータID
-        const csmFloat32 value = static_cast<csmFloat32>(param[ExpressionKeyValue].ToFloat());   // 値
+        const csmFloat32 value = static_cast<csmFloat32>(param[ExpressionKeyValue].ToFloat());                            // 値
 
         // 計算方法の設定
         ExpressionBlendType blendType;
@@ -78,39 +110,10 @@ CubismExpressionMotion* CubismExpressionMotion::Create(const csmByte* buffer, cs
         item.BlendType   = blendType;
         item.Value       = value;
 
-        expression->_parameters.PushBack(item);
+        _parameters.PushBack(item);
     }
 
-    Utils::CubismJson::Delete(json); // JSONデータは不要になったら削除する
-
-    return expression;
-}
-
-void CubismExpressionMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 weight, CubismMotionQueueEntry* motionQueueEntry)
-{
-    for (csmUint32 i = 0; i < _parameters.GetSize(); ++i)
-    {
-        ExpressionParameter& parameter = _parameters[i];
-
-        switch (parameter.BlendType)
-        {
-        case ExpressionBlendType_Add: {
-            model->AddParameterValue(parameter.ParameterId, parameter.Value, weight);            // 相対変化 加算
-            break;
-        }
-        case ExpressionBlendType_Multiply: {
-            model->MultiplyParameterValue(parameter.ParameterId, parameter.Value, weight);       // 相対変化 乗算
-            break;
-        }
-        case ExpressionBlendType_Overwrite: {
-            model->SetParameterValue(parameter.ParameterId, parameter.Value, weight);            // 絶対変化 上書き
-            break;
-        }
-        default:
-            // 仕様にない値を設定したときは既に加算モードになっている
-            break;
-        }
-    }
+    Utils::CubismJson::Delete(json);// JSONデータは不要になったら削除する
 }
 
 }}}

--- a/src/Motion/CubismExpressionMotion.hpp
+++ b/src/Motion/CubismExpressionMotion.hpp
@@ -20,7 +20,7 @@ namespace Live2D { namespace Cubism { namespace Framework {
  */
 class CubismExpressionMotion : public ACubismMotion
 {
-private:
+public:
     /**
      * @brief 表情パラメータ値の計算方式
      *
@@ -32,7 +32,6 @@ private:
         ExpressionBlendType_Overwrite = 2   ///< 上書き
     };
 
-public:
     /**
      * @brief 表情のパラメータ情報
      *
@@ -68,9 +67,19 @@ public:
     */
     virtual void DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 weight, CubismMotionQueueEntry* motionQueueEntry);
 
-private:
+protected:
     CubismExpressionMotion();
     virtual ~CubismExpressionMotion();
+
+    /**
+     * @brief exp3.jsonのパース
+     *
+     * exp3.jsonをパースする。
+     *
+     * @param[in]   exp3Json    exp3.jsonが読み込まれているバッファ
+     * @param[in]   size        バッファのサイズ
+     */
+    void Parse(const csmByte* exp3Json, csmSizeInt size);
 
     csmVector<ExpressionParameter> _parameters;         ///< 表情のパラメータ情報リスト
 };

--- a/src/Motion/CubismMotion.hpp
+++ b/src/Motion/CubismMotion.hpp
@@ -172,7 +172,7 @@ public:
     * @retval       true  -> キーが存在する
     * @retval       false -> キーが存在しない
     */
-    csmBool IsExistOpacity() const;
+    csmBool IsExistModelOpacity() const;
 
     /**
     * @brief 透明度のカーブのインデックスを返す
@@ -180,7 +180,7 @@ public:
     *
     * @return  success：透明度のカーブのインデックス
     */
-    csmInt32 GetOpacityIndex() const;
+    csmInt32 GetModelOpacityIndex() const;
 
     /**
     * @brief 透明度のIdを返す
@@ -188,16 +188,20 @@ public:
     *
     * @return  success：透明度のId
     */
-    CubismIdHandle GetOpacityId(csmInt32 index);
+    CubismIdHandle GetModelOpacityId(csmInt32 index);
 
+protected:
     /**
-    * @brief 指定時間の透明度の値を返す
-    *
-    * @param[in]   motionTimeSeconds        現在の再生時間[秒]
-    *
-    * @return  success：モーションの当該時間におけるOpacityの値
-    */
-    csmFloat32 GetOpacityValue(csmFloat32 motionTimeSeconds) const;
+     *
+     * @brief 透明度の値を返す
+     *
+     * @param[in]   motionTimeSeconds        現在の再生時間[秒]（未利用）
+     *
+     * @return  success：モーションの現在時間のOpacityの値
+     *
+     * @note  更新後の値を取るにはUpdateParameters() の後に呼び出す。
+     */
+    csmFloat32 GetModelOpacityValue() const;
 
 private:
     /**
@@ -241,6 +245,9 @@ private:
 
     CubismIdHandle _modelCurveIdEyeBlink;               ///< モデルが持つ自動まばたき用パラメータIDのハンドル。  モデルとモーションを対応付ける。
     CubismIdHandle _modelCurveIdLipSync;                ///< モデルが持つリップシンク用パラメータIDのハンドル。  モデルとモーションを対応付ける。
+    CubismIdHandle _modelCurveIdOpacity;                ///< モデルが持つ不透明度用パラメータIDのハンドル。  モデルとモーションを対応付ける。
+
+    csmFloat32 _modelOpacity; ///< モーションから取得した不透明度
 };
 
 }}}

--- a/src/Motion/CubismMotionManager.cpp
+++ b/src/Motion/CubismMotionManager.cpp
@@ -44,11 +44,11 @@ CubismMotionQueueEntryHandle CubismMotionManager::StartMotionPriority(ACubismMot
     return CubismMotionQueueManager::StartMotion(motion, autoDelete, _userTimeSeconds);
 }
 
-csmBool CubismMotionManager::UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds, csmFloat32* opacity)
+csmBool CubismMotionManager::UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds)
 {
     _userTimeSeconds += deltaTimeSeconds;
 
-    const csmBool updated = CubismMotionQueueManager::DoUpdateMotion(model, _userTimeSeconds, opacity);
+    const csmBool updated = CubismMotionQueueManager::DoUpdateMotion(model, _userTimeSeconds);
 
     if (IsFinished())
     {

--- a/src/Motion/CubismMotionManager.hpp
+++ b/src/Motion/CubismMotionManager.hpp
@@ -85,7 +85,7 @@ public:
      * @retval  true    更新されている
      * @retval  false   更新されていない
      */
-    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds, csmFloat32* opacity = NULL);
+    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds);
 
     /**
      * @brief モーションの予約

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -61,7 +61,7 @@ CubismMotionQueueEntryHandle CubismMotionQueueManager::StartMotion(ACubismMotion
     return motionQueueEntry->_motionQueueEntryHandle;
 }
 
-csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32* opacity)
+csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds)
 {
     csmBool updated = false;
 
@@ -91,12 +91,6 @@ csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 
         // ------ 値を反映する ------
         motion->UpdateParameters(model, motionQueueEntry, userTimeSeconds);
         updated = true;
-
-        // ------ 不透明度の値が存在すれば反映する ------
-        if (opacity)
-        {
-            *opacity = motion->GetOpacityValue(userTimeSeconds - motionQueueEntry->GetStartTime());
-        }
 
         // ------ ユーザトリガーイベントを検査する ----
         const csmVector<const csmString*>& firedList = motion->GetFiredEvent(

--- a/src/Motion/CubismMotionQueueManager.hpp
+++ b/src/Motion/CubismMotionQueueManager.hpp
@@ -131,11 +131,10 @@ protected:
     *
     * @param[in]   model   対象のモデル
     * @param[in]   userTimeSeconds   デルタ時間の積算値[秒]
-    * @param[in][out]   opacity 透明度の値（Nullable）
     * @retval  true    モデルへパラメータ値の反映あり
     * @retval  false   モデルへパラメータ値の反映なし(モーションの変化なし)
     */
-    virtual csmBool     DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32* opacity = NULL);
+    virtual csmBool     DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds);
 
 
     csmFloat32 _userTimeSeconds;        ///< デルタ時間の積算値[秒]


### PR DESCRIPTION
### Added

* Add some function for checking consistency of MOC3.
  * Add the function of checking consistency on reviving a MOC3. (`CubismMoc::Create`)
  * Add the function of checking consistency from unrevived MOC3. (`CubismMoc::HasMocConsistencyFromUnrevivedMoc`)
* Add some functions to change Multiply and Screen colors on a per part basis.

### Changed

* Change access specifier for `CubismExpressionMotion`.
* Change to get opacity according to the current time of the motion.