### PR TITLE
Update to Cubism 5 SDK for Native R1 beta1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{cpp,hpp}]
+[*.{cpp,hpp,tpp}]
 indent_size = 4
 charset = utf-8-bom
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.1-beta.1] - 2023-08-17
+
+### Added
+
+* Add the function to get the ID of a given parameter.(`CubismModel::GetParameterId`)
+* Add the `CubismExpressionMotionManager` class.
+* Add a Renderer for Vulkan API in Windows.
+
+### Changed
+
+* Unify Offscreen drawing-related terminology with `OffscreenSurface`.
+* Change comment guidelines for headers in the `Framework` directory.
+
+### Fixed
+
+* Fix a bug that caused cocos2d-x culling to not be performed correctly.
+* Fix the structure of the class in renderer.
+* Separate the high precision mask process from the clipping mask setup process.
+* Separate shader class from CubismRenderer files for Cocos2d-x, Metal, OpenGL.
+* Fix Metal rendering results on macOS to be similar to OpenGL.
+  * If you want to apply the previous Metal rendering results, change `mipFilter` in `MTLSamplerDescriptor` from `MTLSamplerMipFilterLinear` to `MTLSamplerMipFilterNotMipmapped`.
+* Fix a bug that the value applied by multiply was not appropriate during expression transitions.
+
+### Removed
+
+* Remove several arguments of `DrawMesh` function.
+
+
 ## [4-r.7] - 2023-05-25
 
 ### Added
@@ -18,7 +46,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Change access specifier for `CubismExpressionMotion`.
 * Change to get opacity according to the current time of the motion.
-
 
 ## [4-r.6.2] - 2023-03-16
 
@@ -276,6 +303,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[5-r.1-beta.1]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.7...5-r.1-beta.1
 [4-r.7]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6.2...4-r.7
 [4-r.6.2]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.6...4-r.6.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 # Cubism Native Framework
 
-Live2D Cubism 4 Editor で出力したモデルをアプリケーションで利用するためのフレームワークです。
+Live2D Cubism Editor で出力したモデルをアプリケーションで利用するためのフレームワークです。
 
 モデルを表示、操作するための各種機能を提供します。
 モデルをロードするには Cubism Core ライブラリと組み合わせて使用します。
@@ -13,6 +13,13 @@ Live2D Cubism 4 Editor で出力したモデルをアプリケーションで利
 ## ライセンス
 
 本フレームワークを使用する前に、[ライセンス](LICENSE.md)をご確認ください。
+
+
+## Cubism 5新機能や過去バージョンとの互換性について
+
+本 SDK はCubism 5に対応した製品です。  
+Cubism 5 Editorに搭載された新機能のSDK対応については [こちら](https://docs.live2d.com/cubism-sdk-manual/cubism-5-new-functions/)をご確認ください。  
+過去バージョンのCubism SDKとの互換性については [こちら](https://docs.live2d.com/cubism-sdk-manual/compatibility-with-cubism-5/)をご確認ください。
 
 
 ## コンポーネント

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Cubism Native Framework
 
-This is a framework for using models output by Live2D Cubism 4 Editor in applications.
+This is a framework for using models output by Live2D Cubism Editor in applications.
 
 It provides various functions for displaying and manipulating the model.
 It is used in conjunction with the Cubism Core library to load the model.
@@ -13,6 +13,18 @@ It is used in conjunction with the Cubism Core library to load the model.
 ## License
 
 Please check the [license](LICENSE.md) before using this framework.
+
+## Translation
+
+Comments of the source codes are being translated into English.
+Please [Go Here](./TRANSLATION.md) for the status.
+
+
+## Compatibility with Cubism 5 new features and previous Cubism SDK versions
+
+This SDK is compatible with Cubism 5.  
+For SDK compatibility with new features in Cubism 5 Editor, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/cubism-5-new-functions/).  
+For compatibility with previous versions of Cubism SDK, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/compatibility-with-cubism-5/).
 
 
 ## Components

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,117 @@
+# Regarding the Translation
+
+Comments of the source codes are being translated into English.
+
+Please see the table below for progress.
+
+---
+
+| Module | Path | Status |
+| ---: | :--- | :---: |
+| Framework Systems | ./src/ | Done |
+| Effect | ./src/Effect/ | - |
+| Id | ./src/Id/ | - |
+| Math | ./src/Math/ | - |
+| Model | ./src/Model/ | - |
+| Physics | ./src/Physics/ | - |
+| Utils | ./src/Utils/ | - |
+| Rendering | ./src/Rendering/ | - |
+
+
+## Framework Systems
+
+| File | Completion Date |
+| :--- | :--- |
+| ./CubismCdiJson.hpp | 2023-05-23 |
+| ./CubismDefaultParameterId.hpp | 2023-05-23 |
+| ./CubismFramework.hpp | 2023-05-23 |
+| ./CubismFrameworkConfig.hpp | 2023-05-23 |
+| ./CubismJsonHolder.hpp | 2023-05-23 |
+| ./CubismModelSettingJson.hpp | 2023-05-23 |
+| ./ICubismAllocator.hpp | 2023-05-23 |
+| ./ICubismModelSetting.hpp | 2023-05-23 |
+| ./Live2DCubismCore.hpp | 2023-05-23 |
+
+## Effect
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Effect/CubismBreath.hpp | - |
+| ./Effect/CubismEyeBlink.hpp | - |
+| ./Effect/CubismPose.hpp | - |
+
+## Id
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Id/CubismId.hpp | - |
+| ./Id/CubismIdManager.hpp | - |
+
+## Math
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Math/CubismMath.hpp | - |
+| ./Math/CubismMatrix44.hpp | - |
+| ./Math/CubismModelMatrix.hpp | - |
+| ./Math/CubismTargetPoint.hpp | - |
+| ./Math/CubismVector2.hpp | - |
+| ./Math/CubismViewMatrix.hpp | - |
+
+## Model
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Model/CubismMoc.hpp | - |
+| ./Model/CubismModel.hpp | - |
+| ./Model/CubismModelUserData.hpp | - |
+| ./Model/CubismModelUserDataJson.hpp | - |
+| ./Model/CubismUserModel.hpp | - |
+
+## Physics
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Physics/CubismPhysics.hpp | - |
+| ./Physics/CubismPhysicsInternal.hpp | - |
+| ./Physics/CubismPhysicsJson.hpp | - |
+
+## Utils
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Utils/CubismDebug.hpp | - |
+| ./Utils/CubismJson.hpp | - |
+| ./Utils/CubismString.hpp | - |
+
+## Rendering
+
+| File | Completion Date |
+| :--- | :--- |
+| ./Rendering/CubismRenderer.hpp | - |
+| ./Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.hpp | - |
+| ./Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp | - |
+| ./Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp | - |
+| ./Rendering/D3D9/CubismNativeInclude_D3D9.hpp | - |
+| ./Rendering/D3D9/CubismOffscreenSurface_D3D9.hpp | - |
+| ./Rendering/D3D9/CubismRenderer_D3D9.hpp | - |
+| ./Rendering/D3D9/CubismRenderState_D3D9.hpp | - |
+| ./Rendering/D3D9/CubismShader_D3D9.hpp | - |
+| ./Rendering/D3D9/CubismType_D3D9.hpp | - |
+| ./Rendering/D3D11/CubismNativeInclude_D3D11.hpp | - |
+| ./Rendering/D3D11/CubismOffscreenSurface_D3D11.hpp | - |
+| ./Rendering/D3D11/CubismRenderer_D3D11.hpp | - |
+| ./Rendering/D3D11/CubismRenderState_D3D11.hpp | - |
+| ./Rendering/D3D11/CubismShader_D3D11.hpp | - |
+| ./Rendering/D3D11/CubismType_D3D11.hpp | - |
+| ./Rendering/Metal/CubismCommandBuffer_Metal.hpp | - |
+| ./Rendering/Metal/CubismOffscreenSurface_Metal.hpp | - |
+| ./Rendering/Metal/CubismRenderer_Metal.hpp | - |
+| ./Rendering/Metal/CubismRenderingInstanceSingleton_Metal.h | - |
+| ./Rendering/Metal/MetalShaderTypes.h | - |
+| ./Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp | - |
+| ./Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp | - |
+
+---
+
+ⒸLive2D

--- a/src/CubismCdiJson.hpp
+++ b/src/CubismCdiJson.hpp
@@ -13,77 +13,139 @@
 //--------- LIVE2D NAMESPACE ------------
 namespace Live2D {  namespace Cubism {  namespace Framework {
 
+/**
+ * Handles the Display Information File.
+ */
 class CubismCdiJson : public CubismJsonHolder
 {
 public:
     /**
-     * @brief コンストラクタ
+     * Constructor<br>
+     * Loads the Display Information File.
      *
-     * コンストラクタ。
-     *
-     * @param[in]   buffer  cdi3.jsonが読み込まれているバッファ
-     * @param[in]   size    バッファのサイズ
+     * @param buffer Buffer that Display Settings File is loaded from.
+     * @param size Number of bytes in buffer
      */
     CubismCdiJson(const csmByte* buffer, csmSizeInt size);
 
     /**
-     * @brief デストラクタ
-     *
-     * デストラクタ。
-     */
+    　* Destructor
+    　*/
     virtual ~CubismCdiJson();
 
-    // Parameters
-
+    /**
+     * Returns the number of parameters.
+     *
+     * @return Number of parameters
+     */
     csmInt32 GetParametersCount();
 
+    /**
+     * Returns the ID of the parameter.
+     *
+     * @param index Index to the desired parameter
+     *
+     * @return ID of the parameter
+     */
     const csmChar* GetParametersId(csmInt32 index);
 
+    /**
+     * Returns the ID of the parameter group that the parameter belongs to.
+     *
+     * @param index Index to the desired parameter
+     *
+     * @return ID of the parameter group
+     */
     const csmChar* GetParametersGroupId(csmInt32 index);
 
+    /**
+     * Returns the name of the parameter.
+     *
+     * @param index Index to the desired parameter
+     *
+     * @return name of parameter
+     */
     const csmChar* GetParametersName(csmInt32 index);
 
-    // ParameterGroups
-
+    /**
+     * Returns the number of parameter groups.
+     *
+     * @return Number of parameter groups
+     */
     csmInt32 GetParameterGroupsCount();
 
+    /**
+     * Returns the ID of the parameter group.
+     *
+     * @param index Index to the desired parameter group
+     *
+     * @return ID of parameter group
+     */
     const csmChar* GetParameterGroupsId(csmInt32 index);
 
+    /**
+     * Returns the ID of the parameter group that the parameter group belongs to.
+     *
+     * @param index Index to the desired parameter group
+     *
+     * @return ID of the parameter group
+     */
     const csmChar* GetParameterGroupsGroupId(csmInt32 index);
 
+    /**
+     * Returns the name of the parameter group.
+     *
+     * @param index Index to the desired parameter group
+     *
+     * @return Name of the parameter group
+     */
     const csmChar* GetParameterGroupsName(csmInt32 index);
 
-    // Parts
-
+    /**
+     * Returns the number of parts.
+     *
+     * @return Number of parts
+     */
     csmInt32 GetPartsCount();
 
+    /**
+     * Returns the ID of the part.
+     *
+     * @param index Index to the desired part
+     *
+     * @return ID of the part
+     */
     const csmChar* GetPartsId(csmInt32 index);
 
+    /**
+     * Returns the name of the part.
+     *
+     * @param index Index to the desired part
+     *
+     * @return name of the part
+     */
     const csmChar* GetPartsName(csmInt32 index);
 
 
 private:
     /**
-     * @brief        パラメータのキーが存在するかどうかを確認する
+     * Returns whether the parameters exist in the Display Information File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if parameters exists; otherwise false.
      */
     csmBool IsExistParameters() const;
 
     /**
-     * @brief        パラメータグループのキーが存在するかどうかを確認する
+     * Returns whether parameter groups exist in the Display Information File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if parameters on paramter groups exist; otherwise false.
      */
     csmBool IsExistParameterGroups() const;
 
     /**
-     * @brief        パーツのキーが存在するかどうかを確認する
+     * Returns whether the parts exist in the Display Information File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if parts exist; otherwise false.
      */
     csmBool IsExistParts() const;
 };

--- a/src/CubismDefaultParameterId.hpp
+++ b/src/CubismDefaultParameterId.hpp
@@ -10,15 +10,15 @@
 #include "CubismFramework.hpp"
 
 /**
- * @brief パラメータIDのデフォルト値を保持する定数<br>
- *         デフォルト値の仕様は以下のマニュアルに基づく<br>
- *         https://docs.live2d.com/cubism-editor-manual/standard-parametor-list/
+ * Constants that hold the default values of parameter IDs.<br>
+ * See manual for details on each ID.<br>
+ * https://docs.live2d.com/en/cubism-editor-manual/standard-parametor-list/
  */
 
 //--------- LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace DefaultParameterId {
 
-// パーツID
+/* ID of Part */
 extern const csmChar* HitAreaPrefix;
 extern const csmChar* HitAreaHead;
 extern const csmChar* HitAreaBody;
@@ -27,7 +27,7 @@ extern const csmChar* PartsArmPrefix;
 extern const csmChar* PartsArmLPrefix;
 extern const csmChar* PartsArmRPrefix;
 
-// パラメータID
+/* ID of Parameter */
 extern const csmChar* ParamAngleX;
 extern const csmChar* ParamAngleY;
 extern const csmChar* ParamAngleZ;

--- a/src/CubismFramework.hpp
+++ b/src/CubismFramework.hpp
@@ -9,19 +9,19 @@
 
 
 //========================================================
-//  Live2D Cubism Coreライブラリをインクルード
+//  Include the Live2D Cubism Core header.
 //========================================================
 #include "Live2DCubismCore.hpp"
 
 
 //========================================================
-//  設定用ヘッダをインクルード
+//  Include the Framework Configurations header.
 //========================================================
 #include "CubismFrameworkConfig.hpp"
 
 
 //========================================================
-//  カスタムアロケータをインクルード
+//  Include the Custom Allocator header.
 //========================================================
 #include <new>
 #include "ICubismAllocator.hpp"
@@ -30,6 +30,10 @@
 #include <cstdlib>
 #endif
 
+
+//========================================================
+//  Configurations of Memory Allocator.
+//========================================================
 namespace Live2D { namespace Cubism { namespace Framework {
 
 class CubismAllocationTag
@@ -43,10 +47,11 @@ static CubismAllocationAlignedTag GloabalAlignedTag;
 
 }}}
 
+// Macros for memory allocation.
 #ifdef CSM_DEBUG_MEMORY_LEAKING
 
-// デバッグ用
-// メモリリークの検出や確保・解放の追跡を行う。
+// For debugging.
+// Tracks / Detects the memory leaking.
 
 void* operator new (Live2D::Cubism::Framework::csmSizeType size, Live2D::Cubism::Framework::CubismAllocationTag tag, const Live2D::Cubism::Framework::csmChar* fileName, Live2D::Cubism::Framework::csmInt32 lineNumber);
 void* operator new (Live2D::Cubism::Framework::csmSizeType size, Live2D::Cubism::Framework::csmUint32 alignment, Live2D::Cubism::Framework::CubismAllocationAlignedTag tag, const Live2D::Cubism::Framework::csmChar* fileName, Live2D::Cubism::Framework::csmInt32 lineNumber);
@@ -76,8 +81,8 @@ void CsmDelete(T* address, const Live2D::Cubism::Framework::csmChar* fileName, L
 
 #else
 
-// リリース用
-// 何も追跡しない。
+// For releasing.
+// Without Tracking / Detecting.
 
 void* operator new (Live2D::Cubism::Framework::csmSizeType size, Live2D::Cubism::Framework::CubismAllocationTag tag);
 void* operator new (Live2D::Cubism::Framework::csmSizeType size, Live2D::Cubism::Framework::csmUint32 alignment, Live2D::Cubism::Framework::CubismAllocationAlignedTag tag);
@@ -111,13 +116,13 @@ void CsmDelete(T* address)
 
 
 //========================================================
-//  アーキテクチャ用型定義をインクルード
+//  Include the definition of types for the each architectures.
 //========================================================
 #include "Type/CubismBasicType.hpp"
 
 
 //========================================================
-//  IDマネージャの前方宣言
+//  Forward Declaration of CubismIdManager.
 //========================================================
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -127,7 +132,7 @@ class CubismIdManager;
 
 
 //========================================================
-//  コンパイラに関する設定
+//  Compiler Setttings for buiding the Framework.
 //========================================================
 #ifdef _MSC_VER
 #pragma warning (disable : 4100)
@@ -139,14 +144,14 @@ class CubismIdManager;
 
 
 //========================================================
-//  検証マクロ
+//  Macros for validation.
 //========================================================
-/*
- * @brief  式が有効であることを保証する。
+/**
+ * Ensures that the expression is valid.
  *
- * @param  expression  検証する式。
- * @param  message     検証結果がfalseだった場合のログメッセージ。
- * @param  body        検証結果がfalseだった場合に実行する処理。
+ * @param expression Expression to be ensured
+ * @param message Message if the expression is invalid
+ * @param body Handler if the expression is invalid
  */
 #define CubismEnsure(expression, message, body)       \
 do                                              \
@@ -162,7 +167,7 @@ while (0);
 
 
 //========================================================
-//  名前空間のエイリアス
+//  Ailias of the Framework.
 //========================================================
 namespace Csm = Live2D::Cubism::Framework;
 
@@ -171,136 +176,230 @@ namespace Csm = Live2D::Cubism::Framework;
 namespace Live2D { namespace Cubism { namespace Framework {
 
 /**
- * @brief Framework内で使う定数の宣言
- *
+ * Constants.
  */
 namespace Constant {
-extern const csmInt32 VertexOffset; ///< メッシュ頂点のオフセット値
-extern const csmInt32 VertexStep;   ///< メッシュ頂点のステップ値
+/** Vertex offset of Drawable */
+extern const csmInt32 VertexOffset;
+
+/** Number of vertices in Drawable */
+extern const csmInt32 VertexStep;
 }
 
 /**
- * @brief Live2D Cubism Original Workflow SDKのエントリポイント<br>
- *         利用開始時はCubismFramework::Initialize()を呼び、CubismFramework::Dispose()で終了する。
+ * Entrypoint for the Live2D Cubism SDK
  *
+ * @see #StartUp()
+ * @see #Initialize()
+ * @see #Dispose()
+ * @see #CleanUp()
+ *
+ * @note At the start of use, call CubismFramework::StartUp() before calling CubismFramework::Initialize(). <br>
+ * At the end, call CubismFramework::Dispose() before calling CubismFramework::CleanUp().
  */
 class CubismFramework
 {
 public:
-
-    /*
-     * @brief CubismFrameworkに設定するオプション要素を定義するクラス
-     *
+    /**
+     * Framework configurations.
      */
     class Option
     {
     public:
         /**
-         * @brief   ログ出力のレベル
+         * Enumerator for Logging level
          */
         enum LogLevel
         {
-            LogLevel_Verbose = 0,   ///<  詳細ログ
-            LogLevel_Debug,         ///<  デバッグログ
-            LogLevel_Info,          ///<  Infoログ
-            LogLevel_Warning,       ///<  警告ログ
-            LogLevel_Error,         ///<  エラーログ
-            LogLevel_Off            ///<  ログ出力無効
+            /** Indicates that the logging of all is enabled. */
+            LogLevel_Verbose = 0,
+
+            /** Indicates that up to the logging level of Debug. */
+            LogLevel_Debug,
+
+            /** Indicates that up to the logging level of Info. */
+            LogLevel_Info,
+
+            /** Indicates that up to the logging level of Warning. */
+            LogLevel_Warning,
+
+            /** Indicates that up to the logging level of Error. */
+            LogLevel_Error,
+
+            /**  Indicates that the logging of all is disabled. */
+            LogLevel_Off
         };
 
-        Core::csmLogFunction LogFunction;       ///< ログ出力の関数ポインタ
-        LogLevel LoggingLevel;                  ///< ログ出力レベル設定
+        /** Logging function */
+        Core::csmLogFunction LogFunction;
+
+        /** Logging level */
+        LogLevel LoggingLevel;
     };
 
-   /**
-    * @brief    Cubism FrameworkのAPIを使用可能にする。<br>
-    *            APIを実行する前に必ずこの関数を実行すること。<br>
-    *            引数に必ずメモリアロケータを渡してください。<br>
-    *            一度準備が完了して以降は、再び実行しても内部処理がスキップされます。
-    *
-    * @param    allocator   ICubismAllocatorクラスのインスタンス
-    * @param    option      Optionクラスのインスタンス
-    *
-    * @return   準備処理が完了したらtrueが返ります。
-    */
+    /**
+     *
+     * Enables the Cubism Framework API.
+     *
+     * @param allocator Instance of memory allocator
+     * @param option Instance of Framework configuration option.<br>
+     * If an empty instance is set, the Framework configuration option is not used.
+     *
+     * @return true if Cubism Framework is available; otherwise false.
+     *
+     * @note Make sure to execute this function before executing the API of the Framework, <br>
+     * and be sure to pass the memory allocator to the argument.<br>
+     * Once the preparation is complete, the process will be skipped if executed again afterwards.
+     */
     static csmBool StartUp(ICubismAllocator* allocator, const Option* option = NULL);
 
     /**
-    * @brief    StartUp()で初期化したCubismFrameworkの各パラメータをクリアします。<br>
-    *            Dispose()したCubismFrameworkを再利用する際に利用してください。<br>
-    *
-    */
+     * Enables the Cubism Framework API to reuse.
+     *
+     * @note Clear each parameter of CubismFramework initialized by StartUp().<br>
+     * Use this method when reusing Cubism Framework that has been Dispose().
+     */
     static void CleanUp();
 
     /**
-     * @brief   Cubism FrameworkのAPIを使用する準備が完了したかどうか？
+     * Returns whether the API of Cubism Framework is available.
      *
-     * @return  APIを使用する準備が完了していればtrueが返ります。
+     * @return true if the API is available; otherwise false.
      */
     static csmBool IsStarted();
 
     /**
-     * @brief  Cubism Framework内のリソースを初期化してモデルを表示可能な状態にします。<br>
-     *         再度Initialize()するには先にDispose()を実行する必要があります。
+     * Initializes the resources in the Cubism Framework and makes the Model ready for display.
      */
     static void Initialize();
 
     /**
-     *@brief Cubism Framework内の全てのリソースを解放します。<br>
-     *        ただし、外部で確保されたリソースについては解放しません。<br>
-     *        外部で適切に破棄する必要があります。
+     * Releases all resources in the Cubism Framework.
+     *
+     * @note Resources allocated externally will not be released.<br>
+     * Discard them externally as appropriate.
      */
     static void Dispose();
 
     /**
-     * @brief   Cubism Frameworkのリソース初期化が既に行われているかどうか？
+     * Returns whether the Cubism Framework resources have been initialized.
      *
-     * @return  リソース確保が完了していればtrueが返ります。
+     * @return true if the resource has been initialized; otherwise false.
      */
     static csmBool IsInitialized();
 
     /**
-     * @brief   Core APIにバインドしたログ関数を実行する
+     * Executes the logging function of Cubism Core API.
      *
-     * @param message   ->  ログメッセージ
+     * @param message Message for logging
+     *
+     * @note Logging using Option::logFunction.
      */
     static void CoreLogFunction(const csmChar* message);
 
     /**
-     * @biref   現在のログ出力レベル設定の値を返す。
+     * Returns the logging level setting.
      *
-     * @return  現在のログ出力レベル設定の値
+     * @return Logging level setting
      */
     static Option::LogLevel GetLoggingLevel();
 
     /**
-     * @brief IDマネージャのインスタンスを取得する。
+     * Returns the instance of CubismIdManager.
      *
-     * @return CubismIdManagerクラスのインスタンス
+     * @note Please use `GetId()` through this function to get `CubismId`.<br>
+     *           ex) CubismFramework::GetIdManager()->GetId(id_str);
+     *
+     * @return Instance of CubismIdManager.
      */
     static CubismIdManager* GetIdManager();
 
 #ifdef CSM_DEBUG_MEMORY_LEAKING
 
+    /**
+     * (For debugging) Allocates the memory.
+     *
+     * @param size Desired amount of memory in bytes
+     * @param fileName Name of source code that called
+     * @param lineNumber Number of line of source code that called
+     *
+     * @return Pointer to the allocated memory if succeeded; otherwise `0`
+     */
     static void* Allocate(csmSizeType size, const csmChar* fileName, csmInt32 lineNumber);
+
+    /**
+     * (For debugging) Allocates the memory with specified alignment.
+     *
+     * @param size Desired amount of memory in bytes
+     * @param alignment Desired alignment of memory in bytes
+     * @param fileName Name of source code that called
+     * @param lineNumber Number of line of source code that called
+     *
+     * @return Pointer to the allocated memory if succeeded; otherwise `0`
+     */
     static void* AllocateAligned(csmSizeType size, csmUint32 alignment, const csmChar* fileName, csmInt32 lineNumber);
+
+    /**
+     * (For debugging) Deallocates the aligned memory.
+     *
+     * @param address Pointer to allocated memory to be deallocated
+     * @param fileName Name of source code that called
+     * @param lineNumber Number of line of source code that called
+     */
     static void  Deallocate(void* address, const csmChar* fileName, csmInt32 lineNumber);
+
+    /**
+     * (For debugging) Deallocates the aligned memory.
+     *
+     * @param address Pointer to allocated memory to be deallocated
+     * @param fileName Name of source code that called
+     * @param lineNumber Number of line of source code that called
+     */
     static void  DeallocateAligned(void* address, const csmChar* fileName, csmInt32 lineNumber);
 
 #else
 
+    /**
+     * Allocates the memory with specified alignment.
+     *
+     * @param size Desired amount of memory in bytes
+     * @param alignment Desired alignment of memory in bytes
+     *
+     * @return PPointer to the allocated memory if succeeded; otherwise `0`
+     */
     static void* Allocate(csmSizeType size);
+
+    /**
+     * Allocates the memory with specified alignment.
+     *
+     * @param size Desired amount of memory in bytes
+     * @param alignment Desired alignment of memory in bytes
+     *
+     * @return Pointer to the allocated memory if succeeded; otherwise `0`
+     */
     static void* AllocateAligned(csmSizeType size, csmUint32 alignment);
+
+    /**
+     * Deallocates the memory.
+     *
+     * @param address Pointer to allocated memory to be deallocated
+     */
     static void  Deallocate(void* address);
+
+    /**
+     * Deallocates the aligned memory.
+     *
+     * @param address Pointer to allocated memory to be deallocated
+     */
     static void  DeallocateAligned(void* address);
 
 #endif
 
 private:
     /**
-     *@brief  コンストラクタ<br>
-     *         静的クラスとして使用する<br>
-     *         インスタンス化させない
+     * Constructor
+     *
+     * @note Prevent instantiating and be used as a static class.
      */
     CubismFramework(){}
 

--- a/src/CubismFrameworkConfig.hpp
+++ b/src/CubismFrameworkConfig.hpp
@@ -7,37 +7,50 @@
 
 #pragma once
 
+/**
+ * A set of macros to configure the Cubism Framework on build.
+ */
 
-//========================================================
-//  デバッグモード指定マクロ
-//========================================================
-// #define CSM_DEBUG                        // デバッグモード
-// #define CSM_DEBUG_MEMORY_LEAKING         // メモリリークチェックモード
+/**
+ * A set of macros to use for debugging Cubism Framework.
+ */
+/** Runs Cubism Framework as debug mode. */
+// #define CSM_DEBUG
+
+/**
+ * Tracks memory leaking of Cubism Framework.
+ *
+ * @note Leakage is verified at the termination of Cubism Framework.
+ */
+// #define CSM_DEBUG_MEMORY_LEAKING
 
 
-//========================================================
-//  ログ出力関数の設定
-//========================================================
-
-//---------- ログ出力レベル 選択項目 定義 ----------
-/// 詳細ログ出力設定
+/**
+ * A set of macros to configure the logging level forcefully.
+ *
+ * @note The set logging level is applied by changing the definition of a group of macros that call logging in the CubismDebug class.
+ */
+/** Indicates that the logging of all is enabled. */
 #define CSM_LOG_LEVEL_VERBOSE  0
-/// デバッグログ出力設定
+
+/** Indicates that up to the logging level of Debug. */
 #define CSM_LOG_LEVEL_DEBUG    1
-/// Infoログ出力設定
+
+/** Indicates that up to the logging level of Info. */
 #define CSM_LOG_LEVEL_INFO     2
-/// 警告ログ出力設定
+
+/** Indicates that up to the logging level of Warning. */
 #define CSM_LOG_LEVEL_WARNING  3
-/// エラーログ出力設定
+
+/** Indicates that up to the logging level of Error. */
 #define CSM_LOG_LEVEL_ERROR    4
-/// ログ出力オフ設定
+
+/**  Indicates that the logging of all is disabled. */
 #define CSM_LOG_LEVEL_OFF      5
 
 /**
-* ログ出力レベル設定。
-*
-* 強制的にログ出力レベルを変える時に定義を有効にする。
-* CSM_LOG_LEVEL_VERBOSE ～ CSM_LOG_LEVEL_OFF を選択する。
-*/
+ * Logging level to set
+ *
+ * @note Set one of the logging levels from CSM_LOG_LEVEL_VERBOSE to CSM_LOG_LEVEL_OFF.
+ */
 #define CSM_LOG_LEVEL CSM_LOG_LEVEL_VERBOSE
-

--- a/src/CubismJsonHolder.hpp
+++ b/src/CubismJsonHolder.hpp
@@ -12,37 +12,29 @@
 //--------- LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework {
     /**
-     * @brief CubismJsonのインスタンス生成や有効性のチェック処理を抽象化したクラス
-     *
-     * 各JsonパーサにおいてCubismJsonのインスタンス生成や
-     * 有効性のチェック処理を共通化するためのインターフェース。
-     *
+     * An interface that implements the CubismJson instantiation<br>
+     * and validity checks at each JSON parser.
      */
     class CubismJsonHolder
     {
     public:
         /**
-         * @brief コンストラクタ
-         *
-         * コンストラクタ。
+         * Constructor
          */
         CubismJsonHolder()
             : _json(NULL)
         { }
 
         /**
-         * @brief デストラクタ
-         *
-         * デストラクタ。
+         * Destructor
          */
         virtual ~CubismJsonHolder()
         { }
 
         /**
-         * @brief CubismJsonの有効性チェック
+         * Returns whether the CubismJson is valid or not.
          *
-         * @retval       true  -> Jsonファイルが正常に読み込めた
-         * @retval       false -> Jsonファイルが読み込めなかった。もしくは、存在しない
+         * @return true if valid; otherwise false
          */
         csmBool IsValid()
         {
@@ -50,12 +42,12 @@ namespace Live2D { namespace Cubism { namespace Framework {
         }
 
     protected:
+
         /**
-         * @brief CubismJsonのインスタンスを生成する
+         * Make the instance of CubismJson.
          *
-         * Util:CubismJsonクラスのCreate関数を呼んで
-         * CubismJsonのインスタンスを生成する。
-         *
+         * @param buffer Buffer into which JSON is loaded
+         * @param size Number of bytes in buffer
          */
         void CreateCubismJson(const csmByte* buffer, csmSizeInt size)
         {
@@ -68,11 +60,7 @@ namespace Live2D { namespace Cubism { namespace Framework {
         };
 
         /**
-         * @brief CubismJsonのインスタンスを破棄する
-         *
-         * Util:CubismJsonクラスのDelete関数を呼んで
-         * CubismJsonのインスタンスを破棄する。
-         *
+         * Destroy the instance of CubismJson.
          */
         void DeleteCubismJson()
         {
@@ -80,6 +68,7 @@ namespace Live2D { namespace Cubism { namespace Framework {
             _json = NULL;
         }
 
-        Utils::CubismJson* _json;   /// CubismJsonの実体
+        /** Instance of CubismJson */
+        Utils::CubismJson* _json;
     };
 }}}

--- a/src/CubismModelSettingJson.hpp
+++ b/src/CubismModelSettingJson.hpp
@@ -15,235 +15,379 @@
 namespace Live2D { namespace Cubism { namespace Framework {
 
 /**
- * @brief Model3Jsonパーサー.
- *
- * model3.jsonファイルをパースして値を取得する。
- *
+ * Handles the Model Settings File
  */
 class CubismModelSettingJson : public ICubismModelSetting, public CubismJsonHolder
 {
 public:
 
     /**
+     * Constructor<br>
+     * Loads the Model Settings File.
      *
-     * @brief 引数付きコンストラクタ
-     *
-     * 引数付きコンストラクタ。
-     *
-     * @param[in] buffer     Model3Jsonをバイト配列として読み込んだデータバッファ
-     * @param[in] size       Model3Jsonのデータサイズ
-     *
+     * @param buffer Buffer into which the Model Settings File is loaded
+     * @param size Number of bytes in buffer
      */
     CubismModelSettingJson(const csmByte* buffer, csmSizeInt size);
 
     /**
-     * @brief デストラクタ
-     *
-     * デストラクタ。
+     * Destructor
      */
     virtual ~CubismModelSettingJson();
 
     /**
-     * @brief   CubismJsonオブジェクトのポインタを取得する
+     * Returns the instance of CubismJson that handles the JSON document.
      *
-     * @return  CubismJsonのポインタ
+     * @return Instance of CubismJson
      */
     Utils::CubismJson* GetJsonPointer() const;
 
+    /**
+     * Returns the file name of MOC3 File.
+     *
+     * @return Name of MOC3 File
+     */
     const csmChar* GetModelFileName();
 
+    /**
+     * Returns the number of textures in the Model.
+     *
+     * @return Number of textures
+     */
     csmInt32 GetTextureCount();
 
+    /**
+     * Returns the name of directory that texture is placed.
+     *
+     * @return Name of directory
+     */
     const csmChar* GetTextureDirectory();
 
+    /**
+     * Returns the name of texture in the Model.
+     *
+     * @param index Index to the desired texture name
+     *
+     * @return Name of texture
+     */
     const csmChar* GetTextureFileName(csmInt32 index);
 
+    /**
+     * Returns the number of Hit Area settings in the Model.
+     *
+     * @return Number of Hit Area settings
+     */
     csmInt32 GetHitAreasCount();
 
+    /**
+     * Returns whether ID of Drawable that is set for the Hit Area.
+     *
+     * @param groupName Name of the desired Motion Group
+     *
+     * @return true if Motion Group information exists; otherwise false
+     */
     CubismIdHandle GetHitAreaId(csmInt32 index);
 
+    /**
+     * Returns the name of Hit Area.
+     *
+     * @param index Index to the desired Hit Area
+     *
+     * @return Name of Hit Area
+     */
     const csmChar* GetHitAreaName(csmInt32 index);
 
+    /**
+     * Returns the name of Physics Settings File in the Model.
+     *
+     * @return Name of Physics Settings File
+     */
     const csmChar* GetPhysicsFileName();
 
+    /**
+     * Returns the name of Pose Settings File in the Model.
+     *
+     * @return Name of Pose Settings File
+     */
     const csmChar* GetPoseFileName();
 
+    /**
+     * Returns the name of Display Settings File in the Model.
+     *
+     * @return Name of Display Settings File
+     */
     const csmChar* GetDisplayInfoFileName();
 
+    /**
+     * Returns the number of expressions in the Model.
+     *
+     * @return Number of expressions
+     */
     csmInt32 GetExpressionCount();
 
+    /**
+     * Returns the name of expression.
+     *
+     * @param index Index to the desired expression
+     *
+     * @return Name of expression
+     */
     const csmChar* GetExpressionName(csmInt32 index);
 
+    /**
+     * Returns the name of Expression Settings File from the expression.
+     *
+     * @param index Index to the desired expression
+     *
+     * @return Name of Expression Settings File
+     */
     const csmChar* GetExpressionFileName(csmInt32 index);
 
+    /**
+     * Returns the number of Motion Groups in the Model.
+     *
+     * @return Number of Motion Groups
+     */
     csmInt32 GetMotionGroupCount();
 
+    /**
+     * Returns the name of Motion Group.
+     *
+     * @param index Index to the desired Motion Group
+     *
+     * @return Name of Motion Group
+     */
     const csmChar* GetMotionGroupName(csmInt32 index);
 
+    /**
+     * Returns the number of Motions in the Motion Group.
+     *
+     * @param groupName Name to the desired Motion Group
+     *
+     * @return Number of Motions
+     */
     csmInt32 GetMotionCount(const csmChar* groupName);
 
+    /**
+     * Returns the file name of Motion File in the Motion Group.
+     *
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired motion
+     *
+     * @return Name of Motion File
+     */
     const csmChar* GetMotionFileName(const csmChar* groupName, csmInt32 index);
 
+    /**
+     * Returns the name of Audio File attached to the Motion in the Motion Group.
+     *
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return Name of Audio File
+     */
     const csmChar* GetMotionSoundFileName(const csmChar* groupName, csmInt32 index);
 
+    /**
+     * Returns the Fade-in time at the start of the Motion in the Motion Group
+     *
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return Fade-in time [sec]
+     */
     csmFloat32 GetMotionFadeInTimeValue(const csmChar* groupName, csmInt32 index);
 
+    /**
+     * Returns the Fade-out time at the end of the Motion in the Motion Group.
+     *
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return Fade-out time [sec]
+     */
     csmFloat32 GetMotionFadeOutTimeValue(const csmChar* groupName, csmInt32 index);
 
+    /**
+     * Returns the name of User Data File in the Model.
+     *
+     * @return Name of User Data File
+     */
     const csmChar* GetUserDataFile();
 
+    /**
+     * Returns the Layout Information set in the model.
+     *
+     * @param outLayoutMap Instance of a collection to store
+     *
+     * @return true if Layout Information exists; otherwise false
+     */
     csmBool GetLayoutMap(csmMap<csmString, csmFloat32>& outLayoutMap);
 
+    /**
+     * Returns the number of parameters attached to the Eye Blinking Settings.
+     *
+     * @return Number of parameters
+     */
     csmInt32 GetEyeBlinkParameterCount();
 
+    /**
+     * Returns the ID of parameter attached to the Eye Blinking Settings.
+     *
+     * @param index Index to the desired parameter
+     *
+     * @return ID of parameter
+     */
     CubismIdHandle GetEyeBlinkParameterId(csmInt32 index);
 
+    /**
+     * Returns the number of parameters attached to the Lip-sync Settings.
+     *
+     * @return Number of parameters
+     */
     csmInt32 GetLipSyncParameterCount();
 
+    /**
+     * Returns the ID of parameter attached to the Lip-sync Settings.
+     *
+     * @param index Index to the desired parameter
+     *
+     * @return ID of parameter
+     */
     CubismIdHandle GetLipSyncParameterId(csmInt32 index);
 
 private:
 
     enum FrequentNode
     {
-        FrequentNode_Groups,        ///< GetRoot()[Groups]
-        FrequentNode_Moc,           ///< GetRoot()[FileReferences][Moc]
-        FrequentNode_Motions,       ///< GetRoot()[FileReferences][Motions]
-        FrequentNode_DisplayInfo,   ///< GetRoot()[FileReferences][DisplayInfo]
-        FrequentNode_Expressions,   ///< GetRoot()[FileReferences][Expressions]
-        FrequentNode_Textures,      ///< GetRoot()[FileReferences][Textures]
-        FrequentNode_Physics,       ///< GetRoot()[FileReferences][Physics]
-        FrequentNode_Pose,          ///< GetRoot()[FileReferences][Pose]
-        FrequentNode_HitAreas,      ///< GetRoot()[HitAreas]
+        FrequentNode_Groups,
+        FrequentNode_Moc,
+        FrequentNode_Motions,
+        FrequentNode_DisplayInfo,
+        FrequentNode_Expressions,
+        FrequentNode_Textures,
+        FrequentNode_Physics,
+        FrequentNode_Pose,
+        FrequentNode_HitAreas,
     };
 
     /**
-     * @brief        モデルファイルのキーが存在するかどうかを確認する
+     * Returns whether the MOC3 File information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if MOC3 File information exists; otherwise false
      */
     csmBool IsExistModelFile() const;
 
     /**
-     * @brief        テクスチャファイルのキーが存在するかどうかを確認する
+     * Returns whether Texture File information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Texture File information exists; otherwise false
      */
     csmBool IsExistTextureFiles() const;
 
     /**
-     * @brief        当たり判定のキーが存在するかどうかを確認する
+     * Returns whether Hit Area information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Hit Area information exists; otherwise false
      */
     csmBool IsExistHitAreas() const;
 
     /**
-     * @brief        物理演算ファイルのキーが存在するかどうかを確認する
+     * Returns whether Physics Settings File information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Physics Settings File information exists; otherwise false
      */
     csmBool IsExistPhysicsFile() const;
 
     /**
-     * @brief        ポーズ設定ファイルのキーが存在するかどうかを確認する
+     * Returns whether Pose Settings File information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Pose Settings File information exists; otherwise false
      */
     csmBool IsExistPoseFile() const;
 
     /**
-     * @brief        表示名称設定ファイルのキーが存在するかどうかを確認する
+     * Returns whether Display Settings File information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Display Settings File information exists; otherwise false
      */
     csmBool IsExistDisplayInfoFile() const;
 
     /**
-     * @brief        表情設定ファイルのキーが存在するかどうかを確認する
+     * Returns whether Expression File information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Expression File information exists; otherwise false
      */
     csmBool IsExistExpressionFile() const;
 
     /**
-     * @brief        モーショングループのキーが存在するかどうかを確認する
+     * Returns whether Motion Group information exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if Motion Group information exists; otherwise false
      */
     csmBool IsExistMotionGroups() const;
 
     /**
-     * @brief        引数で指定したモーショングループのキーが存在するかどうかを確認する
+     * Returns the Motion Group information with the specified name in the Model Settings File.
      *
-     * @param[in]    groupName  グループ名
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @param groupName Name of the desired Motion Group
+     *
+     * @return true if Motion Group information exists; otherwise false
      */
     csmBool IsExistMotionGroupName(const csmChar* groupName) const;
 
     /**
-     * @brief        引数で指定したモーションに対応するサウンドファイルのキーが存在するかどうかを確認する
+     * Returns whether the Audio File information in the Motion Group with the specified name in the Model Settings File.
      *
-     * @param[in]    groupName  グループ名
-     * @param[in]    index   配列のインデックス値
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @param groupName Name of the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return true if Audio File information exists; otherwise false
      */
     csmBool IsExistMotionSoundFile(const csmChar* groupName, csmInt32 index) const;
 
     /**
-     * @brief        引数で指定したモーションに対応するフェードイン時間のキーが存在するかどうかを確認する
+     * Returns whether the Fade-in time at the start of Motion in Motion Group with the specified name exists in Model Setting File.
      *
-     * @param[in]    groupName  グループ名
-     * @param[in]    index   配列のインデックス値
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @param groupName Name of the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return true if Fade-in time exists; otherwise false
      */
     csmBool IsExistMotionFadeIn(const csmChar* groupName, csmInt32 index) const;
 
     /**
-     * @brief        引数で指定したモーションに対応するフェードアウト時間のキーが存在するかどうかを確認する
+     * Returns whether the Fade-out time at the end of the Motion in the Motion Group with the specified name in the Model Settings File.
      *
-     * @param[in]    groupName  グループ名
-     * @param[in]    index   配列のインデックス値
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @param groupName Name of the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return true if Fade-out time exists; otherwise false
      */
     csmBool IsExistMotionFadeOut(const csmChar* groupName, csmInt32 index) const;
 
     /**
-    * @brief        UserDataのファイル名が存在するか確認
-    *
-    * @retval       true   キーが存在する
-    * @retval       false  キーが存在しない
-    */
+     * Returns whether the User Data File information exists in the Model Settings File.
+     *
+     * @return true if User Data File information exists; otherwise false
+     */
     csmBool IsExistUserDataFile() const;
 
     /**
-     * @brief        目パチに対応付けられたパラメータが存在するかどうかを確認する
+     * Returns whether the parameter information attached to the Eye Blinking Settings exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if parameter information exists; otherwise false
      */
     csmBool IsExistEyeBlinkParameters() const;
 
     /**
-     * @brief        リップシンクに対応付けられたパラメータが存在するかどうかを確認する
+     * Returns whether the parameter information attached to the Lip-sync Settings exists in the Model Settings File.
      *
-     * @retval       true  -> キーが存在する
-     * @retval       false -> キーが存在しない
+     * @return true if parameter information exists; otherwise false
      */
     csmBool IsExistLipSyncParameters() const;
 
-    csmVector<Utils::Value*>    _jsonValue;  ///< モデルデータjsonの頻出ノード
+    /** Cache of JSON nodes */
+    csmVector<Utils::Value*>    _jsonValue;
 };
 }}}

--- a/src/Effect/CubismEyeBlink.cpp
+++ b/src/Effect/CubismEyeBlink.cpp
@@ -50,7 +50,7 @@ CubismEyeBlink::CubismEyeBlink(ICubismModelSetting* modelSetting)
 CubismEyeBlink::~CubismEyeBlink()
 { }
 
-csmFloat32 CubismEyeBlink::DeterminNextBlinkingTiming() const
+csmFloat32 CubismEyeBlink::DetermineNextBlinkingTiming() const
 {
     const csmFloat32 r = static_cast<csmFloat32>(rand()) / RAND_MAX;
 
@@ -119,7 +119,7 @@ void CubismEyeBlink::UpdateParameters(CubismModel* model, csmFloat32 deltaTimeSe
         {
             t = 1.0f;
             _blinkingState = EyeState_Interval;
-            _nextBlinkingTime = DeterminNextBlinkingTiming();
+            _nextBlinkingTime = DetermineNextBlinkingTiming();
         }
 
         parameterValue = t;
@@ -138,7 +138,7 @@ void CubismEyeBlink::UpdateParameters(CubismModel* model, csmFloat32 deltaTimeSe
     case EyeState_First:
     default:
         _blinkingState = EyeState_Interval;
-        _nextBlinkingTime = DeterminNextBlinkingTiming();
+        _nextBlinkingTime = DetermineNextBlinkingTiming();
 
         parameterValue = 1.0f;
 

--- a/src/Effect/CubismEyeBlink.hpp
+++ b/src/Effect/CubismEyeBlink.hpp
@@ -131,7 +131,7 @@ private:
      *
      * @return 次のまばたきを行う時刻[秒]
      */
-    csmFloat32        DeterminNextBlinkingTiming() const;
+    csmFloat32        DetermineNextBlinkingTiming() const;
 
     csmInt32                    _blinkingState;                   ///< 現在の状態
     csmVector<CubismIdHandle>   _parameterIds;                    ///< 操作対象のパラメータのIDのリスト

--- a/src/ICubismAllocator.hpp
+++ b/src/ICubismAllocator.hpp
@@ -12,55 +12,48 @@
 namespace Live2D { namespace Cubism { namespace Framework {
 
 /**
- * @brief メモリアロケーションを抽象化したクラス.
- *
- * メモリ確保・解放処理をプラットフォーム側で実装して
- * フレームワークから呼び出すためのインターフェース。
- *
+ * An interface to implement memory allocation and deallocation processes<br>
+ * on the platform side and call from the Framework.
  */
 class ICubismAllocator
 {
 public:
     /**
-     * @brief デストラクタ
-     *
-     * デストラクタ。
+     * Destructor
      */
     virtual ~ICubismAllocator() {}
 
     /**
-     * @brief アラインメント制約なしのヒープ・メモリーを確保します。
+     * Allocates the memory.
      *
-     * @param[in]  size   確保するバイト数
+     * @param size Desired amount of memory in bytes
      *
-     * @return     成功すると割り当てられたメモリのアドレス。 そうでなければ '0'を返す。
+     * @return Pointer to the allocated memory if succeeded; otherwise `0`
      */
     virtual void* Allocate(const csmSizeType size) = 0;
 
     /**
-     * @brief アラインメント制約なしのヒープ・メモリーを解放します。
+     * Deallocates the memory.
      *
-     * @param[in]  memory   解放するメモリのアドレス
-     *
+     * @param memory Pointer to allocated memory to be deallocated
      */
     virtual void Deallocate(void* memory) = 0;
 
 
     /**
-     * @brief アラインメント制約ありのヒープ・メモリーを確保します。
+     * Allocates the memory with specified alignment.
      *
-     * @param[in]  size       確保するバイト数
-     * @param[in]  alignment  メモリーブロックのアラインメント幅
+     * @param size Desired amount of memory in bytes
+     * @param alignment Desired alignment of memory in bytes
      *
-     * @return     成功すると割り当てられたメモリのアドレス。 そうでなければ '0'を返す。
+     * @return Pointer to the allocated memory if succeeded; otherwise `0`
      */
     virtual void* AllocateAligned(const csmSizeType size, const csmUint32 alignment) = 0;
 
     /**
-     * @brief アラインメント制約ありのヒープ・メモリーを解放します。
+     * Deallocates the aligned memory.
      *
-     * @param[in]  alignedMemory       解放するメモリのアドレス
-     *
+     * @param alignedMemory Pointer to allocated memory to be deallocated
      */
     virtual void DeallocateAligned(void* alignedMemory) = 0;
 

--- a/src/ICubismModelSetting.hpp
+++ b/src/ICubismModelSetting.hpp
@@ -15,219 +15,229 @@
 namespace Live2D { namespace Cubism { namespace Framework {
 
 /**
- * @brief モデル設定情報を取り扱う関数を宣言した純粋仮想クラス。
+ * An interface that covers the settings defined in the Model Settings File.
  *
- * このクラスを継承することで、モデル設定情報を取り扱うクラスになる。
- *
+ * @note Inherit this interface if you need to extend model settings or implement a class that uses model settings.
  */
 class ICubismModelSetting
 {
 public:
     /**
-     * @brief デストラクタ
-     *
-     * デストラクタ。
+     * Destructor
      */
     virtual ~ICubismModelSetting() {}
 
     /**
-     * @brief  Mocファイルの名前を取得する
+     * Returns the file name of MOC3 File.
      *
-     * @return Mocファイルの名前
+     * @return Name of MOC3 File
      */
     virtual const csmChar* GetModelFileName() = 0;
 
     /**
-     * @brief  モデルが使用するテクスチャの数を取得する
+     * Returns the number of textures in the Model.
      *
-     * @return テクスチャの数
+     * @return Number of textures
      */
     virtual csmInt32 GetTextureCount() = 0;
 
     /**
-     * @brief  テクスチャが配置されたディレクトリの名前を取得する
+     * Returns the name of directory that texture is placed.
      *
-     * @return テクスチャが配置されたディレクトリの名前
+     * @return Name of directory
      */
     virtual const csmChar* GetTextureDirectory() = 0;
 
     /**
-     * @brief  モデルが使用するテクスチャの名前を取得する
+     * Returns the name of texture in the Model.
      *
-     * @param[in]   index    配列のインデックス値
-     * @return      テクスチャの名前
+     * @param index Index to the desired texture name
+     *
+     * @return Name of texture
      */
     virtual const csmChar* GetTextureFileName(csmInt32 index) = 0;
 
     /**
-     * @brief        モデルに設定された当たり判定の数を取得する
+     * Returns the number of Hit Area settings in the Model.
      *
-     * @return       モデルに設定された当たり判定の数
+     * @return Number of Hit Area settings
      */
     virtual csmInt32 GetHitAreasCount() = 0;
 
     /**
-     * @brief        当たり判定に設定されたIDを取得する
+     * Returns whether ID of Drawable that is set for the Hit Area.
      *
-     * @param[in]    index   配列のインデックス値
-     * @return       当たり判定に設定されたID
+     * @param groupName Name of the desired Motion Group
+     *
+     * @return true if Motion Group information exists; otherwise false
      */
     virtual CubismIdHandle GetHitAreaId(csmInt32 index) = 0;
 
     /**
-     * @brief        当たり判定に設定された名前を取得する
+     * Returns the name of Hit Area.
      *
-     * @param[in]    index   配列のインデックス値
-     * @return       当たり判定に設定された名前
+     * @param index Index to the desired Hit Area
+     *
+     * @return Name of Hit Area
      */
     virtual const csmChar* GetHitAreaName(csmInt32 index) = 0;
 
     /**
-     * @brief        物理演算設定ファイルの名前を取得する
+     * Returns the name of Physics Settings File in the Model.
      *
-     * @return       物理演算設定ファイルの名前
+     * @return Name of Physics Settings File
      */
     virtual const csmChar* GetPhysicsFileName() = 0;
 
     /**
-     * @brief        パーツ切り替え設定ファイルの名前を取得する
+     * Returns the name of Pose Settings File in the Model.
      *
-     * @return       パーツ切り替え設定ファイルの名前
+     * @return Name of Pose Settings File
      */
     virtual const csmChar* GetPoseFileName() = 0;
 
     /**
-     * @brief        表示名称設定ファイルの名前を取得する
+     * Returns the name of Display Settings File in the Model.
      *
-     * @return       表示名称設定ファイルの名前
+     * @return Name of Display Settings File
      */
     virtual const csmChar* GetDisplayInfoFileName() = 0;
 
     /**
-     * @brief        表情設定ファイルの数を取得する
+     * Returns the number of expressions in the Model.
      *
-     * @return       表情設定ファイルの数
+     * @return Number of expressions
      */
     virtual csmInt32 GetExpressionCount() = 0;
 
     /**
-     * @brief        表情設定ファイルを識別する名前（別名）を取得する
+     * Returns the name of expression.
      *
-     * @param[in]    index   配列のインデックス値
-     * @return       表情の名前
+     * @param index Index to the desired expression
+     *
+     * @return Name of expression
      */
     virtual const csmChar* GetExpressionName(csmInt32 index) = 0;
 
     /**
-     * @brief        表情設定ファイルの名前を取得する
+     * Returns the name of Expression Settings File from the expression.
      *
-     * @param[in]    index   配列のインデックス値
-     * @return       表情設定ファイルの名前
+     * @param index Index to the desired expression
+     *
+     * @return Name of Expression Settings File
      */
     virtual const csmChar* GetExpressionFileName(csmInt32 index) = 0;
 
     /**
-     * @brief        モーショングループの数を取得する
+     * Returns the number of Motion Groups in the Model.
      *
-     * @return       モーショングループの数
+     * @return Number of Motion Groups
      */
     virtual csmInt32 GetMotionGroupCount() = 0;
 
     /**
-     * @brief        モーショングループの名前を取得する
+     * Returns the name of Motion Group.
      *
-     * @param[in]    index   配列のインデックス値
-     * @return       モーショングループの名前
+     * @param index Index to the desired Motion Group
+     *
+     * @return Name of Motion Group
      */
     virtual const csmChar* GetMotionGroupName(csmInt32 index) = 0;
 
     /**
-     * @brief        モーショングループに含まれるモーションの数を取得する
+     * Returns the number of Motions in the Motion Group.
      *
-     * @param[in]    groupName      モーショングループの名前
-     * @return       モーショングループの名前
+     * @param groupName Name to the desired Motion Group
+     *
+     * @return Number of Motions
      */
     virtual csmInt32 GetMotionCount(const csmChar* groupName) = 0;
 
     /**
-     * @brief        グループ名とインデックス値からモーションファイルの名前を取得する
+     * Returns the file name of Motion File in the Motion Group.
      *
-     * @param[in]    groupName      モーショングループの名前
-     * @param[in]    index          配列のインデックス値
-     * @return       モーションファイルの名前
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired motion
+     *
+     * @return Name of Motion File
      */
     virtual const csmChar* GetMotionFileName(const csmChar* groupName, csmInt32 index) = 0;
 
     /**
-     * @brief        モーションに対応するサウンドファイルの名前を取得する
+     * Returns the name of Audio File attached to the Motion in the Motion Group.
      *
-     * @param[in]    groupName      モーショングループの名前
-     * @param[in]    index          配列のインデックス値
-     * @return       サウンドファイルの名前
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return Name of Audio File
      */
     virtual const csmChar* GetMotionSoundFileName(const csmChar* groupName, csmInt32 index) = 0;
 
     /**
-     * @brief        モーション開始時のフェードイン処理時間を取得する
+     * Returns the Fade-in time at the start of the Motion in the Motion Group
      *
-     * @param[in]    groupName      モーショングループの名前
-     * @param[in]    index          配列のインデックス値
-     * @return       フェードイン処理時間[秒]
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return Fade-in time [sec]
      */
     virtual csmFloat32 GetMotionFadeInTimeValue(const csmChar* groupName, csmInt32 index) = 0;
 
     /**
-     * @brief        モーション終了時のフェードアウト処理時間を取得する
+     * Returns the Fade-out time at the end of the Motion in the Motion Group.
      *
-     * @param[in]    groupName      モーショングループの名前
-     * @param[in]    index          配列のインデックス値
-     * @return       フェードアウト処理時間[秒]
+     * @param groupName Name to the desired Motion Group
+     * @param index Index to the desired Motion
+     *
+     * @return Fade-out time [sec]
      */
     virtual csmFloat32 GetMotionFadeOutTimeValue(const csmChar* groupName, csmInt32 index) = 0;
 
     /**
-    * @brief        ユーザデータのファイル名を取得する
-    *
-    * @return       ユーザデータのファイル名
-    */
+     * Returns the name of User Data File in the Model.
+     *
+     * @return Name of User Data File
+     */
     virtual const csmChar* GetUserDataFile() = 0;
 
     /**
-     * @brief        レイアウト情報を取得する
+     * Returns the Layout Information set in the model.
      *
-     * @param[out]   outLayoutMap      csmMapクラスのインスタンス
-     * @retval       true  -> レイアウト情報が存在する
-     * @retval       false -> レイアウト情報が存在しない
+     * @param outLayoutMap Instance of a collection to store
+     *
+     * @return true if Layout Information exists; otherwise false
      */
     virtual csmBool GetLayoutMap(csmMap<csmString, csmFloat32>& outLayoutMap) = 0;
 
     /**
-     * @brief        目パチに関連付けられたパラメータの数を取得する
+     * Returns the number of parameters attached to the Eye Blinking Settings.
      *
-     * @return       目パチに関連付けられたパラメータの数
+     * @return Number of parameters
      */
     virtual csmInt32 GetEyeBlinkParameterCount() = 0;
 
     /**
-     * @brief        目パチに関連付けられたパラメータのIDを取得する
+     * Returns the ID of parameter attached to the Eye Blinking Settings.
      *
-     * @param[in]    index          配列のインデックス値
-     * @return       パラメータID
+     * @param index Index to the desired parameter
+     *
+     * @return ID of parameter
      */
     virtual CubismIdHandle GetEyeBlinkParameterId(csmInt32 index) = 0;
 
     /**
-     * @brief        リップシンクに関連付けられたパラメータの数を取得する
+     * Returns the number of parameters attached to the Lip-sync Settings.
      *
-     * @return       リップシンクに関連付けられたパラメータの数
+     * @return Number of parameters
      */
     virtual csmInt32 GetLipSyncParameterCount() = 0;
 
     /**
-     * @brief        リップシンクに関連付けられたパラメータのIDを取得する
+     * Returns the ID of parameter attached to the Lip-sync Settings.
      *
-     * @param[in]    index          配列のインデックス値
-     * @return       パラメータID
+     * @param index Index to the desired parameter
+     *
+     * @return ID of parameter
      */
     virtual CubismIdHandle GetLipSyncParameterId(csmInt32 index) = 0;
 };

--- a/src/Live2DCubismCore.hpp
+++ b/src/Live2DCubismCore.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 /**
- * @brief [NOTICE] "Live2DCubismCore.h"を直接インクルードせず、この"Live2DCubismCore.hpp"をインクルードすること。<br>
- *          Live2D Cubism Coreライブラリを"Live2D::Cubism::Core"名前空間に内包するようにインクルードするヘッダ<br>
+ * Header to include the Live2D Cubism Core in the `Live2D::Cubism::Core` namespace
  *
+ * @note Include this header instead of including the `Live2DCubismCore.h` directly.
  */
 namespace Live2D { namespace Cubism { namespace Core {
 #include "Live2DCubismCore.h"

--- a/src/Model/CubismModel.cpp
+++ b/src/Model/CubismModel.cpp
@@ -188,6 +188,12 @@ csmInt32 CubismModel::GetParameterIndex(CubismIdHandle parameterId)
     return parameterIndex;
 }
 
+CubismIdHandle CubismModel::GetParameterId(csmUint32 parameterIndex)
+{
+    const csmChar** parameterIds = Core::csmGetParameterIds(_model);
+    return CubismFramework::GetIdManager()->GetId(parameterIds[parameterIndex]);
+}
+
 csmFloat32 CubismModel::GetParameterValue(csmInt32 parameterIndex)
 {
     if (_notExistParameterValues.IsExist(parameterIndex))

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -246,6 +246,16 @@ public:
     csmInt32    GetParameterIndex(CubismIdHandle parameterId);
 
     /**
+     * @brief パラメータのIDの取得
+     *
+     * パラメータのIDを取得する。
+     *
+     * @param[in]   parameterIndex  パラメータのIndex
+     * @return  パラメータのID
+     */
+    CubismIdHandle    GetParameterId(csmUint32 parameterIndex);
+
+    /**
      * @brief パラメータの個数の取得
      *
      * パラメータの個数を取得する。

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -43,7 +43,7 @@ CubismUserModel::CubismUserModel()
     _motionManager->SetEventCallback(CubismDefaultMotionEventCallback, this);
 
     // 表情モーションマネージャを作成
-    _expressionManager = CSM_NEW CubismMotionManager();
+    _expressionManager = CSM_NEW CubismExpressionMotionManager();
 
     // ドラッグによるアニメーション
     _dragManager = CSM_NEW CubismTargetPoint();

--- a/src/Model/CubismUserModel.hpp
+++ b/src/Model/CubismUserModel.hpp
@@ -19,6 +19,7 @@
 #include "Physics/CubismPhysics.hpp"
 #include "Rendering/CubismRenderer.hpp"
 #include "Model/CubismModelUserData.hpp"
+#include "Motion/CubismExpressionMotionManager.hpp"
 
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -269,7 +270,7 @@ protected:
     CubismModel*            _model;                     ///< Modelインスタンス
 
     CubismMotionManager*    _motionManager;             ///< モーション管理
-    CubismMotionManager*    _expressionManager;         ///< 表情管理
+    CubismExpressionMotionManager*    _expressionManager;         ///< 表情管理
     CubismEyeBlink*         _eyeBlink;                  ///< 自動まばたき
     CubismBreath*           _breath;                    ///< 呼吸
     CubismModelMatrix*      _modelMatrix;               ///< モデル行列

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -216,6 +216,16 @@ protected:
      */
     virtual csmFloat32 GetModelOpacityValue() const;
 
+    /**
+     * @brief モデルのウェイト更新
+     *
+     * モーションのウェイトを更新する。
+     *
+     * @param[in]   motionQueueEntry    CubismMotionQueueManagerで管理されているモーション
+     * @param[in]   userTimeSeconds     デルタ時間の積算値[秒]
+     */
+    csmFloat32 UpdateFadeWeight(CubismMotionQueueEntry* motionQueueEntry, csmFloat32 userTimeSeconds);
+
 private:
     // Prevention of copy Constructor
     ACubismMotion(const ACubismMotion&);

--- a/src/Motion/CMakeLists.txt
+++ b/src/Motion/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/ACubismMotion.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionMotion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionMotion.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionMotionManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionMotionManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotion.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionInternal.hpp

--- a/src/Motion/CubismExpressionMotion.hpp
+++ b/src/Motion/CubismExpressionMotion.hpp
@@ -10,6 +10,7 @@
 #include "ACubismMotion.hpp"
 #include "Utils/CubismJson.hpp"
 #include "Model/CubismModel.hpp"
+#include "CubismExpressionMotionManager.hpp"
 
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -27,9 +28,9 @@ public:
      */
     enum ExpressionBlendType
     {
-        ExpressionBlendType_Add = 0,        ///< 加算
-        ExpressionBlendType_Multiply = 1,   ///< 乗算
-        ExpressionBlendType_Overwrite = 2   ///< 上書き
+        Additive = 0,   ///< 加算
+        Multiply = 1,   ///< 乗算
+        Overwrite = 2   ///< 上書き
     };
 
     /**
@@ -67,8 +68,50 @@ public:
     */
     virtual void DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 weight, CubismMotionQueueEntry* motionQueueEntry);
 
+    /**
+    * @brief 表情によるモデルのパラメータの計算
+    *
+    * モデルの表情に関するパラメータを計算する。
+    *
+    * @param[in]   model                        対象のモデル
+    * @param[in]   userTimeSeconds              デルタ時間の積算値[秒]
+    * @param[in]   motionQueueEntry             CubismMotionQueueManagerで管理されているモーション
+    * @param[in]   expressionParameterValues    モデルに適用する各パラメータの値
+    * @param[in]   expressionIndex              表情のインデックス
+    */
+    void CalculateExpressionParameters(CubismModel* model, csmFloat32 userTimeSeconds, CubismMotionQueueEntry* motionQueueEntry,
+        csmVector<CubismExpressionMotionManager::ExpressionParameterValue>* expressionParameterValues, csmInt32 expressionIndex);
+
+    /**
+     * @brief 表情が参照しているパラメータを取得
+     *
+     * 表情が参照しているパラメータを取得する。
+     */
+    csmVector<ExpressionParameter> GetExpressionParameters();
+
+    /**
+     * @brief 表情のフェードの値を取得
+     *
+     * 現在の表情のフェードのウェイト値を取得する。
+     */
+    csmFloat32 GetFadeWeight();
+
+    static const csmFloat32 DefaultAdditiveValue;    ///<  加算適用の初期値
+    static const csmFloat32 DefaultMultiplyValue;    ///<  乗算適用の初期値
+
 protected:
+    /**
+    * @brief コンストラクタ
+    *
+    * コンストラクタ。
+    */
     CubismExpressionMotion();
+
+    /**
+    * @brief デストラクタ
+    *
+    * デストラクタ。
+    */
     virtual ~CubismExpressionMotion();
 
     /**
@@ -81,7 +124,20 @@ protected:
      */
     void Parse(const csmByte* exp3Json, csmSizeInt size);
 
-    csmVector<ExpressionParameter> _parameters;         ///< 表情のパラメータ情報リスト
+private:
+
+    /**
+     * @brief ブレンド計算
+     *
+     * 入力された値でブレンド計算をする。
+     *
+     * @param[in]   source          現在の値
+     * @param[in]   destination     適用する値
+     */
+    csmFloat32 CalculateValue(csmFloat32 source, csmFloat32 destination);
+
+    csmVector<ExpressionParameter> _parameters;     ///< 表情が参照しているパラメータ一覧
+    csmFloat32 _fadeWeight;                         ///< 表情の現在のウェイト
 };
 
 }}}

--- a/src/Motion/CubismExpressionMotionManager.cpp
+++ b/src/Motion/CubismExpressionMotionManager.cpp
@@ -1,0 +1,183 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismExpressionMotionManager.hpp"
+#include "CubismExpressionMotion.hpp"
+#include "CubismMotionQueueEntry.hpp"
+#include "CubismFramework.hpp"
+#include "Math/CubismMath.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismExpressionMotionManager::CubismExpressionMotionManager()
+    : _currentPriority(0)
+    , _reservePriority(0)
+    , _expressionParameterValues(CSM_NEW csmVector<ExpressionParameterValue>())
+{ }
+
+CubismExpressionMotionManager::~CubismExpressionMotionManager()
+{
+    if(_expressionParameterValues)
+    {
+        CSM_DELETE(_expressionParameterValues);
+
+        _expressionParameterValues = NULL;
+    }
+}
+
+csmInt32 CubismExpressionMotionManager::GetCurrentPriority() const
+{
+    return _currentPriority;
+}
+
+csmInt32 CubismExpressionMotionManager::GetReservePriority() const
+{
+    return _reservePriority;
+}
+
+void CubismExpressionMotionManager::SetReservePriority(csmInt32 priority)
+{
+    _reservePriority = priority;
+}
+
+CubismMotionQueueEntryHandle CubismExpressionMotionManager::StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority)
+{
+    if (priority == _reservePriority)
+    {
+        _reservePriority = 0;           // 予約を解除
+    }
+    _currentPriority = priority;        // 再生中モーションの優先度を設定
+
+    return CubismMotionQueueManager::StartMotion(motion, autoDelete, _userTimeSeconds);
+}
+
+csmBool CubismExpressionMotionManager::UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds)
+{
+    _userTimeSeconds += deltaTimeSeconds;
+    csmBool updated = false;
+    csmVector<CubismMotionQueueEntry*>* motions = GetCubismMotionQueueEntries();
+
+    csmFloat32 expressionWeight = 0.0f;
+    csmInt32 expressionIndex = 0;
+
+    // ------- 処理を行う --------
+    // 既にモーションがあれば終了フラグを立てる
+    for (csmVector<CubismMotionQueueEntry*>::iterator ite = motions->Begin(); ite != motions->End();)
+    {
+        CubismMotionQueueEntry* motionQueueEntry = *ite;
+
+        if (motionQueueEntry == NULL)
+        {
+            ite = motions->Erase(ite);          // 削除
+            continue;
+        }
+
+        CubismExpressionMotion* expressionMotion = (CubismExpressionMotion*)motionQueueEntry->GetCubismMotion();
+
+        if (expressionMotion == NULL)
+        {
+            CSM_DELETE(motionQueueEntry);
+            ite = motions->Erase(ite);          // 削除
+            continue;
+        }
+
+        csmVector<CubismExpressionMotion::ExpressionParameter> expressionParameters = expressionMotion->GetExpressionParameters();
+        if (motionQueueEntry->IsAvailable())
+        {
+            // 再生中のExpressionが参照しているパラメータをすべてリストアップ
+            for (csmInt32 i = 0; i < expressionParameters.GetSize(); ++i)
+            {
+                if (expressionParameters[i].ParameterId == NULL)
+                {
+                    continue;
+                }
+
+                csmInt32 index = -1;
+                // リストにパラメータIDが存在するか検索
+                for (csmInt32 j = 0; j < _expressionParameterValues->GetSize(); ++j)
+                {
+                    if (_expressionParameterValues->At(j).ParameterId != expressionParameters[i].ParameterId)
+                    {
+                        continue;
+                    }
+
+                    index = j;
+                    break;
+                }
+
+                if (index >= 0)
+                {
+                    continue;
+                }
+
+                // パラメータがリストに存在しないなら新規追加
+                ExpressionParameterValue item;
+                item.ParameterId = expressionParameters[i].ParameterId;
+                item.AdditiveValue = CubismExpressionMotion::DefaultAdditiveValue;
+                item.MultiplyValue = CubismExpressionMotion::DefaultMultiplyValue;
+                item.OverwriteValue = model->GetParameterValue(item.ParameterId);
+                _expressionParameterValues->PushBack(item);
+            }
+        }
+
+        // ------ 値を計算する ------
+        expressionMotion->CalculateExpressionParameters(model, _userTimeSeconds, motionQueueEntry,
+            _expressionParameterValues, expressionIndex);
+
+        expressionWeight += expressionMotion->GetFadeInTime() == 0.0f
+            ? 1.0f
+            : CubismMath::GetEasingSine((_userTimeSeconds - motionQueueEntry->GetFadeInStartTime()) / expressionMotion->GetFadeInTime());
+
+        updated = true;
+
+        if (motionQueueEntry->IsTriggeredFadeOut())
+        {
+            // フェードアウト開始
+            motionQueueEntry->StartFadeout(motionQueueEntry->GetFadeOutSeconds(), _userTimeSeconds);
+        }
+
+        ++ite;
+        ++expressionIndex;
+    }
+
+    // ----- 最新のExpressionのフェードが完了していればそれ以前を削除する ------
+    if (motions->GetSize() > 1)
+    {
+        CubismExpressionMotion* expressionMotion =
+            (CubismExpressionMotion*)(motions->At(motions->GetSize() - 1))->GetCubismMotion();
+        if (expressionMotion->GetFadeWeight() >= 1.0f)
+        {
+            // 配列の最後の要素は削除しない
+            for (csmInt32 i = motions->GetSize()-2; i >= 0; i--)
+            {
+                CubismMotionQueueEntry* motionQueueEntry = motions->At(i);
+                CSM_DELETE(motionQueueEntry);
+                motions->Remove(i);
+            }
+        }
+    }
+
+    if (expressionWeight > 1.0f)
+    {
+        expressionWeight = 1.0f;
+    }
+
+    // モデルに各値を適用
+    for (csmInt32 i = 0; i < _expressionParameterValues->GetSize(); ++i)
+    {
+        model->SetParameterValue(_expressionParameterValues->At(i).ParameterId,
+            (_expressionParameterValues->At(i).OverwriteValue + _expressionParameterValues->At(i).AdditiveValue) * _expressionParameterValues->At(i).MultiplyValue,
+            expressionWeight);
+
+        _expressionParameterValues->At(i).AdditiveValue = CubismExpressionMotion::DefaultAdditiveValue;
+        _expressionParameterValues->At(i).MultiplyValue = CubismExpressionMotion::DefaultMultiplyValue;
+    }
+
+    return updated;
+}
+
+}}}

--- a/src/Motion/CubismExpressionMotionManager.hpp
+++ b/src/Motion/CubismExpressionMotionManager.hpp
@@ -1,0 +1,109 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "Model/CubismModel.hpp"
+#include "ACubismMotion.hpp"
+#include "CubismMotionQueueManager.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * @brief 表情モーションの管理
+ *
+ * 表情モーションの管理を行うクラス。
+ */
+class CubismExpressionMotionManager : public CubismMotionQueueManager
+{
+public:
+    /**
+     * @brief パラメータに適用する表情の値を持たせる構造体
+     */
+    struct ExpressionParameterValue
+    {
+        CubismIdHandle      ParameterId;        ///< パラメータID
+        csmFloat32          AdditiveValue;      ///< 加算値
+        csmFloat32          MultiplyValue;      ///< 乗算値
+        csmFloat32          OverwriteValue;           ///< 上書き値
+    };
+
+    /**
+     * @brief コンストラクタ
+     *
+     * コンストラクタ。
+     */
+    CubismExpressionMotionManager();
+
+    /**
+     * @brief デストラクタ
+     *
+     * デストラクタ。
+     */
+    virtual ~CubismExpressionMotionManager();
+
+    /**
+     * @brief 再生中のモーションの優先度の取得
+     *
+     * 再生中の表情モーションの優先度の取得する。
+     *
+     * @return  表情モーションの優先度
+     */
+    csmInt32 GetCurrentPriority() const;
+
+    /**
+     * @brief 予約中のモーションの優先度の取得
+     *
+     * 予約中の表情モーションの優先度を取得する。
+     *
+     * @return  表情モーションの優先度
+     */
+    csmInt32 GetReservePriority() const;
+
+    /**
+     * @brief 予約中のモーションの優先度の設定
+     *
+     * 予約中の表情モーションの優先度を設定する。
+     *
+     * @param[in]   priority     優先度
+     */
+    void SetReservePriority(csmInt32 priority);
+
+    /**
+     * @brief 優先度を設定して表情モーションの開始
+     *
+     * 優先度を設定して表情モーションを開始する。
+     *
+     * @param[in]   motion          モーション
+     * @param[in]   autoDelete      再生が終了したモーションのインスタンスを削除するならtrue
+     * @param[in]   priority        優先度
+     * @return                      開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判定するIsFinished()の引数で使用する。開始できない時は「-1」
+     */
+    CubismMotionQueueEntryHandle StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority);
+
+    /**
+     * @brief モーションの更新
+     *
+     * 表情モーションを更新して、モデルにパラメータ値を反映する。
+     *
+     * @param[in]   model   対象のモデル
+     * @param[in]   deltaTimeSeconds    デルタ時間[秒]
+     * @retval  true    更新されている
+     * @retval  false   更新されていない
+     */
+    csmBool UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds);
+
+private:
+
+    // モデルに適用する各パラメータの値
+    csmVector<ExpressionParameterValue>* _expressionParameterValues;
+
+    csmInt32 _currentPriority;                  ///<  現在再生中のモーションの優先度
+    csmInt32 _reservePriority;                  ///<  再生予定のモーションの優先度。再生中は0になる。モーションファイルを別スレッドで読み込むときの機能。
+};
+
+}}}

--- a/src/Motion/CubismMotionQueueEntry.cpp
+++ b/src/Motion/CubismMotionQueueEntry.cpp
@@ -151,4 +151,9 @@ csmFloat32 CubismMotionQueueEntry::GetFadeOutSeconds()
     return this->_fadeOutSeconds;
 }
 
+ACubismMotion* CubismMotionQueueEntry::GetCubismMotion()
+{
+    return _motion;
+}
+
 }}}

--- a/src/Motion/CubismMotionQueueEntry.hpp
+++ b/src/Motion/CubismMotionQueueEntry.hpp
@@ -235,6 +235,8 @@ public:
     */
     csmFloat32     GetFadeOutSeconds();
 
+    ACubismMotion* GetCubismMotion();
+
 private:
     csmBool         _autoDelete;                    ///< 自動削除
     ACubismMotion*  _motion;                        ///< モーション

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -125,6 +125,11 @@ csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 
     return updated;
 }
 
+csmVector<CubismMotionQueueEntry*>* CubismMotionQueueManager::GetCubismMotionQueueEntries()
+{
+    return &_motions;
+}
+
 CubismMotionQueueEntry* CubismMotionQueueManager::GetCubismMotionQueueEntry(CubismMotionQueueEntryHandle motionQueueEntryNumber)
 {
     //------- 処理を行う --------

--- a/src/Motion/CubismMotionQueueManager.hpp
+++ b/src/Motion/CubismMotionQueueManager.hpp
@@ -114,6 +114,16 @@ public:
     CubismMotionQueueEntry* GetCubismMotionQueueEntry(CubismMotionQueueEntryHandle motionQueueEntryNumber);
 
     /**
+     * @brief CubismMotionQueueEntryの配列の取得
+     *
+     * CubismMotionQueueEntryの配列を取得する。
+     *
+     * @return  CubismMotionQueueEntryの配列へのポインタ
+     * @retval  NULL   見つからなかった
+     */
+    csmVector<CubismMotionQueueEntry*>* GetCubismMotionQueueEntries();
+
+    /**
     * @brief イベントを受け取るCallbackの登録
     *
     * イベントを受け取るCallbackの登録をする。

--- a/src/Rendering/CMakeLists.txt
+++ b/src/Rendering/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(${LIB_NAME}
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismClippingManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismClippingManager.tpp
 )
 
 if(NOT DEFINED FRAMEWORK_SOURCE)

--- a/src/Rendering/Cocos2d/CMakeLists.txt
+++ b/src/Rendering/Cocos2d/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_Cocos2dx.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Cocos2dx.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Cocos2dx.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_Cocos2dx.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_Cocos2dx.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismCommandBuffer_Cocos2dx.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismCommandBuffer_Cocos2dx.hpp
 )

--- a/src/Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.cpp
@@ -161,11 +161,11 @@ void CubismCommandBuffer_Cocos2dx::SetOperationEnable(OperationType operationTyp
             {
                 switch (_operationStateArray[operationType].Arg0.i32)
                 {
-                case CullType_Front:
-                    GetCocos2dRenderer()->setCullMode(cocos2d::CullMode::FRONT);
-                    break;
                 case CullType_Back:
                     GetCocos2dRenderer()->setCullMode(cocos2d::CullMode::BACK);
+                    break;
+                case CullType_Front:
+                    GetCocos2dRenderer()->setCullMode(cocos2d::CullMode::FRONT);
                     break;
                 }
             }

--- a/src/Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.hpp
@@ -120,8 +120,8 @@ public:
 
     enum CullType
     {
-        CullType_Front,
         CullType_Back,
+        CullType_Front,
     };
 
     enum WindingType

--- a/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.cpp
@@ -10,7 +10,7 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-CubismOffscreenFrame_Cocos2dx::CubismOffscreenFrame_Cocos2dx()
+CubismOffscreenSurface_Cocos2dx::CubismOffscreenSurface_Cocos2dx()
     : _renderTexture(NULL)
     , _colorBuffer(NULL)
     , _isInheritedRenderTexture(false)
@@ -21,7 +21,7 @@ CubismOffscreenFrame_Cocos2dx::CubismOffscreenFrame_Cocos2dx()
 }
 
 
-void CubismOffscreenFrame_Cocos2dx::BeginDraw(CubismCommandBuffer_Cocos2dx* commandBuffer, cocos2d::Texture2D* colorBufferOnFinishDrawing)
+void CubismOffscreenSurface_Cocos2dx::BeginDraw(CubismCommandBuffer_Cocos2dx* commandBuffer, cocos2d::Texture2D* colorBufferOnFinishDrawing)
 {
     if (!IsValid())
     {
@@ -46,7 +46,7 @@ void CubismOffscreenFrame_Cocos2dx::BeginDraw(CubismCommandBuffer_Cocos2dx* comm
     commandBuffer->SetColorBuffer(_renderTexture->getSprite()->getTexture());
 }
 
-void CubismOffscreenFrame_Cocos2dx::EndDraw(CubismCommandBuffer_Cocos2dx* commandBuffer)
+void CubismOffscreenSurface_Cocos2dx::EndDraw(CubismCommandBuffer_Cocos2dx* commandBuffer)
 {
     if (!IsValid())
     {
@@ -57,16 +57,16 @@ void CubismOffscreenFrame_Cocos2dx::EndDraw(CubismCommandBuffer_Cocos2dx* comman
     commandBuffer->SetColorBuffer(_previousColorBuffer);
 }
 
-void CubismOffscreenFrame_Cocos2dx::Clear(CubismCommandBuffer_Cocos2dx* commandBuffer, float r, float g, float b, float a)
+void CubismOffscreenSurface_Cocos2dx::Clear(CubismCommandBuffer_Cocos2dx* commandBuffer, float r, float g, float b, float a)
 {
     // マスクをクリアする
     commandBuffer->Clear(r, g, b, a);
 }
 
-csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::RenderTexture* renderTexture)
+csmBool CubismOffscreenSurface_Cocos2dx::CreateOffscreenSurface(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::RenderTexture* renderTexture)
 {
     // 一旦削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     do
     {
@@ -130,12 +130,12 @@ csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBuf
     } while (0);
 
     // 失敗したので削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     return false;
 }
 
-void CubismOffscreenFrame_Cocos2dx::DestroyOffscreenFrame()
+void CubismOffscreenSurface_Cocos2dx::DestroyOffscreenSurface()
 {
     if ((_renderTexture != NULL) && !_isInheritedRenderTexture)
     {
@@ -144,27 +144,27 @@ void CubismOffscreenFrame_Cocos2dx::DestroyOffscreenFrame()
     }
 }
 
-cocos2d::Texture2D* CubismOffscreenFrame_Cocos2dx::GetColorBuffer() const
+cocos2d::Texture2D* CubismOffscreenSurface_Cocos2dx::GetColorBuffer() const
 {
     return _renderTexture->getSprite()->getTexture();
 }
 
-csmUint32 CubismOffscreenFrame_Cocos2dx::GetBufferWidth() const
+csmUint32 CubismOffscreenSurface_Cocos2dx::GetBufferWidth() const
 {
     return _bufferWidth;
 }
 
-csmUint32 CubismOffscreenFrame_Cocos2dx::GetBufferHeight() const
+csmUint32 CubismOffscreenSurface_Cocos2dx::GetBufferHeight() const
 {
     return _bufferHeight;
 }
 
-csmRectF CubismOffscreenFrame_Cocos2dx::GetViewPortSize() const
+csmRectF CubismOffscreenSurface_Cocos2dx::GetViewPortSize() const
 {
     return _viewPortSize;
 }
 
-csmBool CubismOffscreenFrame_Cocos2dx::IsValid() const
+csmBool CubismOffscreenSurface_Cocos2dx::IsValid() const
 {
     return _renderTexture != NULL;
 }

--- a/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp
@@ -45,11 +45,11 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /**
  * @brief  オフスクリーン描画用構造体
  */
-class CubismOffscreenFrame_Cocos2dx
+class CubismOffscreenSurface_Cocos2dx
 {
 public:
 
-    CubismOffscreenFrame_Cocos2dx();
+    CubismOffscreenSurface_Cocos2dx();
 
     /**
      * @brief   指定の描画ターゲットに向けて描画開始
@@ -74,17 +74,17 @@ public:
     void Clear(CubismCommandBuffer_Cocos2dx* commandBuffer, float r, float g, float b, float a);
 
     /**
-     *  @brief  CubismOffscreenFrame作成
+     *  @brief  CubismOffscreenSurface作成
      *  @param  displayBufferWidth     作成するバッファ幅
      *  @param  displayBufferHeight    作成するバッファ高さ
      *  @param  colorBuffer            0以外の場合、ピクセル格納領域としてcolorBufferを使用する
      */
-    csmBool CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::RenderTexture* renderTexture = NULL);
+    csmBool CreateOffscreenSurface(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, cocos2d::RenderTexture* renderTexture = NULL);
 
     /**
-     * @brief   CubismOffscreenFrameの削除
+     * @brief   CubismOffscreenSurfaceの削除
      */
-    void DestroyOffscreenFrame();
+    void DestroyOffscreenSurface();
 
     /**
      * @brief   カラーバッファメンバーへのアクセッサ

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
@@ -22,139 +22,6 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /*********************************************************************************************************************
 *                                      CubismClippingManager_Cocos2dx
 ********************************************************************************************************************/
-///< ファイルスコープの変数宣言
-namespace {
-const csmInt32 ColorChannelCount = 4;   // 実験時に1チャンネルの場合は1、RGBだけの場合は3、アルファも含める場合は4
-const csmInt32 ClippingMaskMaxCountOnDefault = 36;  // 通常のフレームバッファ1枚あたりのマスク最大数
-const csmInt32 ClippingMaskMaxCountOnMultiRenderTexture = 32;   // フレームバッファが2枚以上ある場合のフレームバッファ1枚あたりのマスク最大数
-}
-
-CubismClippingManager_Cocos2dx::CubismClippingManager_Cocos2dx() :
-                                                                   _clippingMaskBufferSize(256, 256)
-{
-    CubismRenderer::CubismTextureColor* tmp;
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 1.0f;
-    tmp->G = 0.0f;
-    tmp->B = 0.0f;
-    tmp->A = 0.0f;
-    _channelColors.PushBack(tmp);
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 0.0f;
-    tmp->G = 1.0f;
-    tmp->B = 0.0f;
-    tmp->A = 0.0f;
-    _channelColors.PushBack(tmp);
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 0.0f;
-    tmp->G = 0.0f;
-    tmp->B = 1.0f;
-    tmp->A = 0.0f;
-    _channelColors.PushBack(tmp);
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 0.0f;
-    tmp->G = 0.0f;
-    tmp->B = 0.0f;
-    tmp->A = 1.0f;
-    _channelColors.PushBack(tmp);
-
-}
-
-CubismClippingManager_Cocos2dx::~CubismClippingManager_Cocos2dx()
-{
-    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
-    {
-        if (_clippingContextListForMask[i]) CSM_DELETE_SELF(CubismClippingContext, _clippingContextListForMask[i]);
-        _clippingContextListForMask[i] = NULL;
-    }
-
-    // _clippingContextListForDrawは_clippingContextListForMaskにあるインスタンスを指している。上記の処理により要素ごとのDELETEは不要。
-    for (csmUint32 i = 0; i < _clippingContextListForDraw.GetSize(); i++)
-    {
-        _clippingContextListForDraw[i] = NULL;
-    }
-
-    for (csmUint32 i = 0; i < _channelColors.GetSize(); i++)
-    {
-        if (_channelColors[i]) CSM_DELETE(_channelColors[i]);
-        _channelColors[i] = NULL;
-    }
-
-    if (_clearedFrameBufferFlags.GetSize() != 0)
-    {
-        _clearedFrameBufferFlags.Clear();
-        _clearedFrameBufferFlags = NULL;
-    }
-}
-
-void CubismClippingManager_Cocos2dx::Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts, const csmInt32 maskBufferCount)
-{
-    _renderTextureCount = maskBufferCount;
-
-    // レンダーテクスチャのクリアフラグの設定
-    for (csmInt32 i = 0; i < _renderTextureCount; ++i)
-    {
-        _clearedFrameBufferFlags.PushBack(false);
-    }
-
-    //クリッピングマスクを使う描画オブジェクトを全て登録する
-    //クリッピングマスクは、通常数個程度に限定して使うものとする
-    for (csmInt32 i = 0; i < drawableCount; i++)
-    {
-        if (drawableMaskCounts[i] <= 0)
-        {
-            //クリッピングマスクが使用されていないアートメッシュ（多くの場合使用しない）
-            _clippingContextListForDraw.PushBack(NULL);
-            continue;
-        }
-
-        // 既にあるClipContextと同じかチェックする
-        CubismClippingContext* cc = FindSameClip(drawableMasks[i], drawableMaskCounts[i]);
-        if (cc == NULL)
-        {
-            // 同一のマスクが存在していない場合は生成する
-            cc = CSM_NEW CubismClippingContext(this, model, drawableMasks[i], drawableMaskCounts[i]);
-            _clippingContextListForMask.PushBack(cc);
-        }
-
-        cc->AddClippedDrawable(i);
-
-        _clippingContextListForDraw.PushBack(cc);
-
-    }
-}
-
-CubismClippingContext* CubismClippingManager_Cocos2dx::FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const
-{
-    // 作成済みClippingContextと一致するか確認
-    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
-    {
-        CubismClippingContext* cc = _clippingContextListForMask[i];
-        const csmInt32 count = cc->_clippingIdCount;
-        if (count != drawableMaskCounts) continue; //個数が違う場合は別物
-        csmInt32 samecount = 0;
-
-        // 同じIDを持つか確認。配列の数が同じなので、一致した個数が同じなら同じ物を持つとする。
-        for (csmInt32 j = 0; j < count; j++)
-        {
-            const csmInt32 clipId = cc->_clippingIdList[j];
-            for (csmInt32 k = 0; k < count; k++)
-            {
-                if (drawableMasks[k] == clipId)
-                {
-                    samecount++;
-                    break;
-                }
-            }
-        }
-        if (samecount == count)
-        {
-            return cc;
-        }
-    }
-    return NULL; //見つからなかった
-}
-
 void CubismClippingManager_Cocos2dx::SetupClippingContext(CubismModel& model, CubismRenderer_Cocos2dx* renderer, cocos2d::Texture2D* lastColorBuffer, csmRectF lastViewport)
 {
     // 全てのクリッピングを用意する
@@ -163,7 +30,7 @@ void CubismClippingManager_Cocos2dx::SetupClippingContext(CubismModel& model, Cu
     for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
     {
         // １つのクリッピングマスクに関して
-        CubismClippingContext* cc = _clippingContextListForMask[clipIndex];
+        CubismClippingContext_Cocos2dx* cc = _clippingContextListForMask[clipIndex];
 
         // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
         CalcClippedDrawTotalBounds(model, cc);
@@ -174,496 +41,153 @@ void CubismClippingManager_Cocos2dx::SetupClippingContext(CubismModel& model, Cu
         }
     }
 
-    // マスク作成処理
-    if (usingClipCount > 0)
+    if (usingClipCount <= 0)
     {
-        if (!renderer->IsUsingHighPrecisionMask())
-        {
-            // 後の計算のためにインデックスの最初をセット
-            _currentOffscreenFrameBuffer = renderer->GetOffScreenFrameBuffer(0);
-
-            // 生成したFrameBufferと同じサイズでビューポートを設定
-            renderer->GetCommandBuffer()->Viewport(0, 0, _currentOffscreenFrameBuffer->GetViewPortSize().Width, _currentOffscreenFrameBuffer->GetViewPortSize().Height);
-
-            renderer->PreDraw(); // バッファをクリアする
-
-            // _offscreenFrameBufferへ切り替え
-            _currentOffscreenFrameBuffer->BeginDraw(renderer->GetCommandBuffer(), lastColorBuffer);
-        }
-
-        // 各マスクのレイアウトを決定していく
-        SetupLayoutBounds(renderer->IsUsingHighPrecisionMask() ? 0 : usingClipCount);
-
-        // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
-        if (_clearedFrameBufferFlags.GetSize() != _renderTextureCount)
-        {
-            _clearedFrameBufferFlags.Clear();
-
-            for (csmInt32 i = 0; i < _renderTextureCount; ++i)
-            {
-                _clearedFrameBufferFlags.PushBack(false);
-            }
-        }
-        else
-        {
-            // マスクのクリアフラグを毎フレーム開始時に初期化
-            for (csmInt32 i = 0; i < _renderTextureCount; ++i)
-            {
-                _clearedFrameBufferFlags[i] = false;
-            }
-        }
-
-        // 実際にマスクを生成する
-        // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
-        for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
-        {
-            // --- 実際に１つのマスクを描く ---
-            CubismClippingContext* clipContext = _clippingContextListForMask[clipIndex];
-            csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
-            csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
-            const csmFloat32 MARGIN = 0.05f;
-            csmFloat32 scaleX = 0.0f;
-            csmFloat32 scaleY = 0.0f;
-
-            // clipContextに設定したレンダーテクスチャをインデックスで取得
-            CubismOffscreenFrame_Cocos2dx* clipContextOffscreenFrameBuffer = renderer->GetOffScreenFrameBuffer(clipContext->_bufferIndex);
-
-            // 現在のレンダーテクスチャがclipContextのものと異なる場合
-            if (_currentOffscreenFrameBuffer != clipContextOffscreenFrameBuffer &&
-                !renderer->IsUsingHighPrecisionMask())
-            {
-                _currentOffscreenFrameBuffer->EndDraw(renderer->GetCommandBuffer());
-
-                _currentOffscreenFrameBuffer = clipContextOffscreenFrameBuffer;
-
-                renderer->GetCommandBuffer()->Viewport(0, 0, _currentOffscreenFrameBuffer->GetViewPortSize().Width, _currentOffscreenFrameBuffer->GetViewPortSize().Height);
-
-                renderer->PreDraw(); // バッファをクリアする
-
-                _currentOffscreenFrameBuffer->BeginDraw(renderer->GetCommandBuffer(), lastColorBuffer);
-            }
-
-            if (renderer->IsUsingHighPrecisionMask())
-            {
-                const csmFloat32 ppu = model.GetPixelsPerUnit();
-                const csmFloat32 maskPixelWidth = clipContext->GetClippingManager()->_clippingMaskBufferSize.X;
-                const csmFloat32 maskPixelHeight = clipContext->GetClippingManager()->_clippingMaskBufferSize.Y;
-                const csmFloat32 physicalMaskWidth = layoutBoundsOnTex01->Width * maskPixelWidth;
-                const csmFloat32 physicalMaskHeight = layoutBoundsOnTex01->Height * maskPixelHeight;
-
-                _tmpBoundsOnModel.SetRect(allClippedDrawRect);
-
-                if (_tmpBoundsOnModel.Width * ppu > physicalMaskWidth)
-                {
-                    _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, 0.0f);
-                    scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
-                }
-                else
-                {
-                    scaleX = ppu / physicalMaskWidth;
-                }
-
-                if (_tmpBoundsOnModel.Height * ppu > physicalMaskHeight)
-                {
-                    _tmpBoundsOnModel.Expand(0.0f, allClippedDrawRect->Height * MARGIN);
-                    scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
-                }
-                else
-                {
-                    scaleY = ppu / physicalMaskHeight;
-                }
-            }
-            else
-            {
-                // モデル座標上の矩形を、適宜マージンを付けて使う
-                _tmpBoundsOnModel.SetRect(allClippedDrawRect);
-                _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, allClippedDrawRect->Height * MARGIN);
-                //########## 本来は割り当てられた領域の全体を使わず必要最低限のサイズがよい
-                // シェーダ用の計算式を求める。回転を考慮しない場合は以下のとおり
-                // movePeriod' = movePeriod * scaleX + offX     [[ movePeriod' = (movePeriod - tmpBoundsOnModel.movePeriod)*scale + layoutBoundsOnTex01.movePeriod ]]
-                scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
-                scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
-            }
-
-            // マスク生成時に使う行列を求める
-            {
-                // シェーダに渡す行列を求める <<<<<<<<<<<<<<<<<<<<<<<< 要最適化（逆順に計算すればシンプルにできる）
-                _tmpMatrix.LoadIdentity();
-                {
-                    // Layout0..1 を -1..1に変換
-                    _tmpMatrix.TranslateRelative(-1.0f, -1.0f);
-                    _tmpMatrix.ScaleRelative(2.0f, 2.0f);
-                }
-                {
-                    // view to Layout0..1
-                    _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
-                    _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
-                    _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y); //new = [translate][scale][translate]
-                }
-                // tmpMatrixForMask が計算結果
-                _tmpMatrixForMask.SetMatrix(_tmpMatrix.GetArray());
-            }
-
-            //--------- draw時の mask 参照用行列を計算
-            {
-                // シェーダに渡す行列を求める <<<<<<<<<<<<<<<<<<<<<<<< 要最適化（逆順に計算すればシンプルにできる）
-                _tmpMatrix.LoadIdentity();
-                {
-                    _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
-                    _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
-                    _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y); //new = [translate][scale][translate]
-                }
-
-                _tmpMatrixForDraw.SetMatrix(_tmpMatrix.GetArray());
-            }
-
-            clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
-
-            clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
-
-            if (!renderer->IsUsingHighPrecisionMask())
-            {
-                const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
-                for (csmInt32 i = 0; i < clipDrawCount; i++)
-                {
-                    const csmInt32 clipDrawIndex = clipContext->_clippingIdList[i];
-                    CubismCommandBuffer_Cocos2dx::DrawCommandBuffer* drawCommandBufferData = clipContext->_clippingCommandBufferList->At(i);// [i];
-
-
-                    // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
-                    if (!model.GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
-                    {
-                        continue;
-                    }
-
-                    // Update Vertex / Index buffer.
-                    {
-                        csmFloat32* vertices = const_cast<csmFloat32*>(model.GetDrawableVertices(clipDrawIndex));
-                        Core::csmVector2* uvs = const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(clipDrawIndex));
-                        csmUint16* vertexIndices = const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex));
-                        const csmUint32 vertexCount = model.GetDrawableVertexCount(clipDrawIndex);
-                        const csmUint32 vertexIndexCount = model.GetDrawableVertexIndexCount(clipDrawIndex);
-
-                        drawCommandBufferData->UpdateVertexBuffer(vertices, uvs, vertexCount);
-                        drawCommandBufferData->CommitVertexBuffer();
-                        if (vertexIndexCount > 0)
-                        {
-                            drawCommandBufferData->UpdateIndexBuffer(vertexIndices, vertexIndexCount);
-                        }
-
-                        if (vertexCount <= 0)
-                        {
-                            continue;
-                        }
-
-                    }
-
-                    renderer->IsCulling(model.GetDrawableCulling(clipDrawIndex) != 0);
-
-                    // マスクがクリアされていないなら処理する
-                    if (!_clearedFrameBufferFlags[clipContext->_bufferIndex])
-                    {
-                        // マスクをクリアする
-                        // (仮仕様) 1が無効（描かれない）領域、0が有効（描かれる）領域。（シェーダーCd*Csで0に近い値をかけてマスクを作る。1をかけると何も起こらない）
-                        renderer->GetOffScreenFrameBuffer(clipContext->_bufferIndex)->Clear(renderer->GetCommandBuffer(), 1.0f, 1.0f, 1.0f, 1.0f);
-                        _clearedFrameBufferFlags[clipContext->_bufferIndex] = true;
-                    }
-
-                    // 今回専用の変換を適用して描く
-                    // チャンネルも切り替える必要がある(A,R,G,B)
-                    renderer->SetClippingContextBufferForMask(clipContext);
-
-                    renderer->DrawMeshCocos2d(
-                        drawCommandBufferData->GetCommandDraw(),
-                        model.GetDrawableTextureIndex(clipDrawIndex),
-                        model.GetDrawableVertexIndexCount(clipDrawIndex),
-                        model.GetDrawableVertexCount(clipDrawIndex),
-                        const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
-                        const_cast<csmFloat32*>(model.GetDrawableVertices(clipDrawIndex)),
-                        reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(clipDrawIndex))),
-                        model.GetMultiplyColor(clipDrawIndex),
-                        model.GetScreenColor(clipDrawIndex),
-                        model.GetDrawableOpacity(clipDrawIndex),
-                        CubismRenderer::CubismBlendMode_Normal,   //クリッピングは通常描画を強制
-                        false   // マスク生成時はクリッピングの反転使用は全く関係がない
-                    );
-                }
-            }
-        }
-
-        if (!renderer->IsUsingHighPrecisionMask())
-        {
-            // --- 後処理 ---
-            _currentOffscreenFrameBuffer->EndDraw(renderer->GetCommandBuffer()); // 描画対象を戻す
-            renderer->SetClippingContextBufferForMask(NULL);
-            renderer->GetCommandBuffer()->Viewport(lastViewport.X, lastViewport.Y, lastViewport.Width, lastViewport.Height);
-        }
-    }
-}
-
-void CubismClippingManager_Cocos2dx::CalcClippedDrawTotalBounds(CubismModel& model, CubismClippingContext* clippingContext)
-{
-    // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
-    csmFloat32 clippedDrawTotalMinX = FLT_MAX, clippedDrawTotalMinY = FLT_MAX;
-    csmFloat32 clippedDrawTotalMaxX = -FLT_MAX, clippedDrawTotalMaxY = -FLT_MAX;
-
-    // このマスクが実際に必要か判定する
-    // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある
-
-    const csmInt32 clippedDrawCount = clippingContext->_clippedDrawableIndexList->GetSize();
-    for (csmInt32 clippedDrawableIndex = 0; clippedDrawableIndex < clippedDrawCount; clippedDrawableIndex++)
-    {
-        // マスクを使用する描画オブジェクトの描画される矩形を求める
-        const csmInt32 drawableIndex = (*clippingContext->_clippedDrawableIndexList)[clippedDrawableIndex];
-
-        const csmInt32 drawableVertexCount = model.GetDrawableVertexCount(drawableIndex);
-        csmFloat32* drawableVertexes = const_cast<csmFloat32*>(model.GetDrawableVertices(drawableIndex));
-
-        csmFloat32 minX = FLT_MAX, minY = FLT_MAX;
-        csmFloat32 maxX = -FLT_MAX, maxY = -FLT_MAX;
-
-        csmInt32 loop = drawableVertexCount * Constant::VertexStep;
-        for (csmInt32 pi = Constant::VertexOffset; pi < loop; pi += Constant::VertexStep)
-        {
-            csmFloat32 x = drawableVertexes[pi];
-            csmFloat32 y = drawableVertexes[pi + 1];
-            if (x < minX) minX = x;
-            if (x > maxX) maxX = x;
-            if (y < minY) minY = y;
-            if (y > maxY) maxY = y;
-        }
-
-        //
-        if (minX == FLT_MAX) continue; //有効な点がひとつも取れなかったのでスキップする
-
-        // 全体の矩形に反映
-        if (minX < clippedDrawTotalMinX) clippedDrawTotalMinX = minX;
-        if (minY < clippedDrawTotalMinY) clippedDrawTotalMinY = minY;
-        if (maxX > clippedDrawTotalMaxX) clippedDrawTotalMaxX = maxX;
-        if (maxY > clippedDrawTotalMaxY) clippedDrawTotalMaxY = maxY;
-    }
-    if (clippedDrawTotalMinX == FLT_MAX)
-    {
-        clippingContext->_allClippedDrawRect->X = 0.0f;
-        clippingContext->_allClippedDrawRect->Y = 0.0f;
-        clippingContext->_allClippedDrawRect->Width = 0.0f;
-        clippingContext->_allClippedDrawRect->Height = 0.0f;
-        clippingContext->_isUsing = false;
-    }
-    else
-    {
-        clippingContext->_isUsing = true;
-        csmFloat32 w = clippedDrawTotalMaxX - clippedDrawTotalMinX;
-        csmFloat32 h = clippedDrawTotalMaxY - clippedDrawTotalMinY;
-        clippingContext->_allClippedDrawRect->X = clippedDrawTotalMinX;
-        clippingContext->_allClippedDrawRect->Y = clippedDrawTotalMinY;
-        clippingContext->_allClippedDrawRect->Width = w;
-        clippingContext->_allClippedDrawRect->Height = h;
-    }
-}
-
-void CubismClippingManager_Cocos2dx::SetupLayoutBounds(csmInt32 usingClipCount) const
-{
-    const csmInt32 useClippingMaskMaxCount = _renderTextureCount <= 1
-        ? ClippingMaskMaxCountOnDefault
-        : ClippingMaskMaxCountOnMultiRenderTexture * _renderTextureCount;
-
-    if (usingClipCount <= 0 || usingClipCount > useClippingMaskMaxCount)
-    {
-        if (usingClipCount > useClippingMaskMaxCount)
-        {
-            // マスクの制限数の警告を出す
-            csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-            CubismLogError("not supported mask count : %d\n[Details] render texture count : %d\n, mask count : %d"
-                , count, _renderTextureCount, usingClipCount);
-        }
-
-        // この場合は一つのマスクターゲットを毎回クリアして使用する
-        for (csmUint32 index = 0; index < _clippingContextListForMask.GetSize(); index++)
-        {
-            CubismClippingContext* cc = _clippingContextListForMask[index];
-            cc->_layoutChannelNo = 0; // どうせ毎回消すので固定で良い
-            cc->_layoutBounds->X = 0.0f;
-            cc->_layoutBounds->Y = 0.0f;
-            cc->_layoutBounds->Width = 1.0f;
-            cc->_layoutBounds->Height = 1.0f;
-            cc->_bufferIndex = 0;
-        }
         return;
     }
 
-    // レンダーテクスチャが1枚なら9分割する（最大36枚）
-    const csmInt32 layoutCountMaxValue = _renderTextureCount <= 1 ? 9 : 8;
+    // マスク作成処理
+    // 後の計算のためにインデックスの最初をセット
+    _currentMaskBuffer = renderer->GetOffscreenSurface(0);
 
-    // ひとつのRenderTextureを極力いっぱいに使ってマスクをレイアウトする
-    // マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する
-    const csmInt32 countPerSheetDiv = usingClipCount / _renderTextureCount; // レンダーテクスチャ1枚あたり何枚割り当てるか
-    const csmInt32 countPerSheetMod = usingClipCount % _renderTextureCount; // この番号のレンダーテクスチャまでに一つずつ配分する
+    // 生成したOffscreenSurfaceと同じサイズでビューポートを設定
+    renderer->GetCommandBuffer()->Viewport(0, 0, _currentMaskBuffer->GetViewPortSize().Width, _currentMaskBuffer->GetViewPortSize().Height);
 
-    // RGBAを順番に使っていく。
-    const csmInt32 div = countPerSheetDiv / ColorChannelCount; //１チャンネルに配置する基本のマスク個数
-    const csmInt32 mod = countPerSheetDiv % ColorChannelCount; //余り、この番号のチャンネルまでに１つずつ配分する
+    renderer->PreDraw(); // バッファをクリアする
 
-    // RGBAそれぞれのチャンネルを用意していく(0:R , 1:G , 2:B, 3:A, )
-    csmInt32 curClipIndex = 0; //順番に設定していく
+    // _OffscreenSurfaceへ切り替え
+    _currentMaskBuffer->BeginDraw(renderer->GetCommandBuffer(), lastColorBuffer);
 
-    for (csmInt32 renderTextureNo = 0; renderTextureNo < _renderTextureCount; renderTextureNo++)
+    // 各マスクのレイアウトを決定していく
+    SetupLayoutBounds(usingClipCount);
+
+    // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
+    if (_clearedMaskBufferFlags.GetSize() != _renderTextureCount)
     {
-        for (csmInt32 channelNo = 0; channelNo < ColorChannelCount; channelNo++)
+        _clearedMaskBufferFlags.Clear();
+
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
         {
-            // このチャンネルにレイアウトする数
-            csmInt32 layoutCount = div + (channelNo < mod ? 1 : 0);
-
-            // このレンダーテクスチャにまだ割り当てられていなければ追加する
-            const csmInt32 checkChannelNo = mod + 1 >= ColorChannelCount ? 0 : mod + 1;
-            if (layoutCount < layoutCountMaxValue && channelNo == checkChannelNo)
-            {
-                layoutCount += renderTextureNo < countPerSheetMod ? 1 : 0;
-            }
-
-            // 分割方法を決定する
-            if (layoutCount == 0)
-            {
-                // 何もしない
-            }
-            else if (layoutCount == 1)
-            {
-                //全てをそのまま使う
-                CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                cc->_layoutChannelNo = channelNo;
-                cc->_layoutBounds->X = 0.0f;
-                cc->_layoutBounds->Y = 0.0f;
-                cc->_layoutBounds->Width = 1.0f;
-                cc->_layoutBounds->Height = 1.0f;
-                cc->_bufferIndex = renderTextureNo;
-            }
-            else if (layoutCount == 2)
-            {
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    const csmInt32 xpos = i % 2;
-
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = channelNo;
-
-                    cc->_layoutBounds->X = xpos * 0.5f;
-                    cc->_layoutBounds->Y = 0.0f;
-                    cc->_layoutBounds->Width = 0.5f;
-                    cc->_layoutBounds->Height = 1.0f;
-                    cc->_bufferIndex = renderTextureNo;
-                    //UVを2つに分解して使う
-                }
-            }
-            else if (layoutCount <= 4)
-            {
-                //4分割して使う
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    const csmInt32 xpos = i % 2;
-                    const csmInt32 ypos = i / 2;
-
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = channelNo;
-
-                    cc->_layoutBounds->X = xpos * 0.5f;
-                    cc->_layoutBounds->Y = ypos * 0.5f;
-                    cc->_layoutBounds->Width = 0.5f;
-                    cc->_layoutBounds->Height = 0.5f;
-                    cc->_bufferIndex = renderTextureNo;
-                }
-            }
-            else if (layoutCount <= layoutCountMaxValue)
-            {
-                //9分割して使う
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    const csmInt32 xpos = i % 3;
-                    const csmInt32 ypos = i / 3;
-
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = channelNo;
-
-                    cc->_layoutBounds->X = xpos / 3.0f;
-                    cc->_layoutBounds->Y = ypos / 3.0f;
-                    cc->_layoutBounds->Width = 1.0f / 3.0f;
-                    cc->_layoutBounds->Height = 1.0f / 3.0f;
-                    cc->_bufferIndex = renderTextureNo;
-                }
-            }
-            // マスクの制限枚数を超えた場合の処理
-            else
-            {
-                csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-                CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : %d"
-                               , count, _renderTextureCount, usingClipCount);
-
-                // 開発モードの場合は停止させる
-                CSM_ASSERT(0);
-
-                // 引き続き実行する場合、 SetupShaderProgramでオーバーアクセスが発生するので仕方なく適当に入れておく
-                // もちろん描画結果はろくなことにならない
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = 0;
-                    cc->_layoutBounds->X = 0.0f;
-                    cc->_layoutBounds->Y = 0.0f;
-                    cc->_layoutBounds->Width = 1.0f;
-                    cc->_layoutBounds->Height = 1.0f;
-                    cc->_bufferIndex = 0;
-                }
-            }
+            _clearedMaskBufferFlags.PushBack(false);
         }
     }
-}
+    else
+    {
+        // マスクのクリアフラグを毎フレーム開始時に初期化
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+        {
+            _clearedMaskBufferFlags[i] = false;
+        }
+    }
 
-CubismRenderer::CubismTextureColor* CubismClippingManager_Cocos2dx::GetChannelFlagAsColor(csmInt32 channelNo)
-{
-    return _channelColors[channelNo];
-}
+    // 実際にマスクを生成する
+    // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // --- 実際に１つのマスクを描く ---
+        CubismClippingContext_Cocos2dx* clipContext = _clippingContextListForMask[clipIndex];
+        csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+        csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
+        const csmFloat32 MARGIN = 0.05f;
+        const csmBool isRightHanded = false;
 
-csmVector<CubismClippingContext*>* CubismClippingManager_Cocos2dx::GetClippingContextListForDraw()
-{
-    return &_clippingContextListForDraw;
-}
+        // clipContextに設定したレンダーテクスチャをインデックスで取得
+        CubismOffscreenSurface_Cocos2dx* clipContextOffscreenSurface = renderer->GetOffscreenSurface(clipContext->_bufferIndex);
 
-void CubismClippingManager_Cocos2dx::SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height)
-{
-    _clippingMaskBufferSize = CubismVector2(width, height);
-}
+        // 現在のレンダーテクスチャがclipContextのものと異なる場合
+        if (_currentMaskBuffer != clipContextOffscreenSurface)
+        {
+            _currentMaskBuffer->EndDraw(renderer->GetCommandBuffer());
+            _currentMaskBuffer = clipContextOffscreenSurface;
+            renderer->GetCommandBuffer()->Viewport(0, 0, _currentMaskBuffer->GetViewPortSize().Width, _currentMaskBuffer->GetViewPortSize().Height);
+            renderer->PreDraw(); // バッファをクリアする
+            _currentMaskBuffer->BeginDraw(renderer->GetCommandBuffer(), lastColorBuffer);
+        }
 
-CubismVector2 CubismClippingManager_Cocos2dx::GetClippingMaskBufferSize() const
-{
-    return _clippingMaskBufferSize;
-}
 
-csmInt32 CubismClippingManager_Cocos2dx::GetRenderTextureCount() const
-{
-    return _renderTextureCount;
+        // モデル座標上の矩形を、適宜マージンを付けて使う
+        _tmpBoundsOnModel.SetRect(allClippedDrawRect);
+        _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, allClippedDrawRect->Height * MARGIN);
+        //########## 本来は割り当てられた領域の全体を使わず必要最低限のサイズがよい
+        // シェーダ用の計算式を求める。回転を考慮しない場合は以下のとおり
+        // movePeriod' = movePeriod * scaleX + offX     [[ movePeriod' = (movePeriod - tmpBoundsOnModel.movePeriod)*scale + layoutBoundsOnTex01.movePeriod ]]
+        csmFloat32 scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
+        csmFloat32 scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
+
+        // マスク生成時に使う行列を求める
+        createMatrixForMask(isRightHanded, layoutBoundsOnTex01, scaleX, scaleY);
+
+        clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
+        clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
+
+        const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
+        for (csmInt32 i = 0; i < clipDrawCount; i++)
+        {
+            const csmInt32 clipDrawIndex = clipContext->_clippingIdList[i];
+            CubismCommandBuffer_Cocos2dx::DrawCommandBuffer* drawCommandBufferData = clipContext->_clippingCommandBufferList->At(i);// [i];
+
+
+            // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
+            if (!model.GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
+            {
+                continue;
+            }
+
+            // Update Vertex / Index buffer.
+            {
+                csmFloat32* vertices = const_cast<csmFloat32*>(model.GetDrawableVertices(clipDrawIndex));
+                Core::csmVector2* uvs = const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(clipDrawIndex));
+                csmUint16* vertexIndices = const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex));
+                const csmUint32 vertexCount = model.GetDrawableVertexCount(clipDrawIndex);
+                const csmUint32 vertexIndexCount = model.GetDrawableVertexIndexCount(clipDrawIndex);
+
+                drawCommandBufferData->UpdateVertexBuffer(vertices, uvs, vertexCount);
+                drawCommandBufferData->CommitVertexBuffer();
+                if (vertexIndexCount > 0)
+                {
+                    drawCommandBufferData->UpdateIndexBuffer(vertexIndices, vertexIndexCount);
+                }
+
+                if (vertexCount <= 0)
+                {
+                    continue;
+                }
+
+            }
+
+            renderer->IsCulling(model.GetDrawableCulling(clipDrawIndex) != 0);
+
+            // マスクがクリアされていないなら処理する
+            if (!_clearedMaskBufferFlags[clipContext->_bufferIndex])
+            {
+                // マスクをクリアする
+                // (仮仕様) 1が無効（描かれない）領域、0が有効（描かれる）領域。（シェーダーCd*Csで0に近い値をかけてマスクを作る。1をかけると何も起こらない）
+                renderer->GetOffscreenSurface(clipContext->_bufferIndex)->Clear(renderer->GetCommandBuffer(), 1.0f, 1.0f, 1.0f, 1.0f);
+                _clearedMaskBufferFlags[clipContext->_bufferIndex] = true;
+            }
+
+            // 今回専用の変換を適用して描く
+            // チャンネルも切り替える必要がある(A,R,G,B)
+            renderer->SetClippingContextBufferForMask(clipContext);
+            renderer->DrawMeshCocos2d(drawCommandBufferData->GetCommandDraw(), model, clipDrawIndex);
+        }
+    }
+
+    // --- 後処理 ---
+    _currentMaskBuffer->EndDraw(renderer->GetCommandBuffer()); // 描画対象を戻す
+    renderer->SetClippingContextBufferForMask(NULL);
+    renderer->GetCommandBuffer()->Viewport(lastViewport.X, lastViewport.Y, lastViewport.Width, lastViewport.Height);
 }
 
 /*********************************************************************************************************************
-*                                      CubismClippingContext
+*                                      CubismClippingContext_Cocos2dx
 ********************************************************************************************************************/
-CubismClippingContext::CubismClippingContext(CubismClippingManager_Cocos2dx* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+CubismClippingContext_Cocos2dx::CubismClippingContext_Cocos2dx(CubismClippingManager<CubismClippingContext_Cocos2dx, CubismOffscreenSurface_Cocos2dx>* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+   : CubismClippingContext(clippingDrawableIndices, clipCount)
 {
     _owner = manager;
 
-    // クリップしている（＝マスク用の）Drawableのインデックスリスト
-    _clippingIdList = clippingDrawableIndices;
-
-    // マスクの数
-    _clippingIdCount = clipCount;
-
-    _layoutChannelNo = 0;
-
-    _allClippedDrawRect = CSM_NEW csmRectF();
-    _layoutBounds = CSM_NEW csmRectF();
-
-    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
     _clippingCommandBufferList = CSM_NEW csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*>;
-
-
     for (csmUint32 i = 0; i < _clippingIdCount; ++i)
     {
         const csmInt32 clippingId = _clippingIdList[i];
@@ -684,26 +208,8 @@ CubismClippingContext::CubismClippingContext(CubismClippingManager_Cocos2dx* man
     }
 }
 
-CubismClippingContext::~CubismClippingContext()
+CubismClippingContext_Cocos2dx::~CubismClippingContext_Cocos2dx()
 {
-    if (_layoutBounds != NULL)
-    {
-        CSM_DELETE(_layoutBounds);
-        _layoutBounds = NULL;
-    }
-
-    if (_allClippedDrawRect != NULL)
-    {
-        CSM_DELETE(_allClippedDrawRect);
-        _allClippedDrawRect = NULL;
-    }
-
-    if (_clippedDrawableIndexList != NULL)
-    {
-        CSM_DELETE(_clippedDrawableIndexList);
-        _clippedDrawableIndexList = NULL;
-    }
-
     if (_clippingCommandBufferList != NULL)
     {
         for (csmUint32 i = 0; i < _clippingCommandBufferList->GetSize(); ++i)
@@ -717,18 +223,10 @@ CubismClippingContext::~CubismClippingContext()
     }
 }
 
-void CubismClippingContext::AddClippedDrawable(csmInt32 drawableIndex)
-{
-
-    _clippedDrawableIndexList->PushBack(drawableIndex);
-}
-
-CubismClippingManager_Cocos2dx* CubismClippingContext::GetClippingManager()
+CubismClippingManager<CubismClippingContext_Cocos2dx, CubismOffscreenSurface_Cocos2dx>* CubismClippingContext_Cocos2dx::GetClippingManager()
 {
     return _owner;
 }
-
-
 
 /*********************************************************************************************************************
 *                                      CubismDrawProfile_OpenGL
@@ -761,911 +259,6 @@ void CubismRendererProfile_Cocos2dx::Restore()
 
     GetCocos2dRenderer()->setRenderTarget(_lastRenderTargetFlag, _lastColorBuffer, _lastDepthBuffer, _lastStencilBuffer);
     GetCocos2dRenderer()->setViewPort(_lastViewport.X, _lastViewport.Y, _lastViewport.Width, _lastViewport.Height);
-}
-
-
-/*********************************************************************************************************************
-*                                       CubismShader_Cocos2dx
-********************************************************************************************************************/
-namespace {
-    const csmInt32 ShaderCount = 19; ///< シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
-    CubismShader_Cocos2dx* s_instance;
-}
-
-enum ShaderNames
-{
-    // SetupMask
-    ShaderNames_SetupMask,
-
-    //Normal
-    ShaderNames_Normal,
-    ShaderNames_NormalMasked,
-    ShaderNames_NormalMaskedInverted,
-    ShaderNames_NormalPremultipliedAlpha,
-    ShaderNames_NormalMaskedPremultipliedAlpha,
-    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
-
-    //Add
-    ShaderNames_Add,
-    ShaderNames_AddMasked,
-    ShaderNames_AddMaskedInverted,
-    ShaderNames_AddPremultipliedAlpha,
-    ShaderNames_AddMaskedPremultipliedAlpha,
-    ShaderNames_AddMaskedPremultipliedAlphaInverted,
-
-    //Mult
-    ShaderNames_Mult,
-    ShaderNames_MultMasked,
-    ShaderNames_MultMaskedInverted,
-    ShaderNames_MultPremultipliedAlpha,
-    ShaderNames_MultMaskedPremultipliedAlpha,
-    ShaderNames_MultMaskedPremultipliedAlphaInverted,
-};
-
-void CubismShader_Cocos2dx::ReleaseShaderProgram()
-{
-    for (csmUint32 i = 0; i < _shaderSets.GetSize(); i++)
-    {
-        if (_shaderSets[i]->ShaderProgram)
-        {
-            CSM_DELETE(_shaderSets[i]);
-        }
-    }
-}
-
-// SetupMask
-static const csmChar* VertShaderSrcSetupMask =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-    "#version 120\n"
-#endif
-    "attribute vec2 a_position;"
-    "attribute vec2 a_texCoord;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_myPos;"
-    "uniform mat4 u_clipMatrix;"
-    "void main()"
-    "{"
-    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
-    "gl_Position = u_clipMatrix * pos;"
-    "v_myPos = u_clipMatrix * pos;"
-    "v_texCoord = a_texCoord;"
-    "v_texCoord.y = 1.0 - v_texCoord.y;"
-    "}";
-static const csmChar* FragShaderSrcSetupMask =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_myPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "float isInside = "
-    "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-    "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-    "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-    "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-    "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcSetupMaskTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_myPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "float isInside = "
-    "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-    "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-    "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-    "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-    "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-    "}";
-#endif
-
-//----- バーテックスシェーダプログラム -----
-// Normal & Add & Mult 共通
-static const csmChar* VertShaderSrc =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-    "#version 120\n"
-#endif
-    "attribute vec2 a_position;" //v.vertex
-    "attribute vec2 a_texCoord;" //v.texcoord
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform mat4 u_matrix;"
-    "void main()"
-    "{"
-    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
-    "gl_Position = u_matrix * pos;"
-    "v_texCoord = a_texCoord;"
-    "v_texCoord.y = 1.0 - v_texCoord.y;"
-    "}";
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* VertShaderSrcMasked =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-    "#version 120\n"
-#endif
-    "attribute vec2 a_position;"
-    "attribute vec2 a_texCoord;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform mat4 u_matrix;"
-    "uniform mat4 u_clipMatrix;"
-    "void main()"
-    "{"
-    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
-    "gl_Position = u_matrix * pos;"
-    "v_clipPos = u_clipMatrix * pos;"
-#if defined(CC_USE_METAL)
-    "v_clipPos = vec4(v_clipPos.x, 1.0 - v_clipPos.y, v_clipPos.zw);"
-#endif
-    "v_texCoord = a_texCoord;"
-    "v_texCoord.y = 1.0 - v_texCoord.y;"
-    "}";
-
-//----- フラグメントシェーダプログラム -----
-// Normal & Add & Mult 共通
-static const csmChar* FragShaderSrc =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 color = texColor * u_baseColor;"
-    "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 color = texColor * u_baseColor;"
-    "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-    "}";
-#endif
-
-// Normal & Add & Mult 共通 （PremultipliedAlpha）
-static const csmChar* FragShaderSrcPremultipliedAlpha =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-    "gl_FragColor = texColor * u_baseColor;"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-    "gl_FragColor = texColor * u_baseColor;"
-    "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* FragShaderSrcMask =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
-static const csmChar* FragShaderSrcMaskInverted =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskInvertedTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
-#if defined(CC_PLATFORM_MOBILE)
-#else
-#endif
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
-#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "uniform vec4 u_multiplyColor;"
-    "uniform vec4 u_screenColor;"
-    "void main()"
-    "{"
-    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-    "vec4 col_formask = texColor * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
-#endif
-
-CubismShader_Cocos2dx::CubismShader_Cocos2dx()
-{ }
-
-CubismShader_Cocos2dx::~CubismShader_Cocos2dx()
-{
-    ReleaseShaderProgram();
-}
-
-CubismShader_Cocos2dx* CubismShader_Cocos2dx::GetInstance()
-{
-    if (s_instance == NULL)
-    {
-        s_instance = CSM_NEW CubismShader_Cocos2dx();
-    }
-    return s_instance;
-}
-
-void CubismShader_Cocos2dx::DeleteInstance()
-{
-    if (s_instance)
-    {
-        CSM_DELETE_SELF(CubismShader_Cocos2dx, s_instance);
-        s_instance = NULL;
-    }
-}
-
-#ifdef CSM_TARGET_ANDROID_ES2
-csmBool CubismShader_Cocos2dx::s_extMode = false;
-csmBool CubismShader_Cocos2dx::s_extPAMode = false;
-void CubismShader_Cocos2dx::SetExtShaderMode(csmBool extMode, csmBool extPAMode) {
-    s_extMode = extMode;
-    s_extPAMode = extPAMode;
-}
-#endif
-
-void CubismShader_Cocos2dx::GenerateShaders()
-{
-    for (csmInt32 i = 0; i < ShaderCount; i++)
-    {
-        _shaderSets.PushBack(CSM_NEW CubismShaderSet());
-    }
-
-#ifdef CSM_TARGET_ANDROID_ES2
-    if (s_extMode)
-    {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskTegra);
-
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcTegra);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskTegra);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedTegra);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlphaTegra);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlphaTegra);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlphaTegra);
-    }
-    else
-    {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
-
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
-    }
-
-    // 加算も通常と同じシェーダーを利用する
-    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-    // 乗算も通常と同じシェーダーを利用する
-    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-#else
-
-    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
-
-    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
-    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
-    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
-    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
-    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
-    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
-
-
-
-    // 加算も通常と同じシェーダーを利用する
-    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-
-    // 乗算も通常と同じシェーダーを利用する
-    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-#endif
-
-    // SetupMask
-    _shaderSets[0]->AttributePositionLocation = _shaderSets[0]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[0]->AttributeTexCoordLocation = _shaderSets[0]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[0]->SamplerTexture0Location = _shaderSets[0]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[0]->UniformClipMatrixLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[0]->UnifromChannelFlagLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[0]->UniformBaseColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[0]->UniformMultiplyColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[0]->UniformScreenColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 通常
-    _shaderSets[1]->AttributePositionLocation = _shaderSets[1]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[1]->AttributeTexCoordLocation = _shaderSets[1]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[1]->SamplerTexture0Location = _shaderSets[1]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[1]->UniformMatrixLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[1]->UniformBaseColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[1]->UniformMultiplyColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[1]->UniformScreenColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 通常（クリッピング）
-    _shaderSets[2]->AttributePositionLocation = _shaderSets[2]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[2]->AttributeTexCoordLocation = _shaderSets[2]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[2]->SamplerTexture0Location = _shaderSets[2]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[2]->SamplerTexture1Location = _shaderSets[2]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[2]->UniformMatrixLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[2]->UniformClipMatrixLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[2]->UnifromChannelFlagLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[2]->UniformBaseColorLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[2]->UniformMultiplyColorLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[2]->UniformScreenColorLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 通常（クリッピング・反転）
-    _shaderSets[3]->AttributePositionLocation = _shaderSets[3]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[3]->AttributeTexCoordLocation = _shaderSets[3]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[3]->SamplerTexture0Location = _shaderSets[3]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[3]->SamplerTexture1Location = _shaderSets[3]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[3]->UniformMatrixLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[3]->UniformClipMatrixLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[3]->UnifromChannelFlagLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[3]->UniformBaseColorLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[3]->UniformMultiplyColorLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[3]->UniformScreenColorLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 通常（PremultipliedAlpha）
-    _shaderSets[4]->AttributePositionLocation = _shaderSets[4]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[4]->AttributeTexCoordLocation = _shaderSets[4]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[4]->SamplerTexture0Location = _shaderSets[4]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[4]->UniformMatrixLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[4]->UniformBaseColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[4]->UniformMultiplyColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[4]->UniformScreenColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 通常（クリッピング、PremultipliedAlpha）
-    _shaderSets[5]->AttributePositionLocation = _shaderSets[5]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[5]->AttributeTexCoordLocation = _shaderSets[5]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[5]->SamplerTexture0Location = _shaderSets[5]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[5]->SamplerTexture1Location = _shaderSets[5]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[5]->UniformMatrixLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[5]->UniformClipMatrixLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[5]->UnifromChannelFlagLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[5]->UniformBaseColorLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[5]->UniformMultiplyColorLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[5]->UniformScreenColorLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 通常（クリッピング・反転、PremultipliedAlpha）
-    _shaderSets[6]->AttributePositionLocation = _shaderSets[6]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[6]->AttributeTexCoordLocation = _shaderSets[6]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[6]->SamplerTexture0Location = _shaderSets[6]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[6]->SamplerTexture1Location = _shaderSets[6]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[6]->UniformMatrixLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[6]->UniformClipMatrixLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[6]->UnifromChannelFlagLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[6]->UniformBaseColorLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[6]->UniformMultiplyColorLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[6]->UniformScreenColorLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 加算
-    _shaderSets[7]->AttributePositionLocation = _shaderSets[7]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[7]->AttributeTexCoordLocation = _shaderSets[7]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[7]->SamplerTexture0Location = _shaderSets[7]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[7]->UniformMatrixLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[7]->UniformBaseColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[7]->UniformMultiplyColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[7]->UniformScreenColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 加算（クリッピング）
-    _shaderSets[8]->AttributePositionLocation = _shaderSets[8]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[8]->AttributeTexCoordLocation = _shaderSets[8]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[8]->SamplerTexture0Location = _shaderSets[8]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[8]->SamplerTexture1Location = _shaderSets[8]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[8]->UniformMatrixLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[8]->UniformClipMatrixLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[8]->UnifromChannelFlagLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[8]->UniformBaseColorLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[8]->UniformMultiplyColorLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[8]->UniformScreenColorLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 加算（クリッピング・反転）
-    _shaderSets[9]->AttributePositionLocation = _shaderSets[9]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[9]->AttributeTexCoordLocation = _shaderSets[9]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[9]->SamplerTexture0Location = _shaderSets[9]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[9]->SamplerTexture1Location = _shaderSets[9]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[9]->UniformMatrixLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[9]->UniformClipMatrixLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[9]->UnifromChannelFlagLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[9]->UniformBaseColorLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[9]->UniformMultiplyColorLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[9]->UniformScreenColorLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 加算（PremultipliedAlpha）
-    _shaderSets[10]->AttributePositionLocation = _shaderSets[10]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[10]->AttributeTexCoordLocation = _shaderSets[10]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[10]->SamplerTexture0Location = _shaderSets[10]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[10]->UniformMatrixLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[10]->UniformBaseColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[10]->UniformMultiplyColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[10]->UniformScreenColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 加算（クリッピング、PremultipliedAlpha）
-    _shaderSets[11]->AttributePositionLocation = _shaderSets[11]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[11]->AttributeTexCoordLocation = _shaderSets[11]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[11]->SamplerTexture0Location = _shaderSets[11]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[11]->SamplerTexture1Location = _shaderSets[11]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[11]->UniformMatrixLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[11]->UniformClipMatrixLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[11]->UnifromChannelFlagLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[11]->UniformBaseColorLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[11]->UniformMultiplyColorLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[11]->UniformScreenColorLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 加算（クリッピング・反転、PremultipliedAlpha）
-    _shaderSets[12]->AttributePositionLocation = _shaderSets[12]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[12]->AttributeTexCoordLocation = _shaderSets[12]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[12]->SamplerTexture0Location = _shaderSets[12]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[12]->SamplerTexture1Location = _shaderSets[12]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[12]->UniformMatrixLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[12]->UniformClipMatrixLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[12]->UnifromChannelFlagLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[12]->UniformBaseColorLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[12]->UniformMultiplyColorLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[12]->UniformScreenColorLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 乗算
-    _shaderSets[13]->AttributePositionLocation = _shaderSets[13]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[13]->AttributeTexCoordLocation = _shaderSets[13]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[13]->SamplerTexture0Location = _shaderSets[13]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[13]->UniformMatrixLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[13]->UniformBaseColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[13]->UniformMultiplyColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[13]->UniformScreenColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 乗算（クリッピング）
-    _shaderSets[14]->AttributePositionLocation = _shaderSets[14]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[14]->AttributeTexCoordLocation = _shaderSets[14]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[14]->SamplerTexture0Location = _shaderSets[14]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[14]->SamplerTexture1Location = _shaderSets[14]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[14]->UniformMatrixLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[14]->UniformClipMatrixLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[14]->UnifromChannelFlagLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[14]->UniformBaseColorLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[14]->UniformMultiplyColorLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[14]->UniformScreenColorLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 乗算（クリッピング・反転）
-    _shaderSets[15]->AttributePositionLocation = _shaderSets[15]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[15]->AttributeTexCoordLocation = _shaderSets[15]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[15]->SamplerTexture0Location = _shaderSets[15]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[15]->SamplerTexture1Location = _shaderSets[15]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[15]->UniformMatrixLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[15]->UniformClipMatrixLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[15]->UnifromChannelFlagLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[15]->UniformBaseColorLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[15]->UniformMultiplyColorLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[15]->UniformScreenColorLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 乗算（PremultipliedAlpha）
-    _shaderSets[16]->AttributePositionLocation = _shaderSets[16]->ShaderProgram->getAttributeLocation( "a_position");
-    _shaderSets[16]->AttributeTexCoordLocation = _shaderSets[16]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[16]->SamplerTexture0Location = _shaderSets[16]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[16]->UniformMatrixLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[16]->UniformBaseColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[16]->UniformMultiplyColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[16]->UniformScreenColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 乗算（クリッピング、PremultipliedAlpha）
-    _shaderSets[17]->AttributePositionLocation = _shaderSets[17]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[17]->AttributeTexCoordLocation = _shaderSets[17]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[17]->SamplerTexture0Location = _shaderSets[17]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[17]->SamplerTexture1Location = _shaderSets[17]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[17]->UniformMatrixLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[17]->UniformClipMatrixLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[17]->UnifromChannelFlagLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[17]->UniformBaseColorLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[17]->UniformMultiplyColorLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[17]->UniformScreenColorLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_screenColor");
-
-    // 乗算（クリッピング・反転、PremultipliedAlpha）
-    _shaderSets[18]->AttributePositionLocation = _shaderSets[18]->ShaderProgram->getAttributeLocation("a_position");
-    _shaderSets[18]->AttributeTexCoordLocation = _shaderSets[18]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[18]->SamplerTexture0Location = _shaderSets[18]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[18]->SamplerTexture1Location = _shaderSets[18]->ShaderProgram->getUniformLocation("s_texture1");
-    _shaderSets[18]->UniformMatrixLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_matrix");
-    _shaderSets[18]->UniformClipMatrixLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_clipMatrix");
-    _shaderSets[18]->UnifromChannelFlagLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_channelFlag");
-    _shaderSets[18]->UniformBaseColorLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_baseColor");
-    _shaderSets[18]->UniformMultiplyColorLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_multiplyColor");
-    _shaderSets[18]->UniformScreenColorLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_screenColor");
-}
-
-void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, CubismRenderer_Cocos2dx* renderer, cocos2d::Texture2D* texture
-                                                , csmInt32 vertexCount, csmFloat32* vertexArray
-                                                , csmFloat32* uvArray, csmFloat32 opacity
-                                                , CubismRenderer::CubismBlendMode colorBlendMode
-                                                , CubismRenderer::CubismTextureColor baseColor
-                                                , CubismRenderer::CubismTextureColor multiplyColor
-                                                , CubismRenderer::CubismTextureColor screenColor
-                                                , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
-                                                , csmBool invertedMask)
-{
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders();
-    }
-
-    cocos2d::backend::BlendDescriptor* blendDescriptor = drawCommand->GetBlendDescriptor();
-    cocos2d::PipelineDescriptor* pipelineDescriptor = drawCommand->GetPipelineDescriptor();
-
-    cocos2d::backend::ProgramState* programState = pipelineDescriptor->programState;
-
-    if (renderer->GetClippingContextBufferForMask() != NULL) // マスク生成時
-    {
-        CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
-
-        if (!programState)
-        {
-            programState = new cocos2d::backend::ProgramState(shaderSet->ShaderProgram);
-        }
-
-
-        //テクスチャ設定
-        programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
-
-        // 頂点配列の設定
-        programState->getVertexLayout()->setAttribute("a_position", shaderSet->AttributePositionLocation, cocos2d::backend::VertexFormat::FLOAT2, 0, false);
-        // テクスチャ頂点の設定
-        programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, cocos2d::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
-
-        // チャンネル
-        const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
-        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
-        csmFloat32 colorFlag[4] = { colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
-        programState->setUniform(shaderSet->UnifromChannelFlagLocation, colorFlag, sizeof(float) * 4);
-
-        programState->setUniform(shaderSet->UniformClipMatrixLocation,
-                                 renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray(),
-                                 sizeof(float) * 16);
-
-        csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
-
-        csmFloat32 base[4] = { rect->X * 2.0f - 1.0f,
-                                    rect->Y * 2.0f - 1.0f,
-                                    rect->GetRight() * 2.0f - 1.0f,
-                                    rect->GetBottom() * 2.0f - 1.0f };
-        programState->setUniform(shaderSet->UniformBaseColorLocation, base, sizeof(float) * 4);
-
-        csmFloat32 multiply[4] = { multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
-        programState->setUniform(shaderSet->UniformMultiplyColorLocation, multiply, sizeof(float) * 4);
-
-        csmFloat32 screen[4] = { screenColor.R, screenColor.G, screenColor.B, screenColor.A };
-        programState->setUniform(shaderSet->UniformScreenColorLocation, screen, sizeof(float) * 4);
-
-        blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::ZERO;
-        blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_COLOR;
-        blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ZERO;
-        blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
-    }
-    else // マスク生成以外の場合
-    {
-        const csmBool masked = renderer->GetClippingContextBufferForDraw() != NULL;  // この描画オブジェクトはマスク対象か
-        const csmInt32 offset = (masked ? ( invertedMask ? 2 : 1 ) : 0) + (isPremultipliedAlpha ? 3 : 0);
-
-        CubismShaderSet* shaderSet;
-        switch (colorBlendMode)
-        {
-        case CubismRenderer::CubismBlendMode_Normal:
-        default:
-            shaderSet = _shaderSets[ShaderNames_Normal + offset];
-            blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::ONE;
-            blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
-            blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE;
-            blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
-            break;
-
-        case CubismRenderer::CubismBlendMode_Additive:
-            shaderSet = _shaderSets[ShaderNames_Add + offset];
-            blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::ONE;
-            blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE;
-            blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ZERO;
-            blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE;
-            break;
-
-        case CubismRenderer::CubismBlendMode_Multiplicative:
-            shaderSet = _shaderSets[ShaderNames_Mult + offset];
-            blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::DST_COLOR;
-            blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
-            blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ZERO;
-            blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE;
-            break;
-        }
-
-        if (!programState)
-        {
-            programState = new cocos2d::backend::ProgramState(shaderSet->ShaderProgram);
-        }
-
-        // 頂点配列の設定
-        programState->getVertexLayout()->setAttribute("a_position", shaderSet->AttributePositionLocation, cocos2d::backend::VertexFormat::FLOAT2, 0, false);
-        // テクスチャ頂点の設定
-        programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, cocos2d::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
-
-        if (masked)
-        {
-            // frameBufferに書かれたテクスチャ
-            cocos2d::Texture2D* tex = renderer->GetOffScreenFrameBuffer(renderer->GetClippingContextBufferForDraw()->_bufferIndex)->GetColorBuffer();
-
-            programState->setTexture(shaderSet->SamplerTexture1Location, 1, tex->getBackendTexture());
-
-            // View座標をClippingContextの座標に変換するための行列を設定
-            programState->setUniform(shaderSet->UniformClipMatrixLocation,
-                                     renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray(),
-                                     sizeof(float) * 16);
-
-            // 使用するカラーチャンネルを設定
-            const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
-            CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
-            csmFloat32 colorFlag[4] = { colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
-            programState->setUniform(shaderSet->UnifromChannelFlagLocation, colorFlag, sizeof(float) * 4);
-        }
-
-        //テクスチャ設定
-        programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
-
-        //座標変換
-        programState->setUniform(shaderSet->UniformMatrixLocation, matrix4x4.GetArray(), sizeof(float) * 16);
-
-        csmFloat32 base[4] = { baseColor.R, baseColor.G, baseColor.B, baseColor.A };
-        programState->setUniform(shaderSet->UniformBaseColorLocation, base, sizeof(float) * 4);
-
-        csmFloat32 multiply[4] = { multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
-        programState->setUniform(shaderSet->UniformMultiplyColorLocation, multiply, sizeof(float) * 4);
-
-        csmFloat32 screen[4] = { screenColor.R, screenColor.G, screenColor.B, screenColor.A };
-        programState->setUniform(shaderSet->UniformScreenColorLocation, screen, sizeof(float) * 4);
-    }
-
-    programState->getVertexLayout()->setLayout(sizeof(csmFloat32) * 4);
-    blendDescriptor->blendEnabled = true;
-    pipelineDescriptor->programState = programState;
-}
-
-cocos2d::backend::Program* CubismShader_Cocos2dx::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
-{
-    // cocos2dx対応
-    // Create shader program.
-    return cocos2d::backend::Device::getInstance()->newProgram(vertShaderSrc, fragShaderSrc);
 }
 
 /*********************************************************************************************************************
@@ -1733,11 +326,11 @@ CubismRenderer_Cocos2dx::~CubismRenderer_Cocos2dx()
         _textures.Clear();
     }
 
-    for (csmUint32 i = 0; i < _offscreenFrameBuffers.GetSize(); ++i)
+    for (csmUint32 i = 0; i < _offscreenSurfaces.GetSize(); ++i)
     {
-        _offscreenFrameBuffers[i].DestroyOffscreenFrame();
+        _offscreenSurfaces[i].DestroyOffscreenSurface();
     }
-    _offscreenFrameBuffers.Clear();
+    _offscreenSurfaces.Clear();
 }
 
 void CubismRenderer_Cocos2dx::DoStaticRelease()
@@ -1768,19 +361,16 @@ void CubismRenderer_Cocos2dx::Initialize(Framework::CubismModel* model, csmInt32
         _clippingManager = CSM_NEW CubismClippingManager_Cocos2dx();  //クリッピングマスク・バッファ前処理方式を初期化
         _clippingManager->Initialize(
             *model,
-            model->GetDrawableCount(),
-            model->GetDrawableMasks(),
-            model->GetDrawableMaskCounts(),
             maskBufferCount
         );
 
-        _offscreenFrameBuffers.Clear();
+        _offscreenSurfaces.Clear();
 
         for (csmInt32 i = 0; i < maskBufferCount; ++i)
         {
-            CubismOffscreenFrame_Cocos2dx offscreenFrameBuffer;
-            offscreenFrameBuffer.CreateOffscreenFrame(_clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
-            _offscreenFrameBuffers.PushBack(offscreenFrameBuffer);
+            CubismOffscreenSurface_Cocos2dx OffscreenSurface;
+            OffscreenSurface.CreateOffscreenSurface(_clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
+            _offscreenSurfaces.PushBack(OffscreenSurface);
         }
     }
 
@@ -1823,7 +413,6 @@ void CubismRenderer_Cocos2dx::PreDraw()
     }
 }
 
-
 void CubismRenderer_Cocos2dx::DoDrawModel()
 {
     //------------ クリッピングマスク・バッファ前処理方式の場合 ------------
@@ -1834,14 +423,21 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
         // サイズが違う場合はここで作成しなおし
         for (csmInt32 i = 0; i < _clippingManager->GetRenderTextureCount(); ++i)
         {
-            if (_offscreenFrameBuffers[i].GetBufferWidth() != _clippingManager->GetClippingMaskBufferSize().X ||
-                _offscreenFrameBuffers[i].GetBufferHeight() != _clippingManager->GetClippingMaskBufferSize().Y)
+            if (_offscreenSurfaces[i].GetBufferWidth() != _clippingManager->GetClippingMaskBufferSize().X ||
+                _offscreenSurfaces[i].GetBufferHeight() != _clippingManager->GetClippingMaskBufferSize().Y)
             {
-                _offscreenFrameBuffers[i].CreateOffscreenFrame(
-                                                            _clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
+                _offscreenSurfaces[i].CreateOffscreenSurface(_clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
             }
         }
-        _clippingManager->SetupClippingContext(*GetModel(), this, _rendererProfile._lastColorBuffer, _rendererProfile._lastViewport);
+
+        if(IsUsingHighPrecisionMask())
+        {
+            _clippingManager->SetupMatrixForHighPrecision(*GetModel(), false);
+        }
+        else
+        {
+            _clippingManager->SetupClippingContext(*GetModel(), this, _rendererProfile._lastColorBuffer, _rendererProfile._lastViewport);
+        }
     }
 
     // 上記クリッピング処理内でも一度PreDrawを呼ぶので注意!!
@@ -1887,7 +483,7 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
         }
 
         // クリッピングマスク
-        CubismClippingContext* clipContext = (_clippingManager != NULL)
+        CubismClippingContext_Cocos2dx* clipContext = (_clippingManager != NULL)
             ? (*_clippingManager->GetClippingContextListForDraw())[drawableIndex]
             : NULL;
 
@@ -1895,16 +491,16 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
         {
             if(clipContext->_isUsing) // 書くことになっていた
             {
-                // 生成したFrameBufferと同じサイズでビューポートを設定
-                _commandBuffer->Viewport(0, 0, _offscreenFrameBuffers[ clipContext->_bufferIndex].GetViewPortSize().Width, _offscreenFrameBuffers[ clipContext->_bufferIndex].GetViewPortSize().Height);
+                // 生成したOffscreenSurfaceと同じサイズでビューポートを設定
+                _commandBuffer->Viewport(0, 0, _offscreenSurfaces[ clipContext->_bufferIndex].GetViewPortSize().Width, _offscreenSurfaces[ clipContext->_bufferIndex].GetViewPortSize().Height);
 
                 PreDraw(); // バッファをクリアする
 
-                _offscreenFrameBuffers[ clipContext->_bufferIndex].BeginDraw(_commandBuffer, _rendererProfile._lastColorBuffer);
+                _offscreenSurfaces[ clipContext->_bufferIndex].BeginDraw(_commandBuffer, _rendererProfile._lastColorBuffer);
 
                 // マスクをクリアする
                 // 1が無効（描かれない）領域、0が有効（描かれる）領域。（シェーダで Cd*Csで0に近い値をかけてマスクを作る。1をかけると何も起こらない）
-                _offscreenFrameBuffers[ clipContext->_bufferIndex].Clear(_commandBuffer, 1.0f, 1.0f, 1.0f, 1.0f);
+                _offscreenSurfaces[ clipContext->_bufferIndex].Clear(_commandBuffer, 1.0f, 1.0f, 1.0f, 1.0f);
             }
 
             {
@@ -1952,26 +548,13 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
                     // 今回専用の変換を適用して描く
                     // チャンネルも切り替える必要がある(A,R,G,B)
                     SetClippingContextBufferForMask(clipContext);
-                    DrawMeshCocos2d(
-                        drawCommandBufferMask->GetCommandDraw(),
-                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
-                        GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
-                        GetModel()->GetDrawableVertexCount(clipDrawIndex),
-                        const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
-                        const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(clipDrawIndex)),
-                        reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(clipDrawIndex))),
-                        GetModel()->GetMultiplyColor(clipDrawIndex),
-                        GetModel()->GetScreenColor(clipDrawIndex),
-                        GetModel()->GetDrawableOpacity(clipDrawIndex),
-                        CubismRenderer::CubismBlendMode_Normal,   //クリッピングは通常描画を強制
-                        false // マスク生成時はクリッピングの反転使用は全く関係がない
-                    );
+                    DrawMeshCocos2d(drawCommandBufferMask->GetCommandDraw(), *GetModel(), clipDrawIndex);
                 }
             }
 
             {
                 // --- 後処理 ---
-                _offscreenFrameBuffers[ clipContext->_bufferIndex].EndDraw(_commandBuffer);
+                _offscreenSurfaces[ clipContext->_bufferIndex].EndDraw(_commandBuffer);
                 SetClippingContextBufferForMask(NULL);
                 _commandBuffer->Viewport(_rendererProfile._lastViewport.X, _rendererProfile._lastViewport.Y, _rendererProfile._lastViewport.Width, _rendererProfile._lastViewport.Height);
 
@@ -1991,92 +574,36 @@ void CubismRenderer_Cocos2dx::DoDrawModel()
             continue;
         }
 
-        DrawMeshCocos2d(
-            drawCommandDraw,
-            GetModel()->GetDrawableTextureIndex(drawableIndex),
-            GetModel()->GetDrawableVertexIndexCount(drawableIndex),
-            GetModel()->GetDrawableVertexCount(drawableIndex),
-            const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),
-            const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(drawableIndex)),
-            reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(drawableIndex))),
-            GetModel()->GetMultiplyColor(drawableIndex),
-            GetModel()->GetScreenColor(drawableIndex),
-            GetModel()->GetDrawableOpacity(drawableIndex),
-            GetModel()->GetDrawableBlendMode(drawableIndex),
-            GetModel()->GetDrawableInvertedMask(drawableIndex) // マスクを反転使用するか
-        );
+        DrawMeshCocos2d(drawCommandDraw, *GetModel(), drawableIndex);
     }
 
-    //
     PostDraw();
-
 }
 
-void CubismRenderer_Cocos2dx::DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount,
-    csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray, csmFloat32 opacity,
-    CubismBlendMode colorBlendMode, csmBool invertedMask)
-{
-}
-
-void CubismRenderer_Cocos2dx::DrawMeshCocos2d(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
-                                        , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
-                                        , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
-                                        , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask)
+void CubismRenderer_Cocos2dx::DrawMeshCocos2d(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand
+                                            ,const CubismModel& model, const csmInt32 index)
 {
 #ifndef CSM_DEBUG
-    if (_textures[textureNo] == 0) return;    // モデルが参照するテクスチャがバインドされていない場合は描画をスキップする
+    if (_textures[model.GetDrawableTextureIndex(index)] == 0) return;    // モデルが参照するテクスチャがバインドされていない場合は描画をスキップする
 #endif
 
     // 裏面描画の有効・無効
-    if (IsCulling())
-    {
-        _commandBuffer->SetOperationEnable(CubismCommandBuffer_Cocos2dx::OperationType_Culling, true);
-    }
-    else
-    {
-        _commandBuffer->SetOperationEnable(CubismCommandBuffer_Cocos2dx::OperationType_Culling, false);
-    }
+    _commandBuffer->SetOperationEnable(CubismCommandBuffer_Cocos2dx::OperationType_Culling, (IsCulling() ? true : false));
 
     // Cubism SDK OpenGLはマスク・アートメッシュ共にCCWが表面
     _commandBuffer->SetWindingMode(CubismCommandBuffer_Cocos2dx::WindingType_CounterClockWise);
 
-    CubismTextureColor modelColorRGBA = GetModelColor();
-
-    if (GetClippingContextBufferForMask() == NULL) // マスク生成時以外
+    if (IsGeneratingMask()) // マスク生成時
     {
-        modelColorRGBA.A *= opacity;
-        if (IsPremultipliedAlpha())
-        {
-            modelColorRGBA.R *= modelColorRGBA.A;
-            modelColorRGBA.G *= modelColorRGBA.A;
-            modelColorRGBA.B *= modelColorRGBA.A;
-        }
-    }
-
-    cocos2d::Texture2D* drawTexture;   // シェーダに渡すテクスチャ
-
-    // テクスチャマップからバインド済みテクスチャIDを取得
-    // バインドされていなければダミーのテクスチャIDをセットする
-    if(_textures[textureNo] != NULL)
-    {
-        drawTexture = _textures[textureNo];
+        CubismShader_Cocos2dx::GetInstance()->SetupShaderProgramForMask(drawCommand, this, model, index);
     }
     else
     {
-        drawTexture = NULL;
+        CubismShader_Cocos2dx::GetInstance()->SetupShaderProgramForDraw(drawCommand, this, model, index);
     }
-
-
-    CubismShader_Cocos2dx::GetInstance()->SetupShaderProgram(
-        drawCommand, this, drawTexture, vertexCount, vertexArray, uvArray
-        , opacity, colorBlendMode, modelColorRGBA, multiplyColor, screenColor, IsPremultipliedAlpha()
-        , GetMvpMatrix(), invertedMask
-    );
-
 
     // ポリゴンメッシュを描画する
     _commandBuffer->AddDrawCommand(drawCommand);
-
 
     // 後処理
     SetClippingContextBufferForDraw(NULL);
@@ -2132,7 +659,7 @@ void CubismRenderer_Cocos2dx::SetClippingMaskBufferSize(csmFloat32 width, csmFlo
     // インスタンス破棄前にレンダーテクスチャの数を保存
     const csmInt32 renderTextureCount = _clippingManager->GetRenderTextureCount();
 
-    //FrameBufferのサイズを変更するためにインスタンスを破棄・再作成する
+    //OffscreenSurfaceのサイズを変更するためにインスタンスを破棄・再作成する
     CSM_DELETE_SELF(CubismClippingManager_Cocos2dx, _clippingManager);
 
     _clippingManager = CSM_NEW CubismClippingManager_Cocos2dx();
@@ -2141,9 +668,6 @@ void CubismRenderer_Cocos2dx::SetClippingMaskBufferSize(csmFloat32 width, csmFlo
 
     _clippingManager->Initialize(
         *GetModel(),
-        GetModel()->GetDrawableCount(),
-        GetModel()->GetDrawableMasks(),
-        GetModel()->GetDrawableMaskCounts(),
         renderTextureCount
     );
 }
@@ -2158,29 +682,39 @@ CubismVector2 CubismRenderer_Cocos2dx::GetClippingMaskBufferSize() const
     return _clippingManager->GetClippingMaskBufferSize();
 }
 
-CubismOffscreenFrame_Cocos2dx* CubismRenderer_Cocos2dx::GetOffScreenFrameBuffer(csmInt32 index)
+CubismOffscreenSurface_Cocos2dx* CubismRenderer_Cocos2dx::GetOffscreenSurface(csmInt32 index)
 {
-    return &_offscreenFrameBuffers[index];
+    return &_offscreenSurfaces[index];
 }
 
-void CubismRenderer_Cocos2dx::SetClippingContextBufferForMask(CubismClippingContext* clip)
+void CubismRenderer_Cocos2dx::SetClippingContextBufferForMask(CubismClippingContext_Cocos2dx* clip)
 {
     _clippingContextBufferForMask = clip;
 }
 
-CubismClippingContext* CubismRenderer_Cocos2dx::GetClippingContextBufferForMask() const
+CubismClippingContext_Cocos2dx* CubismRenderer_Cocos2dx::GetClippingContextBufferForMask() const
 {
     return _clippingContextBufferForMask;
 }
 
-void CubismRenderer_Cocos2dx::SetClippingContextBufferForDraw(CubismClippingContext* clip)
+void CubismRenderer_Cocos2dx::SetClippingContextBufferForDraw(CubismClippingContext_Cocos2dx* clip)
 {
     _clippingContextBufferForDraw = clip;
 }
 
-CubismClippingContext* CubismRenderer_Cocos2dx::GetClippingContextBufferForDraw() const
+CubismClippingContext_Cocos2dx* CubismRenderer_Cocos2dx::GetClippingContextBufferForDraw() const
 {
     return _clippingContextBufferForDraw;
+}
+
+const csmBool CubismRenderer_Cocos2dx::IsGeneratingMask() const
+{
+    return GetClippingContextBufferForMask() != NULL;
+}
+
+cocos2d::Texture2D* CubismRenderer_Cocos2dx::GetBindedTexture(csmInt32 textureNo)
+{
+    return _textures[textureNo];
 }
 
 }}}}

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
@@ -8,9 +8,11 @@
 #pragma once
 
 #include "../CubismRenderer.hpp"
+#include "../CubismClippingManager.hpp"
 #include "CubismFramework.hpp"
 #include "CubismOffscreenSurface_Cocos2dx.hpp"
 #include "CubismCommandBuffer_Cocos2dx.hpp"
+#include "CubismShader_Cocos2dx.hpp"
 #include "Math/CubismVector2.hpp"
 #include "Type/csmVector.hpp"
 #include "Type/csmRectF.hpp"
@@ -46,55 +48,16 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 
 //  前方宣言
 class CubismRenderer_Cocos2dx;
-class CubismClippingContext;
+class CubismClippingContext_Cocos2dx;
+class CubismShader_Cocos2dx;
 
 /**
  * @brief  クリッピングマスクの処理を実行するクラス
  *
  */
-class CubismClippingManager_Cocos2dx
+class CubismClippingManager_Cocos2dx : public CubismClippingManager<CubismClippingContext_Cocos2dx, CubismOffscreenSurface_Cocos2dx>
 {
-    friend class CubismShader_Cocos2dx;
-    friend class CubismRenderer_Cocos2dx;
-
-private:
-
-    /**
-     * @brief カラーチャンネル(RGBA)のフラグを取得する
-     *
-     * @param[in]   channelNo   ->   カラーチャンネル(RGBA)の番号(0:R , 1:G , 2:B, 3:A)
-     */
-    CubismRenderer::CubismTextureColor* GetChannelFlagAsColor(csmInt32 channelNo);
-
-    /**
-     * @brief   マスクされる描画オブジェクト群全体を囲む矩形(モデル座標系)を計算する
-     *
-     * @param[in]   model            ->  モデルのインスタンス
-     * @param[in]   clippingContext  ->  クリッピングマスクのコンテキスト
-     */
-    void CalcClippedDrawTotalBounds(CubismModel& model, CubismClippingContext* clippingContext);
-
-    /**
-     * @brief    コンストラクタ
-     */
-    CubismClippingManager_Cocos2dx();
-
-    /**
-     * @brief    デストラクタ
-     */
-    virtual ~CubismClippingManager_Cocos2dx();
-
-    /**
-     * @brief    マネージャの初期化処理<br>
-     *           クリッピングマスクを使う描画オブジェクトの登録を行う
-     *
-     * @param[in]   model           ->  モデルのインスタンス
-     * @param[in]   drawableCount   ->  描画オブジェクトの数
-     * @param[in]   drawableMasks   ->  描画オブジェクトをマスクする描画オブジェクトのインデックスのリスト
-     * @param[in]   drawableMaskCounts   ->  描画オブジェクトをマスクする描画オブジェクトの数
-     * @param[in]   maskBufferCount ->  バッファの生成数
-     */
-    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts, const csmInt32 maskBufferCount);
+public:
 
     /**
      * @brief   クリッピングコンテキストを作成する。モデル描画時に実行する。
@@ -105,236 +68,38 @@ private:
      * @param[in]   lastViewport ->  ビューポート
      */
     void SetupClippingContext(CubismModel& model, CubismRenderer_Cocos2dx* renderer, cocos2d::Texture2D* lastColorBuffer, csmRectF lastViewport);
-
-    /**
-     * @brief   既にマスクを作っているかを確認。<br>
-     *          作っているようであれば該当するクリッピングマスクのインスタンスを返す。<br>
-     *          作っていなければNULLを返す
-     *
-     * @param[in]   drawableMasks    ->  描画オブジェクトをマスクする描画オブジェクトのリスト
-     * @param[in]   drawableMaskCounts ->  描画オブジェクトをマスクする描画オブジェクトの数
-     * @return          該当するクリッピングマスクが存在すればインスタンスを返し、なければNULLを返す。
-     */
-    CubismClippingContext* FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const;
-
-    /**
-     * @brief   クリッピングコンテキストを配置するレイアウト。<br>
-     *           ひとつのレンダーテクスチャを極力いっぱいに使ってマスクをレイアウトする。<br>
-     *           マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する。
-     *
-     * @param[in]   usingClipCount  ->  配置するクリッピングコンテキストの数
-     */
-    void SetupLayoutBounds(csmInt32 usingClipCount) const;
-
-    /**
-     * @brief   画面描画に使用するクリッピングマスクのリストを取得する
-     *
-     * @return  画面描画に使用するクリッピングマスクのリスト
-     */
-    csmVector<CubismClippingContext*>* GetClippingContextListForDraw();
-
-    /**
-     *@brief  クリッピングマスクバッファのサイズを設定する
-     *
-     *@param  size -> クリッピングマスクバッファのサイズ
-     *
-     */
-    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
-
-    /**
-     * @brief  クリッピングマスクバッファのサイズを取得する
-     *
-     * @return クリッピングマスクバッファのサイズ
-     *
-     */
-    CubismVector2 GetClippingMaskBufferSize() const;
-
-    /**
-     * このバッファのレンダーテクスチャの枚数を取得する。
-     *
-     * @return このバッファのレンダーテクスチャの枚数
-     */
-    csmInt32 GetRenderTextureCount() const;
-
-    CubismOffscreenFrame_Cocos2dx* _currentOffscreenFrameBuffer;   ///< レンダーターゲットとなるオフスクリーンフレームバッファを保持する
-    csmVector<csmBool> _clearedFrameBufferFlags; /// マスクのクリアフラグの配列
-
-    csmVector<CubismRenderer::CubismTextureColor*>  _channelColors;
-    csmVector<CubismClippingContext*>               _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
-    csmVector<CubismClippingContext*>               _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
-    CubismVector2                                   _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
-    csmInt32                                        _renderTextureCount;           ///< 生成するレンダーテクスチャの枚数
-
-    CubismMatrix44  _tmpMatrix;              ///< マスク計算用の行列
-    CubismMatrix44  _tmpMatrixForMask;       ///< マスク計算用の行列
-    CubismMatrix44  _tmpMatrixForDraw;       ///< マスク計算用の行列
-    csmRectF        _tmpBoundsOnModel;       ///< マスク配置計算用の矩形
-
 };
 
 /**
  * @brief   クリッピングマスクのコンテキスト
  */
-class CubismClippingContext
+class CubismClippingContext_Cocos2dx : public CubismClippingContext
 {
     friend class CubismClippingManager_Cocos2dx;
-    friend class CubismShader_Cocos2dx;
     friend class CubismRenderer_Cocos2dx;
 
-private:
+public:
     /**
      * @brief   引数付きコンストラクタ
      *
      */
-    CubismClippingContext(CubismClippingManager_Cocos2dx* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
+    CubismClippingContext_Cocos2dx(CubismClippingManager<CubismClippingContext_Cocos2dx, CubismOffscreenSurface_Cocos2dx>* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
 
     /**
      * @brief   デストラクタ
      */
-    virtual ~CubismClippingContext();
-
-    /**
-     * @brief   このマスクにクリップされる描画オブジェクトを追加する
-     *
-     * @param[in]   drawableIndex   ->  クリッピング対象に追加する描画オブジェクトのインデックス
-     */
-    void AddClippedDrawable(csmInt32 drawableIndex);
+    virtual ~CubismClippingContext_Cocos2dx();
 
     /**
      * @brief   このマスクを管理するマネージャのインスタンスを取得する。
      *
      * @return  クリッピングマネージャのインスタンス
      */
-    CubismClippingManager_Cocos2dx* GetClippingManager();
+    CubismClippingManager<CubismClippingContext_Cocos2dx, CubismOffscreenSurface_Cocos2dx>* GetClippingManager();
 
-    csmBool _isUsing;                                ///< 現在の描画状態でマスクの準備が必要ならtrue
-    const csmInt32* _clippingIdList;                 ///< クリッピングマスクのIDリスト
-    csmInt32 _clippingIdCount;                       ///< クリッピングマスクの数
-    csmInt32 _layoutChannelNo;                       ///< RGBAのいずれのチャンネルにこのクリップを配置するか(0:R , 1:G , 2:B , 3:A)
-    csmRectF* _layoutBounds;                         ///< マスク用チャンネルのどの領域にマスクを入れるか(View座標-1..1, UVは0..1に直す)
-    csmRectF* _allClippedDrawRect;                   ///< このクリッピングで、クリッピングされる全ての描画オブジェクトの囲み矩形（毎回更新）
-    CubismMatrix44 _matrixForMask;                   ///< マスクの位置計算結果を保持する行列
-    CubismMatrix44 _matrixForDraw;                   ///< 描画オブジェクトの位置計算結果を保持する行列
-    csmVector<csmInt32>* _clippedDrawableIndexList;  ///< このマスクにクリップされる描画オブジェクトのリスト
+private:
     csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*>* _clippingCommandBufferList;
-    csmInt32 _bufferIndex;                           ///< このマスクが割り当てられるレンダーテクスチャ（フレームバッファ）やカラーバッファのインデックス
-
-    CubismClippingManager_Cocos2dx* _owner;        ///< このマスクを管理しているマネージャのインスタンス
-};
-
-/**
- * @brief   Cocos2dx用のシェーダプログラムを生成・破棄するクラス<br>
- *           シングルトンなクラスであり、CubismShader_Cocos2dx::GetInstance()からアクセスする。
- *
- */
-class CubismShader_Cocos2dx
-{
-    friend class CubismRenderer_Cocos2dx;
-
-private:
-    /**
-     * @brief   インスタンスを取得する（シングルトン）。
-     *
-     * @return  インスタンスのポインタ
-     */
-    static CubismShader_Cocos2dx* GetInstance();
-
-    /**
-     * @brief   インスタンスを解放する（シングルトン）。
-     */
-    static void DeleteInstance();
-
-    /**
-    * @bref    シェーダープログラムとシェーダ変数のアドレスを保持する構造体
-    *
-    */
-    struct CubismShaderSet
-    {
-        cocos2d::backend::Program* ShaderProgram;               ///< シェーダプログラムのアドレス
-        unsigned int AttributePositionLocation;   ///< シェーダプログラムに渡す変数のアドレス(Position)
-        unsigned int AttributeTexCoordLocation;   ///< シェーダプログラムに渡す変数のアドレス(TexCoord)
-        cocos2d::backend::UniformLocation UniformMatrixLocation;        ///< シェーダプログラムに渡す変数のアドレス(Matrix)
-        cocos2d::backend::UniformLocation UniformClipMatrixLocation;    ///< シェーダプログラムに渡す変数のアドレス(ClipMatrix)
-        cocos2d::backend::UniformLocation SamplerTexture0Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture0)
-        cocos2d::backend::UniformLocation SamplerTexture1Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture1)
-        cocos2d::backend::UniformLocation UniformBaseColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(BaseColor)
-        cocos2d::backend::UniformLocation UniformMultiplyColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(MultiplyColor)
-        cocos2d::backend::UniformLocation UniformScreenColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(ScreenColor)
-        cocos2d::backend::UniformLocation UnifromChannelFlagLocation;   ///< シェーダプログラムに渡す変数のアドレス(ChannelFlag)
-    };
-
-    /**
-     * @brief   privateなコンストラクタ
-     */
-    CubismShader_Cocos2dx();
-
-    /**
-     * @brief   privateなデストラクタ
-     */
-    virtual ~CubismShader_Cocos2dx();
-
-    /**
-     * @brief   シェーダプログラムの一連のセットアップを実行する
-     *
-     * @param[in]   renderer              ->  レンダラのインスタンス
-     * @param[in]   textureId             ->  GPUのテクスチャID
-     * @param[in]   vertexCount           ->  ポリゴンメッシュの頂点数
-     * @param[in]   vertexArray           ->  ポリゴンメッシュの頂点配列
-     * @param[in]   uvArray               ->  uv配列
-     * @param[in]   opacity               ->  不透明度
-     * @param[in]   colorBlendMode        ->  カラーブレンディングのタイプ
-     * @param[in]   baseColor             ->  ベースカラー
-     * @param[in]   isPremultipliedAlpha  ->  乗算済みアルファかどうか
-     * @param[in]   matrix4x4             ->  Model-View-Projection行列
-     * @param[in]   invertedMask           ->  マスクを反転して使用するフラグ
-     */
-    void SetupShaderProgram(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, CubismRenderer_Cocos2dx* renderer, cocos2d::Texture2D* texture
-                            , csmInt32 vertexCount, csmFloat32* vertexArray
-                            , csmFloat32* uvArray, csmFloat32 opacity
-                            , CubismRenderer::CubismBlendMode colorBlendMode
-                            , CubismRenderer::CubismTextureColor baseColor
-                            , CubismRenderer::CubismTextureColor multiplyColor
-                            , CubismRenderer::CubismTextureColor screenColor
-                            , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
-                            , csmBool invertedMask);
-
-    /**
-     * @brief   シェーダプログラムを解放する
-     */
-    void ReleaseShaderProgram();
-
-    /**
-     * @brief   シェーダプログラムを初期化する
-     */
-    void GenerateShaders();
-
-    /**
-     * @brief   シェーダプログラムをロードしてアドレス返す。
-     *
-     * @param[in]   vertShaderSrc   ->  頂点シェーダのソース
-     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのソース
-     *
-     * @return  シェーダプログラムのアドレス
-     */
-    cocos2d::backend::Program* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
-
-#ifdef CSM_TARGET_ANDROID_ES2
-public:
-    /**
-     * @brief   Tegraプロセッサ対応。拡張方式による描画の有効・無効
-     *
-     * @param[in]   extMode     ->  trueなら拡張方式で描画する
-     * @param[in]   extPAMode   ->  trueなら拡張方式のPA設定を有効にする
-     */
-    static void SetExtShaderMode(csmBool extMode, csmBool extPAMode);
-
-private:
-    static csmBool  s_extMode;      ///< Tegra対応.拡張方式で描画
-    static csmBool  s_extPAMode;    ///< 拡張方式のPA設定用の変数
-#endif
-
-    csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
-
+    CubismClippingManager<CubismClippingContext_Cocos2dx, CubismOffscreenSurface_Cocos2dx>* _owner;        ///< このマスクを管理しているマネージャのインスタンス
 };
 
 /**
@@ -420,7 +185,7 @@ public:
 
     /**
      * @brief  クリッピングマスクバッファのサイズを設定する<br>
-     *         マスク用のFrameBufferを破棄・再作成するため処理コストは高い。
+     *         マスク用のOffscreenSurfaceを破棄・再作成するため処理コストは高い。
      *
      * @param[in]  width -> クリッピングマスクバッファの横サイズ
      * @param[in]  height -> クリッピングマスクバッファの縦サイズ
@@ -445,12 +210,12 @@ public:
     CubismVector2 GetClippingMaskBufferSize() const;
 
     /**
-     * @brief  オフスクリーンフレームバッファを取得する
+     * @brief  オフスクリーンサーフェスを取得する
      *
-     * @return オフスクリーンフレームバッファへの参照
+     * @return オフスクリーンサーフェスへの参照
      *
      */
-    CubismOffscreenFrame_Cocos2dx* GetOffScreenFrameBuffer(csmInt32 index);
+    CubismOffscreenSurface_Cocos2dx* GetOffscreenSurface(csmInt32 index);
 
     static CubismCommandBuffer_Cocos2dx* GetCommandBuffer();
 
@@ -476,28 +241,16 @@ protected:
     void DoDrawModel();
 
     /**
-     * @brief   [オーバーライド]<br>
-     *           描画オブジェクト（アートメッシュ）を描画する。<br>
-     *           ポリゴンメッシュとテクスチャ番号をセットで渡す。
+     * @brief   描画オブジェクト（アートメッシュ）を描画する。<br>
+     *           描画するモデルと、描画対象のインデックスを渡す。
      *
-     * @param[in]   textureNo       ->  描画するテクスチャ番号
-     * @param[in]   indexCount      ->  描画オブジェクトのインデックス値
-     * @param[in]   vertexCount     ->  ポリゴンメッシュの頂点数
-     * @param[in]   indexArray      ->  ポリゴンメッシュのインデックス配列
-     * @param[in]   vertexArray     ->  ポリゴンメッシュの頂点配列
-     * @param[in]   uvArray         ->  uv配列
-     * @param[in]   opacity         ->  不透明度
-     * @param[in]   colorBlendMode  ->  カラー合成タイプ
-     * @param[in]   invertedMask     ->  マスク使用時のマスクの反転使用
+     * @param[in]   drawCommand     ->  コマンドバッファ
+     * @param[in]   model           ->  描画対象のモデル
+     * @param[in]   index           ->  描画すべき対象のインデックス
      *
      */
-
-    void DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount, csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray, csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
-
-    void DrawMeshCocos2d(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
-                  , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
-                  , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
-                  , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
+    void DrawMeshCocos2d(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand
+                        ,const CubismModel& model, const csmInt32 index);
 
     CubismCommandBuffer_Cocos2dx::DrawCommandBuffer* GetDrawCommandBufferData(csmInt32 drawableIndex);
 
@@ -553,37 +306,52 @@ private:
     /**
      * @brief   マスクテクスチャに描画するクリッピングコンテキストをセットする。
      */
-    void SetClippingContextBufferForMask(CubismClippingContext* clip);
+    void SetClippingContextBufferForMask(CubismClippingContext_Cocos2dx* clip);
 
     /**
      * @brief   マスクテクスチャに描画するクリッピングコンテキストを取得する。
      *
      * @return  マスクテクスチャに描画するクリッピングコンテキスト
      */
-    CubismClippingContext* GetClippingContextBufferForMask() const;
+    CubismClippingContext_Cocos2dx* GetClippingContextBufferForMask() const;
 
     /**
      * @brief   画面上に描画するクリッピングコンテキストをセットする。
      */
-    void SetClippingContextBufferForDraw(CubismClippingContext* clip);
+    void SetClippingContextBufferForDraw(CubismClippingContext_Cocos2dx* clip);
 
     /**
      * @brief   画面上に描画するクリッピングコンテキストを取得する。
      *
      * @return  画面上に描画するクリッピングコンテキスト
      */
-    CubismClippingContext* GetClippingContextBufferForDraw() const;
+    CubismClippingContext_Cocos2dx* GetClippingContextBufferForDraw() const;
+
+    /**
+     * @brief   マスク生成時かを判定する
+     *
+     * @return  判定値
+     */
+    const csmBool inline IsGeneratingMask() const;
+
+    /**
+     * @brief   テクスチャマップからバインド済みテクスチャIDを取得する
+     *          バインドされていなければNULLを返却される
+     *
+     * @return  バインドされたテクスチャ
+     */
+    cocos2d::Texture2D* GetBindedTexture(csmInt32 textureNo);
 
 
-    csmMap<csmInt32, cocos2d::Texture2D*>            _textures;                      ///< モデルが参照するテクスチャとレンダラでバインドしているテクスチャとのマップ
-    csmVector<csmInt32>                 _sortedDrawableIndexList;       ///< 描画オブジェクトのインデックスを描画順に並べたリスト
-    CubismRendererProfile_Cocos2dx     _rendererProfile;               ///< OpenGLのステートを保持するオブジェクト
-    CubismClippingManager_Cocos2dx*    _clippingManager;               ///< クリッピングマスク管理オブジェクト
-    CubismClippingContext*              _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
-    CubismClippingContext*              _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
+    csmMap<csmInt32, cocos2d::Texture2D*> _textures;                      ///< モデルが参照するテクスチャとレンダラでバインドしているテクスチャとのマップ
+    csmVector<csmInt32> _sortedDrawableIndexList;       ///< 描画オブジェクトのインデックスを描画順に並べたリスト
+    CubismRendererProfile_Cocos2dx _rendererProfile;               ///< OpenGLのステートを保持するオブジェクト
+    CubismClippingManager_Cocos2dx* _clippingManager;               ///< クリッピングマスク管理オブジェクト
+    CubismClippingContext_Cocos2dx* _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
+    CubismClippingContext_Cocos2dx* _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
 
-    csmVector<CubismOffscreenFrame_Cocos2dx>   _offscreenFrameBuffers;          ///< マスク描画用のフレームバッファ
-    csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*>  _drawableDrawCommandBuffer;
+    csmVector<CubismOffscreenSurface_Cocos2dx> _offscreenSurfaces;          ///< マスク描画用のフレームバッファ
+    csmVector<CubismCommandBuffer_Cocos2dx::DrawCommandBuffer*> _drawableDrawCommandBuffer;
 };
 
 }}}}

--- a/src/Rendering/Cocos2d/CubismShader_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismShader_Cocos2dx.cpp
@@ -1,0 +1,947 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismShader_Cocos2dx.hpp"
+#include <float.h>
+#include "renderer/backend/Device.h"
+
+#ifdef CSM_TARGET_WIN_GL
+#include <Windows.h>
+#endif
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/*********************************************************************************************************************
+*                                       CubismShader_Cocos2dx
+********************************************************************************************************************/
+namespace {
+    const csmInt32 ShaderCount = 19; ///< シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
+    CubismShader_Cocos2dx* s_instance;
+}
+
+enum ShaderNames
+{
+    // SetupMask
+    ShaderNames_SetupMask,
+
+    //Normal
+    ShaderNames_Normal,
+    ShaderNames_NormalMasked,
+    ShaderNames_NormalMaskedInverted,
+    ShaderNames_NormalPremultipliedAlpha,
+    ShaderNames_NormalMaskedPremultipliedAlpha,
+    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
+
+    //Add
+    ShaderNames_Add,
+    ShaderNames_AddMasked,
+    ShaderNames_AddMaskedInverted,
+    ShaderNames_AddPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlphaInverted,
+
+    //Mult
+    ShaderNames_Mult,
+    ShaderNames_MultMasked,
+    ShaderNames_MultMaskedInverted,
+    ShaderNames_MultPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlphaInverted,
+};
+
+void CubismShader_Cocos2dx::ReleaseShaderProgram()
+{
+    for (csmUint32 i = 0; i < _shaderSets.GetSize(); i++)
+    {
+        if (_shaderSets[i]->ShaderProgram)
+        {
+            CSM_DELETE(_shaderSets[i]);
+        }
+    }
+}
+
+// SetupMask
+static const csmChar* VertShaderSrcSetupMask =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+    "#version 120\n"
+#endif
+    "attribute vec2 a_position;"
+    "attribute vec2 a_texCoord;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_myPos;"
+    "uniform mat4 u_clipMatrix;"
+    "void main()"
+    "{"
+    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
+    "gl_Position = u_clipMatrix * pos;"
+    "v_myPos = u_clipMatrix * pos;"
+    "v_texCoord = a_texCoord;"
+    "v_texCoord.y = 1.0 - v_texCoord.y;"
+    "}";
+static const csmChar* FragShaderSrcSetupMask =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_myPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "void main()"
+    "{"
+    "float isInside = "
+    "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
+    "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
+    "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
+    "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
+
+    "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcSetupMaskTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_myPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "void main()"
+    "{"
+    "float isInside = "
+    "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
+    "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
+    "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
+    "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
+
+    "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
+    "}";
+#endif
+
+//----- バーテックスシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* VertShaderSrc =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+    "#version 120\n"
+#endif
+    "attribute vec2 a_position;" //v.vertex
+    "attribute vec2 a_texCoord;" //v.texcoord
+    "varying vec2 v_texCoord;" //v2f.texcoord
+    "uniform mat4 u_matrix;"
+    "void main()"
+    "{"
+    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
+    "gl_Position = u_matrix * pos;"
+    "v_texCoord = a_texCoord;"
+    "v_texCoord.y = 1.0 - v_texCoord.y;"
+    "}";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* VertShaderSrcMasked =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+    "#version 120\n"
+#endif
+    "attribute vec2 a_position;"
+    "attribute vec2 a_texCoord;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform mat4 u_matrix;"
+    "uniform mat4 u_clipMatrix;"
+    "void main()"
+    "{"
+    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
+    "gl_Position = u_matrix * pos;"
+    "v_clipPos = u_clipMatrix * pos;"
+#if defined(CC_USE_METAL)
+    "v_clipPos = vec4(v_clipPos.x, 1.0 - v_clipPos.y, v_clipPos.zw);"
+#endif
+    "v_texCoord = a_texCoord;"
+    "v_texCoord.y = 1.0 - v_texCoord.y;"
+    "}";
+
+//----- フラグメントシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* FragShaderSrc =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;" //v2f.texcoord
+    "uniform sampler2D s_texture0;" //_MainTex
+    "uniform vec4 u_baseColor;" //v2f.color
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 color = texColor * u_baseColor;"
+    "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;" //v2f.texcoord
+    "uniform sampler2D s_texture0;" //_MainTex
+    "uniform vec4 u_baseColor;" //v2f.color
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 color = texColor * u_baseColor;"
+    "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
+    "}";
+#endif
+
+// Normal & Add & Mult 共通 （PremultipliedAlpha）
+static const csmChar* FragShaderSrcPremultipliedAlpha =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;" //v2f.texcoord
+    "uniform sampler2D s_texture0;" //_MainTex
+    "uniform vec4 u_baseColor;" //v2f.color
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+    "gl_FragColor = texColor * u_baseColor;"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;" //v2f.texcoord
+    "uniform sampler2D s_texture0;" //_MainTex
+    "uniform vec4 u_baseColor;" //v2f.color
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+    "gl_FragColor = texColor * u_baseColor;"
+    "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* FragShaderSrcMask =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * maskVal;"
+    "gl_FragColor = col_formask;"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcMaskTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * maskVal;"
+    "gl_FragColor = col_formask;"
+    "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
+static const csmChar* FragShaderSrcMaskInverted =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * (1.0 - maskVal);"
+    "gl_FragColor = col_formask;"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcMaskInvertedTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * (1.0 - maskVal);"
+    "gl_FragColor = col_formask;"
+    "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * maskVal;"
+    "gl_FragColor = col_formask;"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * maskVal;"
+    "gl_FragColor = col_formask;"
+    "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
+#if defined(CC_PLATFORM_MOBILE)
+#else
+#endif
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * (1.0 - maskVal);"
+    "gl_FragColor = col_formask;"
+    "}";
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
+    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+    "precision mediump float;"
+    "varying vec2 v_texCoord;"
+    "varying vec4 v_clipPos;"
+    "uniform sampler2D s_texture0;"
+    "uniform sampler2D s_texture1;"
+    "uniform vec4 u_channelFlag;"
+    "uniform vec4 u_baseColor;"
+    "uniform vec4 u_multiplyColor;"
+    "uniform vec4 u_screenColor;"
+    "void main()"
+    "{"
+    "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+    "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+    "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+    "vec4 col_formask = texColor * u_baseColor;"
+    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+    "col_formask = col_formask * (1.0 - maskVal);"
+    "gl_FragColor = col_formask;"
+    "}";
+#endif
+
+CubismShader_Cocos2dx::CubismShader_Cocos2dx()
+{ }
+
+CubismShader_Cocos2dx::~CubismShader_Cocos2dx()
+{
+    ReleaseShaderProgram();
+}
+
+CubismShader_Cocos2dx* CubismShader_Cocos2dx::GetInstance()
+{
+    if (s_instance == NULL)
+    {
+        s_instance = CSM_NEW CubismShader_Cocos2dx();
+    }
+    return s_instance;
+}
+
+void CubismShader_Cocos2dx::DeleteInstance()
+{
+    if (s_instance)
+    {
+        CSM_DELETE_SELF(CubismShader_Cocos2dx, s_instance);
+        s_instance = NULL;
+    }
+}
+
+#ifdef CSM_TARGET_ANDROID_ES2
+csmBool CubismShader_Cocos2dx::s_extMode = false;
+csmBool CubismShader_Cocos2dx::s_extPAMode = false;
+void CubismShader_Cocos2dx::SetExtShaderMode(csmBool extMode, csmBool extPAMode) {
+    s_extMode = extMode;
+    s_extPAMode = extPAMode;
+}
+#endif
+
+void CubismShader_Cocos2dx::GenerateShaders()
+{
+    for (csmInt32 i = 0; i < ShaderCount; i++)
+    {
+        _shaderSets.PushBack(CSM_NEW CubismShaderSet());
+    }
+
+#ifdef CSM_TARGET_ANDROID_ES2
+    if (s_extMode)
+    {
+        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskTegra);
+
+        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcTegra);
+        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskTegra);
+        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedTegra);
+        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlphaTegra);
+        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlphaTegra);
+        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlphaTegra);
+    }
+    else
+    {
+        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+
+        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
+        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
+        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
+        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
+        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
+        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+    }
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+#else
+
+    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+
+    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
+    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
+    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
+    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
+    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
+    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+
+
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+#endif
+
+    // SetupMask
+    _shaderSets[0]->AttributePositionLocation = _shaderSets[0]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[0]->AttributeTexCoordLocation = _shaderSets[0]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[0]->SamplerTexture0Location = _shaderSets[0]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[0]->UniformClipMatrixLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[0]->UnifromChannelFlagLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[0]->UniformBaseColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[0]->UniformMultiplyColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[0]->UniformScreenColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 通常
+    _shaderSets[1]->AttributePositionLocation = _shaderSets[1]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[1]->AttributeTexCoordLocation = _shaderSets[1]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[1]->SamplerTexture0Location = _shaderSets[1]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[1]->UniformMatrixLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[1]->UniformBaseColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[1]->UniformMultiplyColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[1]->UniformScreenColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 通常（クリッピング）
+    _shaderSets[2]->AttributePositionLocation = _shaderSets[2]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[2]->AttributeTexCoordLocation = _shaderSets[2]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[2]->SamplerTexture0Location = _shaderSets[2]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[2]->SamplerTexture1Location = _shaderSets[2]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[2]->UniformMatrixLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[2]->UniformClipMatrixLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[2]->UnifromChannelFlagLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[2]->UniformBaseColorLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[2]->UniformMultiplyColorLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[2]->UniformScreenColorLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 通常（クリッピング・反転）
+    _shaderSets[3]->AttributePositionLocation = _shaderSets[3]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[3]->AttributeTexCoordLocation = _shaderSets[3]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[3]->SamplerTexture0Location = _shaderSets[3]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[3]->SamplerTexture1Location = _shaderSets[3]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[3]->UniformMatrixLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[3]->UniformClipMatrixLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[3]->UnifromChannelFlagLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[3]->UniformBaseColorLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[3]->UniformMultiplyColorLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[3]->UniformScreenColorLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 通常（PremultipliedAlpha）
+    _shaderSets[4]->AttributePositionLocation = _shaderSets[4]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[4]->AttributeTexCoordLocation = _shaderSets[4]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[4]->SamplerTexture0Location = _shaderSets[4]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[4]->UniformMatrixLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[4]->UniformBaseColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[4]->UniformMultiplyColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[4]->UniformScreenColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 通常（クリッピング、PremultipliedAlpha）
+    _shaderSets[5]->AttributePositionLocation = _shaderSets[5]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[5]->AttributeTexCoordLocation = _shaderSets[5]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[5]->SamplerTexture0Location = _shaderSets[5]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[5]->SamplerTexture1Location = _shaderSets[5]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[5]->UniformMatrixLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[5]->UniformClipMatrixLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[5]->UnifromChannelFlagLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[5]->UniformBaseColorLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[5]->UniformMultiplyColorLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[5]->UniformScreenColorLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 通常（クリッピング・反転、PremultipliedAlpha）
+    _shaderSets[6]->AttributePositionLocation = _shaderSets[6]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[6]->AttributeTexCoordLocation = _shaderSets[6]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[6]->SamplerTexture0Location = _shaderSets[6]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[6]->SamplerTexture1Location = _shaderSets[6]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[6]->UniformMatrixLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[6]->UniformClipMatrixLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[6]->UnifromChannelFlagLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[6]->UniformBaseColorLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[6]->UniformMultiplyColorLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[6]->UniformScreenColorLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 加算
+    _shaderSets[7]->AttributePositionLocation = _shaderSets[7]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[7]->AttributeTexCoordLocation = _shaderSets[7]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[7]->SamplerTexture0Location = _shaderSets[7]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[7]->UniformMatrixLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[7]->UniformBaseColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[7]->UniformMultiplyColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[7]->UniformScreenColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 加算（クリッピング）
+    _shaderSets[8]->AttributePositionLocation = _shaderSets[8]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[8]->AttributeTexCoordLocation = _shaderSets[8]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[8]->SamplerTexture0Location = _shaderSets[8]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[8]->SamplerTexture1Location = _shaderSets[8]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[8]->UniformMatrixLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[8]->UniformClipMatrixLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[8]->UnifromChannelFlagLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[8]->UniformBaseColorLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[8]->UniformMultiplyColorLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[8]->UniformScreenColorLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 加算（クリッピング・反転）
+    _shaderSets[9]->AttributePositionLocation = _shaderSets[9]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[9]->AttributeTexCoordLocation = _shaderSets[9]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[9]->SamplerTexture0Location = _shaderSets[9]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[9]->SamplerTexture1Location = _shaderSets[9]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[9]->UniformMatrixLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[9]->UniformClipMatrixLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[9]->UnifromChannelFlagLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[9]->UniformBaseColorLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[9]->UniformMultiplyColorLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[9]->UniformScreenColorLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 加算（PremultipliedAlpha）
+    _shaderSets[10]->AttributePositionLocation = _shaderSets[10]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[10]->AttributeTexCoordLocation = _shaderSets[10]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[10]->SamplerTexture0Location = _shaderSets[10]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[10]->UniformMatrixLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[10]->UniformBaseColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[10]->UniformMultiplyColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[10]->UniformScreenColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 加算（クリッピング、PremultipliedAlpha）
+    _shaderSets[11]->AttributePositionLocation = _shaderSets[11]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[11]->AttributeTexCoordLocation = _shaderSets[11]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[11]->SamplerTexture0Location = _shaderSets[11]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[11]->SamplerTexture1Location = _shaderSets[11]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[11]->UniformMatrixLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[11]->UniformClipMatrixLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[11]->UnifromChannelFlagLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[11]->UniformBaseColorLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[11]->UniformMultiplyColorLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[11]->UniformScreenColorLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 加算（クリッピング・反転、PremultipliedAlpha）
+    _shaderSets[12]->AttributePositionLocation = _shaderSets[12]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[12]->AttributeTexCoordLocation = _shaderSets[12]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[12]->SamplerTexture0Location = _shaderSets[12]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[12]->SamplerTexture1Location = _shaderSets[12]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[12]->UniformMatrixLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[12]->UniformClipMatrixLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[12]->UnifromChannelFlagLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[12]->UniformBaseColorLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[12]->UniformMultiplyColorLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[12]->UniformScreenColorLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 乗算
+    _shaderSets[13]->AttributePositionLocation = _shaderSets[13]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[13]->AttributeTexCoordLocation = _shaderSets[13]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[13]->SamplerTexture0Location = _shaderSets[13]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[13]->UniformMatrixLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[13]->UniformBaseColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[13]->UniformMultiplyColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[13]->UniformScreenColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 乗算（クリッピング）
+    _shaderSets[14]->AttributePositionLocation = _shaderSets[14]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[14]->AttributeTexCoordLocation = _shaderSets[14]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[14]->SamplerTexture0Location = _shaderSets[14]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[14]->SamplerTexture1Location = _shaderSets[14]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[14]->UniformMatrixLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[14]->UniformClipMatrixLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[14]->UnifromChannelFlagLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[14]->UniformBaseColorLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[14]->UniformMultiplyColorLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[14]->UniformScreenColorLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 乗算（クリッピング・反転）
+    _shaderSets[15]->AttributePositionLocation = _shaderSets[15]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[15]->AttributeTexCoordLocation = _shaderSets[15]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[15]->SamplerTexture0Location = _shaderSets[15]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[15]->SamplerTexture1Location = _shaderSets[15]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[15]->UniformMatrixLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[15]->UniformClipMatrixLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[15]->UnifromChannelFlagLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[15]->UniformBaseColorLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[15]->UniformMultiplyColorLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[15]->UniformScreenColorLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 乗算（PremultipliedAlpha）
+    _shaderSets[16]->AttributePositionLocation = _shaderSets[16]->ShaderProgram->getAttributeLocation( "a_position");
+    _shaderSets[16]->AttributeTexCoordLocation = _shaderSets[16]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[16]->SamplerTexture0Location = _shaderSets[16]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[16]->UniformMatrixLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[16]->UniformBaseColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[16]->UniformMultiplyColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[16]->UniformScreenColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 乗算（クリッピング、PremultipliedAlpha）
+    _shaderSets[17]->AttributePositionLocation = _shaderSets[17]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[17]->AttributeTexCoordLocation = _shaderSets[17]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[17]->SamplerTexture0Location = _shaderSets[17]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[17]->SamplerTexture1Location = _shaderSets[17]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[17]->UniformMatrixLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[17]->UniformClipMatrixLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[17]->UnifromChannelFlagLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[17]->UniformBaseColorLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[17]->UniformMultiplyColorLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[17]->UniformScreenColorLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_screenColor");
+
+    // 乗算（クリッピング・反転、PremultipliedAlpha）
+    _shaderSets[18]->AttributePositionLocation = _shaderSets[18]->ShaderProgram->getAttributeLocation("a_position");
+    _shaderSets[18]->AttributeTexCoordLocation = _shaderSets[18]->ShaderProgram->getAttributeLocation("a_texCoord");
+    _shaderSets[18]->SamplerTexture0Location = _shaderSets[18]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[18]->SamplerTexture1Location = _shaderSets[18]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[18]->UniformMatrixLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_matrix");
+    _shaderSets[18]->UniformClipMatrixLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_clipMatrix");
+    _shaderSets[18]->UnifromChannelFlagLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_channelFlag");
+    _shaderSets[18]->UniformBaseColorLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_baseColor");
+    _shaderSets[18]->UniformMultiplyColorLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_multiplyColor");
+    _shaderSets[18]->UniformScreenColorLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_screenColor");
+}
+
+void CubismShader_Cocos2dx::SetupShaderProgramForMask(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, CubismRenderer_Cocos2dx* renderer
+                                                    ,const CubismModel& model, const csmInt32 index)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders();
+    }
+
+    cocos2d::backend::BlendDescriptor* blendDescriptor = drawCommand->GetBlendDescriptor();
+    cocos2d::PipelineDescriptor* pipelineDescriptor = drawCommand->GetPipelineDescriptor();
+
+    cocos2d::backend::ProgramState* programState = pipelineDescriptor->programState;
+
+    CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
+
+    if (!programState)
+    {
+        programState = new cocos2d::backend::ProgramState(shaderSet->ShaderProgram);
+    }
+
+
+    //テクスチャ設定
+    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
+    cocos2d::Texture2D* texture = renderer->GetBindedTexture(textureNo);
+    programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
+
+    // 頂点配列の設定
+    programState->getVertexLayout()->setAttribute("a_position", shaderSet->AttributePositionLocation, cocos2d::backend::VertexFormat::FLOAT2, 0, false);
+    // テクスチャ頂点の設定
+    programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, cocos2d::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
+
+    // チャンネル
+    const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
+    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    csmFloat32 colorFlag[4] = { colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
+    programState->setUniform(shaderSet->UnifromChannelFlagLocation, colorFlag, sizeof(float) * 4);
+
+    //マスク用行列
+    programState->setUniform(shaderSet->UniformClipMatrixLocation,
+                             renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray(),
+                             sizeof(float) * 16);
+
+    //マスク描画範囲
+    csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
+    csmFloat32 base[4] = { rect->X * 2.0f - 1.0f,
+                            rect->Y * 2.0f - 1.0f,
+                            rect->GetRight() * 2.0f - 1.0f,
+                            rect->GetBottom() * 2.0f - 1.0f };
+    programState->setUniform(shaderSet->UniformBaseColorLocation, base, sizeof(float) * 4);
+
+    //乗算色
+    const CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+    csmFloat32 multiply[4] = { multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
+    programState->setUniform(shaderSet->UniformMultiplyColorLocation, multiply, sizeof(float) * 4);
+
+    //スクリーン色
+    const CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+    csmFloat32 screen[4] = { screenColor.R, screenColor.G, screenColor.B, screenColor.A };
+    programState->setUniform(shaderSet->UniformScreenColorLocation, screen, sizeof(float) * 4);
+
+    blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::ZERO;
+    blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_COLOR;
+    blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ZERO;
+    blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
+
+    programState->getVertexLayout()->setLayout(sizeof(csmFloat32) * 4);
+    blendDescriptor->blendEnabled = true;
+    pipelineDescriptor->programState = programState;
+}
+
+void CubismShader_Cocos2dx::SetupShaderProgramForDraw(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand
+                                                    , CubismRenderer_Cocos2dx* renderer, const CubismModel& model, const csmInt32 index)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders();
+    }
+
+    // _shaderSets用offsetの計算
+    const csmBool masked = renderer->GetClippingContextBufferForDraw() != NULL;  // この描画オブジェクトはマスク対象か
+    const csmBool invertedMask = model.GetDrawableInvertedMask(index);
+    const csmBool isPremultipliedAlpha = renderer->IsPremultipliedAlpha();
+    const csmInt32 offset = (masked ? ( invertedMask ? 2 : 1 ) : 0) + (isPremultipliedAlpha ? 3 : 0);
+
+    CubismShaderSet* shaderSet;
+    cocos2d::backend::BlendDescriptor* blendDescriptor = drawCommand->GetBlendDescriptor();
+    switch (model.GetDrawableBlendMode(index))
+    {
+    case CubismRenderer::CubismBlendMode_Normal:
+    default:
+        shaderSet = _shaderSets[ShaderNames_Normal + offset];
+        blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::ONE;
+        blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
+        blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE;
+        blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
+        break;
+
+    case CubismRenderer::CubismBlendMode_Additive:
+        shaderSet = _shaderSets[ShaderNames_Add + offset];
+        blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::ONE;
+        blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE;
+        blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ZERO;
+        blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE;
+        break;
+
+    case CubismRenderer::CubismBlendMode_Multiplicative:
+        shaderSet = _shaderSets[ShaderNames_Mult + offset];
+        blendDescriptor->sourceRGBBlendFactor = cocos2d::backend::BlendFactor::DST_COLOR;
+        blendDescriptor->destinationRGBBlendFactor = cocos2d::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
+        blendDescriptor->sourceAlphaBlendFactor = cocos2d::backend::BlendFactor::ZERO;
+        blendDescriptor->destinationAlphaBlendFactor = cocos2d::backend::BlendFactor::ONE;
+        break;
+    }
+
+    cocos2d::PipelineDescriptor* pipelineDescriptor = drawCommand->GetPipelineDescriptor();
+    cocos2d::backend::ProgramState* programState = pipelineDescriptor->programState;
+    if (!programState)
+    {
+        programState = new cocos2d::backend::ProgramState(shaderSet->ShaderProgram);
+    }
+
+    // 頂点配列の設定
+    programState->getVertexLayout()->setAttribute("a_position", shaderSet->AttributePositionLocation, cocos2d::backend::VertexFormat::FLOAT2, 0, false);
+    // テクスチャ頂点の設定
+    programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, cocos2d::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
+
+    if (masked)
+    {
+        // frameBufferに書かれたテクスチャ
+        cocos2d::Texture2D* tex = renderer->GetOffscreenSurface(renderer->GetClippingContextBufferForDraw()->_bufferIndex)->GetColorBuffer();
+
+        programState->setTexture(shaderSet->SamplerTexture1Location, 1, tex->getBackendTexture());
+
+        // View座標をClippingContextの座標に変換するための行列を設定
+        programState->setUniform(shaderSet->UniformClipMatrixLocation,
+                                 renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray(),
+                                 sizeof(float) * 16);
+
+        // 使用するカラーチャンネルを設定
+        const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        csmFloat32 colorFlag[4] = { colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
+        programState->setUniform(shaderSet->UnifromChannelFlagLocation, colorFlag, sizeof(float) * 4);
+    }
+
+    //テクスチャ設定
+    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
+    cocos2d::Texture2D* texture = renderer->GetBindedTexture(textureNo);
+    programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
+
+    //座標変換
+    CubismMatrix44 matrix4x4 = renderer->GetMvpMatrix();
+    programState->setUniform(shaderSet->UniformMatrixLocation, matrix4x4.GetArray(), sizeof(float) * 16);
+
+    //ベース色
+    CubismRenderer::CubismTextureColor baseColor = renderer->GetModelColorWithOpacity(model.GetDrawableOpacity(index));
+    csmFloat32 base[4] = { baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+    programState->setUniform(shaderSet->UniformBaseColorLocation, base, sizeof(float) * 4);
+
+    //乗算色
+    const CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+    csmFloat32 multiply[4] = { multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
+    programState->setUniform(shaderSet->UniformMultiplyColorLocation, multiply, sizeof(float) * 4);
+
+    //スクリーン色
+    const CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+    csmFloat32 screen[4] = { screenColor.R, screenColor.G, screenColor.B, screenColor.A };
+    programState->setUniform(shaderSet->UniformScreenColorLocation, screen, sizeof(float) * 4);
+
+    programState->getVertexLayout()->setLayout(sizeof(csmFloat32) * 4);
+    blendDescriptor->blendEnabled = true;
+    pipelineDescriptor->programState = programState;
+}
+
+cocos2d::backend::Program* CubismShader_Cocos2dx::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
+{
+    // cocos2dx対応
+    // Create shader program.
+    return cocos2d::backend::Device::getInstance()->newProgram(vertShaderSrc, fragShaderSrc);
+}
+
+}}}}
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Cocos2d/CubismShader_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismShader_Cocos2dx.hpp
@@ -1,0 +1,155 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "CubismFramework.hpp"
+#include "CubismCommandBuffer_Cocos2dx.hpp"
+#include "CubismRenderer_Cocos2dx.hpp"
+#include "Type/csmVector.hpp"
+
+#ifdef CSM_TARGET_ANDROID_ES2
+#include <jni.h>
+#include <errno.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#endif
+
+#ifdef CSM_TARGET_IPHONE_ES2
+#include <OpenGLES/ES2/gl.h>
+#include <OpenGLES/ES2/glext.h>
+#endif
+
+#if defined(CSM_TARGET_WIN_GL) || defined(CSM_TARGET_LINUX_GL)
+#include <GL/glew.h>
+#include <GL/gl.h>
+#endif
+
+#ifdef CSM_TARGET_MAC_GL
+#ifndef CSM_TARGET_COCOS
+#include <GL/glew.h>
+#endif
+#include <OpenGL/gl.h>
+#endif
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+// 前方宣言
+class CubismRenderer_Cocos2dx;
+
+/**
+ * @brief   Cocos2dx用のシェーダプログラムを生成・破棄するクラス<br>
+ *           シングルトンなクラスであり、CubismShader_Cocos2dx::GetInstance()からアクセスする。
+ */
+class CubismShader_Cocos2dx
+{
+public:
+    /**
+     * @brief   インスタンスを取得する（シングルトン）。
+     *
+     * @return  インスタンスのポインタ
+     */
+    static CubismShader_Cocos2dx* GetInstance();
+
+    /**
+     * @brief   インスタンスを解放する（シングルトン）。
+     */
+    static void DeleteInstance();
+
+    /**
+     * @brief   マスク用のシェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   drawCommand            ->  コマンドバッファ
+     * @param[in]   renderer               ->  レンダラー
+     * @param[in]   model                  ->  描画対象のモデル
+     * @param[in]   index                  ->  描画対象のメッシュのインデックス
+     */
+    void SetupShaderProgramForMask(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, CubismRenderer_Cocos2dx* renderer
+                                ,const CubismModel& model, const csmInt32 index);
+
+    /**
+     * @brief   描画用のシェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   drawCommand            ->  コマンドバッファ
+     * @param[in]   renderer               ->  レンダラー
+     * @param[in]   model                  ->  描画対象のモデル
+     * @param[in]   index                  ->  描画対象のメッシュのインデックス
+     */
+    void SetupShaderProgramForDraw(CubismCommandBuffer_Cocos2dx::DrawCommandBuffer::DrawCommand* drawCommand, CubismRenderer_Cocos2dx* renderer
+                                ,const CubismModel& model, const csmInt32 index);
+
+private:
+    /**
+    * @bref    シェーダープログラムとシェーダ変数のアドレスを保持する構造体
+    *
+    */
+    struct CubismShaderSet
+    {
+        cocos2d::backend::Program* ShaderProgram;               ///< シェーダプログラムのアドレス
+        unsigned int AttributePositionLocation;   ///< シェーダプログラムに渡す変数のアドレス(Position)
+        unsigned int AttributeTexCoordLocation;   ///< シェーダプログラムに渡す変数のアドレス(TexCoord)
+        cocos2d::backend::UniformLocation UniformMatrixLocation;        ///< シェーダプログラムに渡す変数のアドレス(Matrix)
+        cocos2d::backend::UniformLocation UniformClipMatrixLocation;    ///< シェーダプログラムに渡す変数のアドレス(ClipMatrix)
+        cocos2d::backend::UniformLocation SamplerTexture0Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture0)
+        cocos2d::backend::UniformLocation SamplerTexture1Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture1)
+        cocos2d::backend::UniformLocation UniformBaseColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(BaseColor)
+        cocos2d::backend::UniformLocation UniformMultiplyColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(MultiplyColor)
+        cocos2d::backend::UniformLocation UniformScreenColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(ScreenColor)
+        cocos2d::backend::UniformLocation UnifromChannelFlagLocation;   ///< シェーダプログラムに渡す変数のアドレス(ChannelFlag)
+    };
+
+    /**
+     * @brief   privateなコンストラクタ
+     */
+    CubismShader_Cocos2dx();
+
+    /**
+     * @brief   privateなデストラクタ
+     */
+    virtual ~CubismShader_Cocos2dx();
+
+    /**
+     * @brief   シェーダプログラムを解放する
+     */
+    void ReleaseShaderProgram();
+
+    /**
+     * @brief   シェーダプログラムを初期化する
+     */
+    void GenerateShaders();
+
+    /**
+     * @brief   シェーダプログラムをロードしてアドレス返す。
+     *
+     * @param[in]   vertShaderSrc   ->  頂点シェーダのソース
+     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのソース
+     *
+     * @return  シェーダプログラムのアドレス
+     */
+    cocos2d::backend::Program* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
+
+#ifdef CSM_TARGET_ANDROID_ES2
+public:
+    /**
+     * @brief   Tegraプロセッサ対応。拡張方式による描画の有効・無効
+     *
+     * @param[in]   extMode     ->  trueなら拡張方式で描画する
+     * @param[in]   extPAMode   ->  trueなら拡張方式のPA設定を有効にする
+     */
+    static void SetExtShaderMode(csmBool extMode, csmBool extPAMode);
+
+private:
+    static csmBool  s_extMode;      ///< Tegra対応.拡張方式で描画
+    static csmBool  s_extPAMode;    ///< 拡張方式のPA設定用の変数
+#endif
+
+    csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
+};
+
+}}}}
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/CubismClippingManager.hpp
+++ b/src/Rendering/CubismClippingManager.hpp
@@ -1,0 +1,155 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <float.h>
+#include "CubismFramework.hpp"
+#include "Type/csmVector.hpp"
+#include "Type/csmRectF.hpp"
+#include "Math/CubismVector2.hpp"
+#include "Math/CubismMatrix44.hpp"
+#include "Model/CubismModel.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+///< ファイルスコープの変数宣言
+#ifndef CSM_MASK_FILESCOPE
+#define CSM_MASK_FILESCOPE
+namespace {
+const csmInt32 ColorChannelCount = 4;   // 実験時に1チャンネルの場合は1、RGBだけの場合は3、アルファも含める場合は4
+const csmInt32 ClippingMaskMaxCountOnDefault = 36;  // 通常のフレームバッファ1枚あたりのマスク最大数
+const csmInt32 ClippingMaskMaxCountOnMultiRenderTexture = 32;   // フレームバッファが2枚以上ある場合のフレームバッファ1枚あたりのマスク最大数
+}
+#endif
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+class CubismClippingManager
+{
+public:
+    /**
+     * @brief    コンストラクタ
+     */
+    CubismClippingManager();
+
+    /**
+     * @brief    デストラクタ
+     */
+    virtual ~CubismClippingManager();
+
+    /**
+     * @brief    マネージャの初期化処理<br>
+     *           クリッピングマスクを使う描画オブジェクトの登録を行う
+     *
+     * @param[in]   model           ->  モデルのインスタンス
+     * @param[in]   maskBufferCount ->  バッファの生成数
+     */
+    void Initialize(CubismModel& model, const csmInt32 maskBufferCount);
+
+    /**
+     * @brief   既にマスクを作っているかを確認。<br>
+     *          作っているようであれば該当するクリッピングマスクのインスタンスを返す。<br>
+     *          作っていなければNULLを返す
+     *
+     * @param[in]   drawableMasks    ->  描画オブジェクトをマスクする描画オブジェクトのリスト
+     * @param[in]   drawableMaskCounts ->  描画オブジェクトをマスクする描画オブジェクトの数
+     * @return          該当するクリッピングマスクが存在すればインスタンスを返し、なければNULLを返す。
+     */
+    T_ClippingContext* FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const;
+
+    /**
+     * @brief   高精細マスク処理用の行列を計算する
+     *
+     * @param[in]   model         ->  モデルのインスタンス
+     * @param[in]   isRightHanded ->  処理が右手系であるか
+     */
+    void SetupMatrixForHighPrecision(CubismModel& model, csmBool isRightHanded);
+
+    /**
+     * @brief   マスク作成・描画用の行列を作成する。
+     *
+     * @param[in]   isRightHanded        ->  座標を右手系として扱うかを指定
+     * @param[in]   layoutBoundsOnTex01  ->  マスクを収める領域
+     * @param[in]   scaleX               ->  描画オブジェクトの伸縮率
+     * @param[in]   scaleY               ->  描画オブジェクトの伸縮率
+     */
+    void createMatrixForMask(csmBool isRightHanded, csmRectF* layoutBoundsOnTex01, csmFloat32 scaleX, csmFloat32 scaleY);
+
+    /**
+     * @brief   クリッピングコンテキストを配置するレイアウト。<br>
+     *           ひとつのレンダーテクスチャを極力いっぱいに使ってマスクをレイアウトする。<br>
+     *           マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する。
+     *
+     * @param[in]   usingClipCount  ->  配置するクリッピングコンテキストの数
+     */
+    void SetupLayoutBounds(csmInt32 usingClipCount) const;
+
+    /**
+     * @brief   マスクされる描画オブジェクト群全体を囲む矩形(モデル座標系)を計算する
+     *
+     * @param[in]   model            ->  モデルのインスタンス
+     * @param[in]   clippingContext  ->  クリッピングマスクのコンテキスト
+     */
+    void CalcClippedDrawTotalBounds(CubismModel& model, T_ClippingContext* clippingContext);
+
+    /**
+     * @brief   画面描画に使用するクリッピングマスクのリストを取得する
+     *
+     * @return  画面描画に使用するクリッピングマスクのリスト
+     */
+    csmVector<T_ClippingContext*>* GetClippingContextListForDraw();
+
+    /**
+     *@brief  クリッピングマスクバッファのサイズを取得する
+     *
+     *@return クリッピングマスクバッファのサイズ
+     */
+    CubismVector2 GetClippingMaskBufferSize() const;
+
+    /**
+     * このバッファのレンダーテクスチャの枚数を取得する。
+     *
+     * @return このバッファのレンダーテクスチャの枚数
+     */
+    csmInt32 GetRenderTextureCount();
+
+    /**
+     * @brief   カラーチャンネル(RGBA)のフラグを取得する
+     *
+     * @param[in]   channelNo   ->   カラーチャンネル(RGBA)の番号(0:R , 1:G , 2:B, 3:A)
+     */
+    CubismRenderer::CubismTextureColor* GetChannelFlagAsColor(csmInt32 channelNo);
+
+    /**
+     *@brief  クリッピングマスクバッファのサイズを設定する
+     *
+     *@param  size -> クリッピングマスクバッファのサイズ
+     *
+     */
+    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
+
+protected:
+    T_OffscreenSurface* _currentMaskBuffer; /// オフスクリーンサーフェイスのアドレス
+    csmVector<csmBool> _clearedMaskBufferFlags; /// マスクのクリアフラグの配列
+
+    csmVector<CubismRenderer::CubismTextureColor*> _channelColors;
+    csmVector<T_ClippingContext*> _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
+    csmVector<T_ClippingContext*> _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
+    CubismVector2 _clippingMaskBufferSize;       ///< クリッピングマスクのバッファサイズ（初期値:256）
+    csmInt32 _renderTextureCount;           ///< 生成するレンダーテクスチャの枚数
+
+    CubismMatrix44 _tmpMatrix;              ///< マスク計算用の行列
+    CubismMatrix44 _tmpMatrixForMask;       ///< マスク計算用の行列
+    CubismMatrix44 _tmpMatrixForDraw;       ///< マスク計算用の行列
+    csmRectF _tmpBoundsOnModel;       ///< マスク配置計算用の矩形
+};
+
+#include "CubismClippingManager.tpp"
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/CubismClippingManager.tpp
+++ b/src/Rendering/CubismClippingManager.tpp
@@ -1,0 +1,507 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+// template で宣言下 CubismClippingManager の実装を記述
+template <class T_ClippingContext, class T_OffscreenSurface>
+CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::CubismClippingManager() :
+                                                                    _clippingMaskBufferSize(256, 256)
+{
+    CubismRenderer::CubismTextureColor* tmp = NULL;
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 1.0f;
+    tmp->G = 0.0f;
+    tmp->B = 0.0f;
+    tmp->A = 0.0f;
+    _channelColors.PushBack(tmp);
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 0.0f;
+    tmp->G = 1.0f;
+    tmp->B = 0.0f;
+    tmp->A = 0.0f;
+    _channelColors.PushBack(tmp);
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 0.0f;
+    tmp->G = 0.0f;
+    tmp->B = 1.0f;
+    tmp->A = 0.0f;
+    _channelColors.PushBack(tmp);
+    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
+    tmp->R = 0.0f;
+    tmp->G = 0.0f;
+    tmp->B = 0.0f;
+    tmp->A = 1.0f;
+    _channelColors.PushBack(tmp);
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::~CubismClippingManager()
+{
+    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
+    {
+        if (_clippingContextListForMask[i]) CSM_DELETE_SELF(T_ClippingContext, _clippingContextListForMask[i]);
+        _clippingContextListForMask[i] = NULL;
+    }
+
+    // _clippingContextListForDrawは_clippingContextListForMaskにあるインスタンスを指している。上記の処理により要素ごとのDELETEは不要。
+    for (csmUint32 i = 0; i < _clippingContextListForDraw.GetSize(); i++)
+    {
+        _clippingContextListForDraw[i] = NULL;
+    }
+
+    for (csmUint32 i = 0; i < _channelColors.GetSize(); i++)
+    {
+        if (_channelColors[i]) CSM_DELETE(_channelColors[i]);
+        _channelColors[i] = NULL;
+    }
+
+    if (_clearedMaskBufferFlags.GetSize() != 0)
+    {
+        _clearedMaskBufferFlags.Clear();
+        _clearedMaskBufferFlags = NULL;
+    }
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+void CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::Initialize(CubismModel& model, const csmInt32 maskBufferCount)
+{
+    _renderTextureCount = maskBufferCount;
+
+    // レンダーテクスチャのクリアフラグの設定
+    for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+    {
+        _clearedMaskBufferFlags.PushBack(false);
+    }
+
+    //クリッピングマスクを使う描画オブジェクトを全て登録する
+    //クリッピングマスクは、通常数個程度に限定して使うものとする
+    for (csmInt32 i = 0; i < model.GetDrawableCount(); i++)
+    {
+        if (model.GetDrawableMaskCounts()[i] <= 0)
+        {
+            //クリッピングマスクが使用されていないアートメッシュ（多くの場合使用しない）
+            _clippingContextListForDraw.PushBack(NULL);
+            continue;
+        }
+
+        // 既にあるClipContextと同じかチェックする
+        T_ClippingContext* cc = FindSameClip(model.GetDrawableMasks()[i], model.GetDrawableMaskCounts()[i]);
+        if (cc == NULL)
+        {
+            // 同一のマスクが存在していない場合は生成する
+            cc = CSM_NEW T_ClippingContext(this, model, model.GetDrawableMasks()[i], model.GetDrawableMaskCounts()[i]);
+            _clippingContextListForMask.PushBack(cc);
+        }
+
+        cc->AddClippedDrawable(i);
+
+        _clippingContextListForDraw.PushBack(cc);
+    }
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+T_ClippingContext* CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const
+{
+    // 作成済みClippingContextと一致するか確認
+    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
+    {
+        T_ClippingContext* cc = _clippingContextListForMask[i];
+        const csmInt32 count = cc->_clippingIdCount;
+        if (count != drawableMaskCounts) continue; //個数が違う場合は別物
+        csmInt32 samecount = 0;
+
+        // 同じIDを持つか確認。配列の数が同じなので、一致した個数が同じなら同じ物を持つとする。
+        for (csmInt32 j = 0; j < count; j++)
+        {
+            const csmInt32 clipId = cc->_clippingIdList[j];
+            for (csmInt32 k = 0; k < count; k++)
+            {
+                if (drawableMasks[k] == clipId)
+                {
+                    samecount++;
+                    break;
+                }
+            }
+        }
+        if (samecount == count)
+        {
+            return cc;
+        }
+    }
+    return NULL; //見つからなかった
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+void CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::SetupMatrixForHighPrecision(CubismModel& model, csmBool isRightHanded)
+{
+    // 全てのクリッピングを用意する
+    // 同じクリップ（複数の場合はまとめて１つのクリップ）を使う場合は１度だけ設定する
+    csmInt32 usingClipCount = 0;
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // １つのクリッピングマスクに関して
+        T_ClippingContext* cc = _clippingContextListForMask[clipIndex];
+
+        // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
+        CalcClippedDrawTotalBounds(model, cc);
+
+        if (cc->_isUsing)
+        {
+            usingClipCount++; //使用中としてカウント
+        }
+    }
+
+    if (usingClipCount <= 0) {
+        return;
+    }
+    // マスク行列作成処理
+    SetupLayoutBounds(0);
+
+    // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
+    if (_clearedMaskBufferFlags.GetSize() != _renderTextureCount)
+    {
+        _clearedMaskBufferFlags.Clear();
+
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+        {
+            _clearedMaskBufferFlags.PushBack(false);
+        }
+    }
+    else
+    {
+        // マスクのクリアフラグを毎フレーム開始時に初期化
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+        {
+            _clearedMaskBufferFlags[i] = false;
+        }
+    }
+
+    // 実際にマスクを生成する
+    // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // --- 実際に１つのマスクを描く ---
+        T_ClippingContext* clipContext = _clippingContextListForMask[clipIndex];
+        csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+        csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
+        const csmFloat32 MARGIN = 0.05f;
+        csmFloat32 scaleX = 0.0f;
+        csmFloat32 scaleY = 0.0f;
+        const csmFloat32 ppu = model.GetPixelsPerUnit();
+        const csmFloat32 maskPixelWidth = clipContext->GetClippingManager()->_clippingMaskBufferSize.X;
+        const csmFloat32 maskPixelHeight = clipContext->GetClippingManager()->_clippingMaskBufferSize.Y;
+        const csmFloat32 physicalMaskWidth = layoutBoundsOnTex01->Width * maskPixelWidth;
+        const csmFloat32 physicalMaskHeight = layoutBoundsOnTex01->Height * maskPixelHeight;
+
+        _tmpBoundsOnModel.SetRect(allClippedDrawRect);
+        if (_tmpBoundsOnModel.Width * ppu > physicalMaskWidth)
+        {
+            _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, 0.0f);
+            scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
+        }
+        else
+        {
+            scaleX = ppu / physicalMaskWidth;
+        }
+
+        if (_tmpBoundsOnModel.Height * ppu > physicalMaskHeight)
+        {
+            _tmpBoundsOnModel.Expand(0.0f, allClippedDrawRect->Height * MARGIN);
+            scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
+        }
+        else
+        {
+            scaleY = ppu / physicalMaskHeight;
+        }
+
+
+        // マスク生成時に使う行列を求める
+        createMatrixForMask(isRightHanded, layoutBoundsOnTex01, scaleX, scaleY);
+
+        clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
+        clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
+    }
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+void CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::createMatrixForMask(csmBool isRightHanded, csmRectF* layoutBoundsOnTex01, csmFloat32 scaleX, csmFloat32 scaleY)
+{
+    _tmpMatrix.LoadIdentity();
+    {
+        // Layout0..1 を -1..1に変換
+        _tmpMatrix.TranslateRelative(-1.0f, -1.0f);
+        _tmpMatrix.ScaleRelative(2.0f, 2.0f);
+    }
+    {
+        // view to Layout0..1
+        _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
+        _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
+        _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y); //new = [translate][scale][translate]
+     }
+     // tmpMatrixForMask が計算結果
+     _tmpMatrixForMask.SetMatrix(_tmpMatrix.GetArray());
+
+    _tmpMatrix.LoadIdentity();
+    {
+        _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y * ((isRightHanded) ? -1.0f : 1.0f)); //new = [translate]
+        _tmpMatrix.ScaleRelative(scaleX, scaleY * ((isRightHanded) ? -1.0f : 1.0f)); //new = [translate][scale]
+        _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y); //new = [translate][scale][translate]
+    }
+
+    _tmpMatrixForDraw.SetMatrix(_tmpMatrix.GetArray());
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+void CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::SetupLayoutBounds(csmInt32 usingClipCount) const
+{
+    const csmInt32 useClippingMaskMaxCount = _renderTextureCount <= 1
+        ? ClippingMaskMaxCountOnDefault
+        : ClippingMaskMaxCountOnMultiRenderTexture * _renderTextureCount;
+
+    if (usingClipCount <= 0 || usingClipCount > useClippingMaskMaxCount)
+    {
+        if (usingClipCount > useClippingMaskMaxCount)
+        {
+            // マスクの制限数の警告を出す
+            csmInt32 count = usingClipCount - useClippingMaskMaxCount;
+            CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : %d"
+                , count, _renderTextureCount, usingClipCount);
+        }
+
+        // この場合は一つのマスクターゲットを毎回クリアして使用する
+        for (csmUint32 index = 0; index < _clippingContextListForMask.GetSize(); index++)
+        {
+            T_ClippingContext* cc = _clippingContextListForMask[index];
+            cc->_layoutChannelNo = 0; // どうせ毎回消すので固定で良い
+            cc->_layoutBounds->X = 0.0f;
+            cc->_layoutBounds->Y = 0.0f;
+            cc->_layoutBounds->Width = 1.0f;
+            cc->_layoutBounds->Height = 1.0f;
+            cc->_bufferIndex = 0;
+        }
+        return;
+    }
+
+    // レンダーテクスチャが1枚なら9分割する（最大36枚）
+    const csmInt32 layoutCountMaxValue = _renderTextureCount <= 1 ? 9 : 8;
+
+    // ひとつのRenderTextureを極力いっぱいに使ってマスクをレイアウトする
+    // マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する
+    const csmInt32 countPerSheetDiv = usingClipCount / _renderTextureCount; // レンダーテクスチャ1枚あたり何枚割り当てるか
+    const csmInt32 countPerSheetMod = usingClipCount % _renderTextureCount; // この番号のレンダーテクスチャまでに一つずつ配分する
+
+    // RGBAを順番に使っていく。
+    const csmInt32 div = countPerSheetDiv / ColorChannelCount; //１チャンネルに配置する基本のマスク個数
+    const csmInt32 mod = countPerSheetDiv % ColorChannelCount; //余り、この番号のチャンネルまでに１つずつ配分する
+
+    // RGBAそれぞれのチャンネルを用意していく(0:R , 1:G , 2:B, 3:A, )
+    csmInt32 curClipIndex = 0; //順番に設定していく
+
+    for (csmInt32 renderTextureNo = 0; renderTextureNo < _renderTextureCount; renderTextureNo++)
+    {
+        for (csmInt32 channelNo = 0; channelNo < ColorChannelCount; channelNo++)
+        {
+            // このチャンネルにレイアウトする数
+            csmInt32 layoutCount = div + (channelNo < mod ? 1 : 0);
+
+            // このレンダーテクスチャにまだ割り当てられていなければ追加する
+            const csmInt32 checkChannelNo = mod + 1 >= ColorChannelCount ? 0 : mod + 1;
+            if (layoutCount < layoutCountMaxValue && channelNo == checkChannelNo)
+            {
+                layoutCount += renderTextureNo < countPerSheetMod ? 1 : 0;
+            }
+
+            // 分割方法を決定する
+            if (layoutCount == 0)
+            {
+                // 何もしない
+            }
+            else if (layoutCount == 1)
+            {
+                //全てをそのまま使う
+                T_ClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                cc->_layoutChannelNo = channelNo;
+                cc->_layoutBounds->X = 0.0f;
+                cc->_layoutBounds->Y = 0.0f;
+                cc->_layoutBounds->Width = 1.0f;
+                cc->_layoutBounds->Height = 1.0f;
+                cc->_bufferIndex = renderTextureNo;
+            }
+            else if (layoutCount == 2)
+            {
+                for (csmInt32 i = 0; i < layoutCount; i++)
+                {
+                    const csmInt32 xpos = i % 2;
+
+                    T_ClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                    cc->_layoutChannelNo = channelNo;
+
+                    cc->_layoutBounds->X = xpos * 0.5f;
+                    cc->_layoutBounds->Y = 0.0f;
+                    cc->_layoutBounds->Width = 0.5f;
+                    cc->_layoutBounds->Height = 1.0f;
+                    cc->_bufferIndex = renderTextureNo;
+                    //UVを2つに分解して使う
+                }
+            }
+            else if (layoutCount <= 4)
+            {
+                //4分割して使う
+                for (csmInt32 i = 0; i < layoutCount; i++)
+                {
+                    const csmInt32 xpos = i % 2;
+                    const csmInt32 ypos = i / 2;
+
+                    T_ClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                    cc->_layoutChannelNo = channelNo;
+
+                    cc->_layoutBounds->X = xpos * 0.5f;
+                    cc->_layoutBounds->Y = ypos * 0.5f;
+                    cc->_layoutBounds->Width = 0.5f;
+                    cc->_layoutBounds->Height = 0.5f;
+                    cc->_bufferIndex = renderTextureNo;
+                }
+            }
+            else if (layoutCount <= layoutCountMaxValue)
+            {
+                //9分割して使う
+                for (csmInt32 i = 0; i < layoutCount; i++)
+                {
+                    const csmInt32 xpos = i % 3;
+                    const csmInt32 ypos = i / 3;
+
+                    T_ClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                    cc->_layoutChannelNo = channelNo;
+
+                    cc->_layoutBounds->X = xpos / 3.0f;
+                    cc->_layoutBounds->Y = ypos / 3.0f;
+                    cc->_layoutBounds->Width = 1.0f / 3.0f;
+                    cc->_layoutBounds->Height = 1.0f / 3.0f;
+                    cc->_bufferIndex = renderTextureNo;
+                }
+            }
+            // マスクの制限枚数を超えた場合の処理
+            else
+            {
+                csmInt32 count = usingClipCount - useClippingMaskMaxCount;
+
+
+                CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : %d"
+                    , count, _renderTextureCount, usingClipCount);
+
+                // 開発モードの場合は停止させる
+                CSM_ASSERT(0);
+
+                // 引き続き実行する場合、 SetupShaderProgramでオーバーアクセスが発生するので仕方なく適当に入れておく
+                // もちろん描画結果はろくなことにならない
+                for (csmInt32 i = 0; i < layoutCount; i++)
+                {
+                    T_ClippingContext* cc = _clippingContextListForMask[curClipIndex++];
+                    cc->_layoutChannelNo = 0;
+                    cc->_layoutBounds->X = 0.0f;
+                    cc->_layoutBounds->Y = 0.0f;
+                    cc->_layoutBounds->Width = 1.0f;
+                    cc->_layoutBounds->Height = 1.0f;
+                    cc->_bufferIndex = 0;
+                }
+            }
+        }
+    }
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+void CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::CalcClippedDrawTotalBounds(CubismModel& model, T_ClippingContext* clippingContext)
+{
+    // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
+    csmFloat32 clippedDrawTotalMinX = FLT_MAX, clippedDrawTotalMinY = FLT_MAX;
+    csmFloat32 clippedDrawTotalMaxX = -FLT_MAX, clippedDrawTotalMaxY = -FLT_MAX;
+
+    // このマスクが実際に必要か判定する
+    // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある
+
+    const csmInt32 clippedDrawCount = clippingContext->_clippedDrawableIndexList->GetSize();
+    for (csmInt32 clippedDrawableIndex = 0; clippedDrawableIndex < clippedDrawCount; clippedDrawableIndex++)
+    {
+        // マスクを使用する描画オブジェクトの描画される矩形を求める
+        const csmInt32 drawableIndex = (*clippingContext->_clippedDrawableIndexList)[clippedDrawableIndex];
+
+        csmInt32 drawableVertexCount = model.GetDrawableVertexCount(drawableIndex);
+        csmFloat32* drawableVertexes = const_cast<csmFloat32*>(model.GetDrawableVertices(drawableIndex));
+
+        csmFloat32 minX = FLT_MAX, minY = FLT_MAX;
+        csmFloat32 maxX = -FLT_MAX, maxY = -FLT_MAX;
+
+        csmInt32 loop = drawableVertexCount * Constant::VertexStep;
+        for (csmInt32 pi = Constant::VertexOffset; pi < loop; pi += Constant::VertexStep)
+        {
+            csmFloat32 x = drawableVertexes[pi];
+            csmFloat32 y = drawableVertexes[pi + 1];
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+        }
+
+        //
+        if (minX == FLT_MAX) continue; //有効な点がひとつも取れなかったのでスキップする
+
+        // 全体の矩形に反映
+        if (minX < clippedDrawTotalMinX) clippedDrawTotalMinX = minX;
+        if (minY < clippedDrawTotalMinY) clippedDrawTotalMinY = minY;
+        if (maxX > clippedDrawTotalMaxX) clippedDrawTotalMaxX = maxX;
+        if (maxY > clippedDrawTotalMaxY) clippedDrawTotalMaxY = maxY;
+    }
+    if (clippedDrawTotalMinX == FLT_MAX)
+    {
+        clippingContext->_allClippedDrawRect->X = 0.0f;
+        clippingContext->_allClippedDrawRect->Y = 0.0f;
+        clippingContext->_allClippedDrawRect->Width = 0.0f;
+        clippingContext->_allClippedDrawRect->Height = 0.0f;
+        clippingContext->_isUsing = false;
+    }
+    else
+    {
+        clippingContext->_isUsing = true;
+        csmFloat32 w = clippedDrawTotalMaxX - clippedDrawTotalMinX;
+        csmFloat32 h = clippedDrawTotalMaxY - clippedDrawTotalMinY;
+        clippingContext->_allClippedDrawRect->X = clippedDrawTotalMinX;
+        clippingContext->_allClippedDrawRect->Y = clippedDrawTotalMinY;
+        clippingContext->_allClippedDrawRect->Width = w;
+        clippingContext->_allClippedDrawRect->Height = h;
+    }
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+csmVector<T_ClippingContext*>* CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::GetClippingContextListForDraw()
+{
+    return &_clippingContextListForDraw;
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+CubismVector2 CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::GetClippingMaskBufferSize() const
+{
+    return _clippingMaskBufferSize;
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+csmInt32 CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::GetRenderTextureCount()
+{
+    return _renderTextureCount;
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+CubismRenderer::CubismTextureColor* CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::GetChannelFlagAsColor(csmInt32 channelNo)
+{
+    return _channelColors[channelNo];
+}
+
+template <class T_ClippingContext, class T_OffscreenSurface>
+void CubismClippingManager<T_ClippingContext, T_OffscreenSurface>::SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height)
+{
+    _clippingMaskBufferSize = CubismVector2(width, height);
+}

--- a/src/Rendering/CubismRenderer.cpp
+++ b/src/Rendering/CubismRenderer.cpp
@@ -95,6 +95,19 @@ CubismRenderer::CubismTextureColor CubismRenderer::GetModelColor() const
     return  _modelColor;
 }
 
+CubismRenderer::CubismTextureColor CubismRenderer::GetModelColorWithOpacity(const csmFloat32 opacity) const
+{
+    CubismTextureColor modelColorRGBA = GetModelColor();
+    modelColorRGBA.A *= opacity;
+    if (IsPremultipliedAlpha())
+    {
+        modelColorRGBA.R *= modelColorRGBA.A;
+        modelColorRGBA.G *= modelColorRGBA.A;
+        modelColorRGBA.B *= modelColorRGBA.A;
+    }
+    return modelColorRGBA;
+}
+
 void CubismRenderer::IsPremultipliedAlpha(csmBool enable)
 {
     _isPremultipliedAlpha = enable;
@@ -138,6 +151,51 @@ void CubismRenderer::UseHighPrecisionMask(csmBool high)
 csmBool CubismRenderer::IsUsingHighPrecisionMask()
 {
     return _useHighPrecisionMask;
+}
+
+/*********************************************************************************************************************
+*                                      CubismClippingContext
+********************************************************************************************************************/
+CubismClippingContext::CubismClippingContext(const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+{
+    // クリップしている（＝マスク用の）Drawableのインデックスリスト
+    _clippingIdList = clippingDrawableIndices;
+
+    // マスクの数
+    _clippingIdCount = clipCount;
+
+    _layoutChannelNo = 0;
+
+    _allClippedDrawRect = CSM_NEW csmRectF();
+    _layoutBounds = CSM_NEW csmRectF();
+
+    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
+}
+
+CubismClippingContext::~CubismClippingContext()
+{
+    if (_layoutBounds != NULL)
+    {
+        CSM_DELETE(_layoutBounds);
+        _layoutBounds = NULL;
+    }
+
+    if (_allClippedDrawRect != NULL)
+    {
+        CSM_DELETE(_allClippedDrawRect);
+        _allClippedDrawRect = NULL;
+    }
+
+    if (_clippedDrawableIndexList != NULL)
+    {
+        CSM_DELETE(_clippedDrawableIndexList);
+        _clippedDrawableIndexList = NULL;
+    }
+}
+
+void CubismClippingContext::AddClippedDrawable(csmInt32 drawableIndex)
+{
+    _clippedDrawableIndexList->PushBack(drawableIndex);
 }
 
 }}}}

--- a/src/Rendering/CubismRenderer.hpp
+++ b/src/Rendering/CubismRenderer.hpp
@@ -9,6 +9,8 @@
 
 #include "CubismFramework.hpp"
 #include "Math/CubismMatrix44.hpp"
+#include "Type/csmVector.hpp"
+#include "Type/csmRectF.hpp"
 
 namespace Live2D {namespace Cubism {namespace Framework {
 class CubismModel;
@@ -20,7 +22,6 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /**
  * @brief   モデル描画を処理するレンダラ<br>
  *           サブクラスに環境依存の描画命令を記述する
- *
  */
 class CubismRenderer
 {
@@ -36,6 +37,8 @@ public:
         CubismBlendMode_Additive = 1,        ///< 加算
 
         CubismBlendMode_Multiplicative = 2,  ///< 乗算
+
+        CubismBlendMode_Mask = 3,            ///< マスク
     };  // CubismBlendMode
 
     /**
@@ -149,6 +152,15 @@ public:
     CubismTextureColor GetModelColor() const;
 
     /**
+     * @brief       透明度を考慮したモデルの色を計算する。
+     *
+     * @param[in]   opacity    ->   透明度
+     *
+     * @return      RGBAのカラー情報
+     */
+    CubismTextureColor GetModelColorWithOpacity(const csmFloat32 opacity) const;
+
+    /**
      * @brief  乗算済みαの有効・無効をセットする。<br>
      *          有効にするならtrue, 無効にするならfalseをセットする。
      */
@@ -230,25 +242,6 @@ protected:
     virtual void DoDrawModel() = 0;
 
     /**
-     * @brief   描画オブジェクト（アートメッシュ）を描画する。<br>
-     *           ポリゴンメッシュとテクスチャ番号をセットで渡す。
-     *
-     * @param[in]   textureNo            ->  描画するテクスチャ番号
-     * @param[in]   indexCount           ->  描画オブジェクトのインデックス値
-     * @param[in]   vertexCount          ->  ポリゴンメッシュの頂点数
-     * @param[in]   indexArray           ->  ポリゴンメッシュ頂点のインデックス配列
-     * @param[in]   vertexArray          ->  ポリゴンメッシュの頂点配列
-     * @param[in]   uvArray              ->  uv配列
-     * @param[in]   opacity              ->  不透明度
-     * @param[in]   colorBlendMode       ->  カラーブレンディングのタイプ
-     * @param[in]   invertedMask          ->  マスク使用時のマスクの反転使用
-     *
-     */
-    virtual void DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
-                          , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
-                          , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask) = 0;
-
-    /**
      * @brief   モデル描画直前のレンダラのステートを保持する
      */
     virtual void SaveProfile() = 0;
@@ -272,6 +265,44 @@ private:
     CubismModel*        _model;                 ///< レンダリング対象のモデル
 
     csmBool             _useHighPrecisionMask;  ///< falseの場合、マスクを纏めて描画する trueの場合、マスクはパーツ描画ごとに書き直す
+};
+
+
+/**
+ * @brief   クリッピングについての設定を保持するクラス<br>
+ *           サブクラスに環境依存のフィールドを保持する
+ */
+class CubismClippingContext
+{
+public:
+    /**
+     * @brief   引数付きコンストラクタ
+     *
+     */
+    CubismClippingContext(const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
+
+    /**
+     * @brief   デストラクタ
+     */
+    ~CubismClippingContext();
+
+    /**
+     * @brief   このマスクにクリップされる描画オブジェクトを追加する
+     *
+     * @param[in]   drawableIndex   ->  クリッピング対象に追加する描画オブジェクトのインデックス
+     */
+    void AddClippedDrawable(csmInt32 drawableIndex);
+
+    csmBool _isUsing;                                ///< 現在の描画状態でマスクの準備が必要ならtrue
+    const csmInt32* _clippingIdList;                 ///< クリッピングマスクのIDリスト
+    csmInt32 _clippingIdCount;                       ///< クリッピングマスクの数
+    csmInt32 _layoutChannelNo;                       ///< RGBAのいずれのチャンネルにこのクリップを配置するか(0:R , 1:G , 2:B , 3:A)
+    csmRectF* _layoutBounds;                         ///< マスク用チャンネルのどの領域にマスクを入れるか(View座標-1..1, UVは0..1に直す)
+    csmRectF* _allClippedDrawRect;                   ///< このクリッピングで、クリッピングされる全ての描画オブジェクトの囲み矩形（毎回更新）
+    CubismMatrix44 _matrixForMask;                   ///< マスクの位置計算結果を保持する行列
+    CubismMatrix44 _matrixForDraw;                   ///< 描画オブジェクトの位置計算結果を保持する行列
+    csmVector<csmInt32>* _clippedDrawableIndexList;  ///< このマスクにクリップされる描画オブジェクトのリスト
+    csmInt32 _bufferIndex;                           ///< このマスクが割り当てられるレンダーテクスチャ（フレームバッファ）やカラーバッファのインデックス
 };
 
 }}}}

--- a/src/Rendering/D3D11/CubismOffscreenSurface_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismOffscreenSurface_D3D11.cpp
@@ -12,7 +12,7 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-CubismOffscreenFrame_D3D11::CubismOffscreenFrame_D3D11()
+CubismOffscreenSurface_D3D11::CubismOffscreenSurface_D3D11()
     : _texture(NULL)
     , _textureView(NULL)
     , _renderTargetView(NULL)
@@ -26,7 +26,7 @@ CubismOffscreenFrame_D3D11::CubismOffscreenFrame_D3D11()
 }
 
 
-void CubismOffscreenFrame_D3D11::BeginDraw(ID3D11DeviceContext* renderContext)
+void CubismOffscreenSurface_D3D11::BeginDraw(ID3D11DeviceContext* renderContext)
 {
     if(_textureView==NULL || _renderTargetView==NULL || _depthView==NULL)
     {
@@ -51,7 +51,7 @@ void CubismOffscreenFrame_D3D11::BeginDraw(ID3D11DeviceContext* renderContext)
     renderContext->OMSetRenderTargets( 1, &_renderTargetView, _depthView);
 }
 
-void CubismOffscreenFrame_D3D11::EndDraw(ID3D11DeviceContext* renderContext)
+void CubismOffscreenSurface_D3D11::EndDraw(ID3D11DeviceContext* renderContext)
 {
     if (_textureView == NULL || _renderTargetView == NULL || _depthView == NULL)
     {
@@ -74,17 +74,17 @@ void CubismOffscreenFrame_D3D11::EndDraw(ID3D11DeviceContext* renderContext)
     }
 }
 
-void CubismOffscreenFrame_D3D11::Clear(ID3D11DeviceContext* renderContext, float r, float g, float b, float a)
+void CubismOffscreenSurface_D3D11::Clear(ID3D11DeviceContext* renderContext, float r, float g, float b, float a)
 {
     float clearColor[4] = {r,g,b,a};
     renderContext->ClearRenderTargetView(_renderTargetView, clearColor);
     renderContext->ClearDepthStencilView(_depthView, D3D11_CLEAR_DEPTH, 1.0f, 0);
 }
 
-csmBool CubismOffscreenFrame_D3D11::CreateOffscreenFrame(ID3D11Device* device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight)
+csmBool CubismOffscreenSurface_D3D11::CreateOffscreenSurface(ID3D11Device* device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight)
 {
     // 一旦削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     do
     {
@@ -176,12 +176,12 @@ csmBool CubismOffscreenFrame_D3D11::CreateOffscreenFrame(ID3D11Device* device, c
     } while (0);
 
     // 失敗したので削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     return false;
 }
 
-void CubismOffscreenFrame_D3D11::DestroyOffscreenFrame()
+void CubismOffscreenSurface_D3D11::DestroyOffscreenSurface()
 {
     // これらがあるのはEndDrawが来なかった場合
     if (_backupDepth)
@@ -223,22 +223,22 @@ void CubismOffscreenFrame_D3D11::DestroyOffscreenFrame()
     }
 }
 
-ID3D11ShaderResourceView* CubismOffscreenFrame_D3D11::GetTextureView() const
+ID3D11ShaderResourceView* CubismOffscreenSurface_D3D11::GetTextureView() const
 {
     return _textureView;
 }
 
-csmUint32 CubismOffscreenFrame_D3D11::GetBufferWidth() const
+csmUint32 CubismOffscreenSurface_D3D11::GetBufferWidth() const
 {
     return _bufferWidth;
 }
 
-csmUint32 CubismOffscreenFrame_D3D11::GetBufferHeight() const
+csmUint32 CubismOffscreenSurface_D3D11::GetBufferHeight() const
 {
     return _bufferHeight;
 }
 
-csmBool CubismOffscreenFrame_D3D11::IsValid() const
+csmBool CubismOffscreenSurface_D3D11::IsValid() const
 {
     if (_textureView == NULL || _renderTargetView == NULL || _depthView == NULL)
     {

--- a/src/Rendering/D3D11/CubismOffscreenSurface_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismOffscreenSurface_D3D11.hpp
@@ -18,11 +18,11 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /**
  * @brief  オフスクリーン描画用構造体
  */
-class CubismOffscreenFrame_D3D11
+class CubismOffscreenSurface_D3D11
 {
 public:
 
-    CubismOffscreenFrame_D3D11();
+    CubismOffscreenSurface_D3D11();
 
     /**
      * @brief   指定の描画ターゲットに向けて描画開始
@@ -49,17 +49,17 @@ public:
     void Clear(ID3D11DeviceContext* renderContext, float r, float g, float b, float a);
 
     /**
-     *  @brief  CubismOffscreenFrame作成
+     *  @brief  CubismOffscreenSurface作成
      *  @param  device[in]                 D3dデバイス
      *  @param  displayBufferWidth[in]     作成するバッファ幅
      *  @param  displayBufferHeight[in]    作成するバッファ高さ
      */
-    csmBool CreateOffscreenFrame(ID3D11Device* device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight);
+    csmBool CreateOffscreenSurface(ID3D11Device* device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight);
 
     /**
-     * @brief   CubismOffscreenFrameの削除
+     * @brief   CubismOffscreenSurfaceの削除
      */
-    void DestroyOffscreenFrame();
+    void DestroyOffscreenSurface();
 
     /**
      * @brief   クリアカラーの上書き

--- a/src/Rendering/D3D9/CubismOffscreenSurface_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismOffscreenSurface_D3D9.cpp
@@ -13,7 +13,7 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-CubismOffscreenFrame_D3D9::CubismOffscreenFrame_D3D9()
+CubismOffscreenSurface_D3D9::CubismOffscreenSurface_D3D9()
     : _texture(NULL)
     , _textureSurface(NULL)
     , _depthSurface(NULL)
@@ -25,7 +25,7 @@ CubismOffscreenFrame_D3D9::CubismOffscreenFrame_D3D9()
 }
 
 
-void CubismOffscreenFrame_D3D9::BeginDraw(LPDIRECT3DDEVICE9 device)
+void CubismOffscreenSurface_D3D9::BeginDraw(LPDIRECT3DDEVICE9 device)
 {
     if(_depthSurface==NULL || _texture==NULL)
     {
@@ -59,7 +59,7 @@ void CubismOffscreenFrame_D3D9::BeginDraw(LPDIRECT3DDEVICE9 device)
     }
 }
 
-void CubismOffscreenFrame_D3D9::EndDraw(LPDIRECT3DDEVICE9 device)
+void CubismOffscreenSurface_D3D9::EndDraw(LPDIRECT3DDEVICE9 device)
 {
     if (_depthSurface == NULL || _texture == NULL)
     {
@@ -95,17 +95,17 @@ void CubismOffscreenFrame_D3D9::EndDraw(LPDIRECT3DDEVICE9 device)
     device->BeginScene();
 }
 
-void CubismOffscreenFrame_D3D9::Clear(LPDIRECT3DDEVICE9 device,  float r, float g, float b, float a)
+void CubismOffscreenSurface_D3D9::Clear(LPDIRECT3DDEVICE9 device,  float r, float g, float b, float a)
 {
     // マスクをクリアする
     device->Clear(0, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER,
         D3DCOLOR_COLORVALUE(r, g, b, a), 1.0f, 0);
 }
 
-csmBool CubismOffscreenFrame_D3D9::CreateOffscreenFrame(LPDIRECT3DDEVICE9 device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight)
+csmBool CubismOffscreenSurface_D3D9::CreateOffscreenSurface(LPDIRECT3DDEVICE9 device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight)
 {
     // 一旦削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     if (FAILED(D3DXCreateTexture(
         device,
@@ -144,7 +144,7 @@ csmBool CubismOffscreenFrame_D3D9::CreateOffscreenFrame(LPDIRECT3DDEVICE9 device
     return true;
 }
 
-void CubismOffscreenFrame_D3D9::DestroyOffscreenFrame()
+void CubismOffscreenSurface_D3D9::DestroyOffscreenSurface()
 {
     // これらがあるのはEndDrawが来なかった場合
     if(_backupDepth)
@@ -176,22 +176,22 @@ void CubismOffscreenFrame_D3D9::DestroyOffscreenFrame()
     }
 }
 
-LPDIRECT3DTEXTURE9 CubismOffscreenFrame_D3D9::GetTexture() const
+LPDIRECT3DTEXTURE9 CubismOffscreenSurface_D3D9::GetTexture() const
 {
     return _texture;
 }
 
-csmUint32 CubismOffscreenFrame_D3D9::GetBufferWidth() const
+csmUint32 CubismOffscreenSurface_D3D9::GetBufferWidth() const
 {
     return _bufferWidth;
 }
 
-csmUint32 CubismOffscreenFrame_D3D9::GetBufferHeight() const
+csmUint32 CubismOffscreenSurface_D3D9::GetBufferHeight() const
 {
     return _bufferHeight;
 }
 
-csmBool CubismOffscreenFrame_D3D9::IsValid() const
+csmBool CubismOffscreenSurface_D3D9::IsValid() const
 {
     if (_depthSurface == NULL || _texture == NULL)
     {

--- a/src/Rendering/D3D9/CubismOffscreenSurface_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismOffscreenSurface_D3D9.hpp
@@ -18,11 +18,11 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /**
  * @brief  オフスクリーン描画用構造体
  */
-class CubismOffscreenFrame_D3D9
+class CubismOffscreenSurface_D3D9
 {
 public:
 
-    CubismOffscreenFrame_D3D9();
+    CubismOffscreenSurface_D3D9();
 
     /**
      * @brief   指定の描画ターゲットに向けて描画開始
@@ -49,17 +49,17 @@ public:
     void Clear(LPDIRECT3DDEVICE9 device, float r, float g, float b, float a);
 
     /**
-     *  @brief  CubismOffscreenFrame作成
+     *  @brief  CubismOffscreenSurface作成
      *  @param  device[in]                D3dデバイス
      *  @param  displayBufferWidth[in]     作成するバッファ幅
      *  @param  displayBufferHeight[in]    作成するバッファ高さ
      */
-    csmBool CreateOffscreenFrame(LPDIRECT3DDEVICE9 device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight);
+    csmBool CreateOffscreenSurface(LPDIRECT3DDEVICE9 device, csmUint32 displayBufferWidth, csmUint32 displayBufferHeight);
 
     /**
-     * @brief   CubismOffscreenFrameの削除
+     * @brief   CubismOffscreenSurfaceの削除
      */
-    void DestroyOffscreenFrame();
+    void DestroyOffscreenSurface();
 
     /**
      * @brief   テクスチャメンバーへのアクセッサ

--- a/src/Rendering/D3D9/CubismShader_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismShader_D3D9.hpp
@@ -18,7 +18,7 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 
 //  前方宣言
 class CubismRenderer_D3D9;
-class CubismClippingContext;
+class CubismClippingContext_D3D9;
 
 /**
  * @bref    DX9シェーダエフェクト

--- a/src/Rendering/Metal/CMakeLists.txt
+++ b/src/Rendering/Metal/CMakeLists.txt
@@ -6,6 +6,8 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Metal.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismCommandBuffer_Metal.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismCommandBuffer_Metal.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_Metal.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_Metal.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderingInstanceSingleton_Metal.m
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderingInstanceSingleton_Metal.h
     ${CMAKE_CURRENT_SOURCE_DIR}/MetalShaderTypes.h

--- a/src/Rendering/Metal/CubismCommandBuffer_Metal.hpp
+++ b/src/Rendering/Metal/CubismCommandBuffer_Metal.hpp
@@ -13,7 +13,7 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-class CubismOffscreenFrame_Metal;
+class CubismOffscreenSurface_Metal;
 
 class CubismCommandBuffer_Metal
 {

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.hpp
@@ -16,24 +16,24 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /**
  * @brief  オフスクリーン描画用構造体
  */
-class CubismOffscreenFrame_Metal
+class CubismOffscreenSurface_Metal
 {
 public:
 
-    CubismOffscreenFrame_Metal();
+    CubismOffscreenSurface_Metal();
 
     /**
-     * @brief  CubismOffscreenFrame作成
+     * @brief  CubismOffscreenSurface作成
      * @param  displayBufferWidth     作成するバッファ幅
      * @param  displayBufferHeight    作成するバッファ高さ
      * @param  colorBuffer            0以外の場合、ピクセル格納領域としてcolorBufferを使用する
      */
-    csmBool CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, id <MTLTexture> colorBuffer = NULL);
+    csmBool CreateOffscreenSurface(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, id <MTLTexture> colorBuffer = NULL);
 
     /**
-     * @brief   CubismOffscreenFrameの削除
+     * @brief   CubismOffscreenSurfaceの削除
      */
-    void DestroyOffscreenFrame();
+    void DestroyOffscreenSurface();
 
     /**
      * @brief   カラーバッファメンバーへのアクセッサ

--- a/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
+++ b/src/Rendering/Metal/CubismOffscreenSurface_Metal.mm
@@ -11,7 +11,7 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-CubismOffscreenFrame_Metal::CubismOffscreenFrame_Metal()
+CubismOffscreenSurface_Metal::CubismOffscreenSurface_Metal()
     : _colorBuffer(NULL)
     , _renderPassDescriptor(NULL)
     , _bufferWidth(0)
@@ -24,10 +24,10 @@ CubismOffscreenFrame_Metal::CubismOffscreenFrame_Metal()
 {
 }
 
-csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, id <MTLTexture> colorBuffer)
+csmBool CubismOffscreenSurface_Metal::CreateOffscreenSurface(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, id <MTLTexture> colorBuffer)
 {
     // 一旦削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     do
     {
@@ -84,12 +84,12 @@ csmBool CubismOffscreenFrame_Metal::CreateOffscreenFrame(csmUint32 displayBuffer
     } while (0);
 
     // 失敗したので削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     return false;
 }
 
-void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
+void CubismOffscreenSurface_Metal::DestroyOffscreenSurface()
 {
     if (_colorBuffer != NULL)
     {
@@ -104,12 +104,12 @@ void CubismOffscreenFrame_Metal::DestroyOffscreenFrame()
     }
 }
 
-id <MTLTexture> CubismOffscreenFrame_Metal::GetColorBuffer() const
+id <MTLTexture> CubismOffscreenSurface_Metal::GetColorBuffer() const
 {
     return _colorBuffer;
 }
 
-void CubismOffscreenFrame_Metal::SetClearColor(float r, float g, float b, float a)
+void CubismOffscreenSurface_Metal::SetClearColor(float r, float g, float b, float a)
 {
     _clearColorR = r;
     _clearColorG = g;
@@ -117,32 +117,32 @@ void CubismOffscreenFrame_Metal::SetClearColor(float r, float g, float b, float 
     _clearColorA = a;
 }
 
-csmUint32 CubismOffscreenFrame_Metal::GetBufferWidth() const
+csmUint32 CubismOffscreenSurface_Metal::GetBufferWidth() const
 {
     return _bufferWidth;
 }
 
-csmUint32 CubismOffscreenFrame_Metal::GetBufferHeight() const
+csmUint32 CubismOffscreenSurface_Metal::GetBufferHeight() const
 {
     return _bufferHeight;
 }
 
-csmBool CubismOffscreenFrame_Metal::IsValid() const
+csmBool CubismOffscreenSurface_Metal::IsValid() const
 {
     return _renderPassDescriptor != NULL;
 }
 
-const MTLViewport* CubismOffscreenFrame_Metal::GetViewport() const
+const MTLViewport* CubismOffscreenSurface_Metal::GetViewport() const
 {
     return &_viewPort;
 }
 
-MTLRenderPassDescriptor* CubismOffscreenFrame_Metal::GetRenderPassDescriptor() const
+MTLRenderPassDescriptor* CubismOffscreenSurface_Metal::GetRenderPassDescriptor() const
 {
     return _renderPassDescriptor;
 }
 
-void CubismOffscreenFrame_Metal::SetMTLPixelFormat(MTLPixelFormat pixelFormat)
+void CubismOffscreenSurface_Metal::SetMTLPixelFormat(MTLPixelFormat pixelFormat)
 {
     _pixelFormat = pixelFormat;
 }

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -9,6 +9,7 @@
 
 #include <MetalKit/MetalKit.h>
 #include "../CubismRenderer.hpp"
+#include "../CubismClippingManager.hpp"
 #include "CubismFramework.hpp"
 #include "CubismOffscreenSurface_Metal.hpp"
 #include "CubismCommandBuffer_Metal.hpp"
@@ -22,54 +23,16 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 
 //  前方宣言
 class CubismRenderer_Metal;
-class CubismClippingContext;
+class CubismClippingContext_Metal;
+class CubismShader_Metal;
 
 /**
  * @brief  クリッピングマスクの処理を実行するクラス
  *
  */
-class CubismClippingManager_Metal
+class CubismClippingManager_Metal : public CubismClippingManager<CubismClippingContext_Metal, CubismOffscreenSurface_Metal>
 {
-    friend class CubismShader_Metal;
-    friend class CubismRenderer_Metal;
-
-private:
-
-    /**
-     * @brief カラーチャンネル(RGBA)のフラグを取得する
-     *
-     * @param[in]   channelNo   ->   カラーチャンネル(RGBA)の番号(0:R , 1:G , 2:B, 3:A)
-     */
-    CubismRenderer::CubismTextureColor* GetChannelFlagAsColor(csmInt32 channelNo);
-
-    /**
-     * @brief   マスクされる描画オブジェクト群全体を囲む矩形(モデル座標系)を計算する
-     *
-     * @param[in]   model            ->  モデルのインスタンス
-     * @param[in]   clippingContext  ->  クリッピングマスクのコンテキスト
-     */
-    void CalcClippedDrawTotalBounds(CubismModel& model, CubismClippingContext* clippingContext);
-
-    /**
-     * @brief    コンストラクタ
-     */
-    CubismClippingManager_Metal();
-
-    /**
-     * @brief    デストラクタ
-     */
-    virtual ~CubismClippingManager_Metal();
-
-    /**
-     * @brief    マネージャの初期化処理<br>
-     *           クリッピングマスクを使う描画オブジェクトの登録を行う
-     *
-     * @param[in]   model           ->  モデルのインスタンス
-     * @param[in]   drawableCount   ->  描画オブジェクトの数
-     * @param[in]   drawableMasks   ->  描画オブジェクトをマスクする描画オブジェクトのインデックスのリスト
-     * @param[in]   drawableMaskCounts   ->  描画オブジェクトをマスクする描画オブジェクトの数
-     */
-    void Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts, const csmInt32 maskBufferCount);
+public:
 
     /**
      * @brief   クリッピングコンテキストを作成する。モデル描画時に実行する。
@@ -79,222 +42,40 @@ private:
      * @param[in]   lastFBO      ->  フレームバッファ
      * @param[in]   lastViewport ->  ビューポート
      */
-    void SetupClippingContext(CubismModel& model, CubismRenderer_Metal* renderer, CubismOffscreenFrame_Metal* lastColorBuffer, csmRectF lastViewport);
-
-    /**
-     * @brief   既にマスクを作っているかを確認。<br>
-     *          作っているようであれば該当するクリッピングマスクのインスタンスを返す。<br>
-     *          作っていなければNULLを返す
-     *
-     * @param[in]   drawableMasks    ->  描画オブジェクトをマスクする描画オブジェクトのリスト
-     * @param[in]   drawableMaskCounts ->  描画オブジェクトをマスクする描画オブジェクトの数
-     * @return          該当するクリッピングマスクが存在すればインスタンスを返し、なければNULLを返す。
-     */
-    CubismClippingContext* FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const;
-
-    /**
-     * @brief   クリッピングコンテキストを配置するレイアウト。<br>
-     *           ひとつのレンダーテクスチャを極力いっぱいに使ってマスクをレイアウトする。<br>
-     *           マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する。
-     *
-     * @param[in]   usingClipCount  ->  配置するクリッピングコンテキストの数
-     */
-    void SetupLayoutBounds(csmInt32 usingClipCount) const;
-
-    /**
-     * @brief   画面描画に使用するクリッピングマスクのリストを取得する
-     *
-     * @return  画面描画に使用するクリッピングマスクのリスト
-     */
-    csmVector<CubismClippingContext*>* GetClippingContextListForDraw();
-
-    /**
-     * @brief  クリッピングマスクバッファのサイズを設定する
-     *
-     * @param  size -> クリッピングマスクバッファのサイズ
-     *
-     */
-    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
-
-    /**
-     * @brief  クリッピングマスクバッファのサイズを取得する
-     *
-     * @return クリッピングマスクバッファのサイズ
-     *
-     */
-    CubismVector2 GetClippingMaskBufferSize() const;
-
-    /**
-     * このバッファのレンダーテクスチャの枚数を取得する。
-     *
-     * @return このバッファのレンダーテクスチャの枚数
-     */
-    csmInt32 GetRenderTextureCount() const;
-
-    CubismOffscreenFrame_Metal* _currentOffscreenFrameBuffer;   ///< レンダーターゲットとなるオフスクリーンフレームバッファを保持する
-    csmVector<csmBool> _clearedFrameBufferFlags; /// マスクのクリアフラグの配列
-
-    csmVector<CubismRenderer::CubismTextureColor*>  _channelColors;
-    csmVector<CubismClippingContext*>               _clippingContextListForMask;   ///< マスク用クリッピングコンテキストのリスト
-    csmVector<CubismClippingContext*>               _clippingContextListForDraw;   ///< 描画用クリッピングコンテキストのリスト
-    CubismVector2                                   _clippingMaskBufferSize; ///< クリッピングマスクのバッファサイズ（初期値:256）
-    csmInt32                                        _renderTextureCount;           ///< 生成するレンダーテクスチャの枚数
-
-    CubismMatrix44  _tmpMatrix;              ///< マスク計算用の行列
-    CubismMatrix44  _tmpMatrixForMask;       ///< マスク計算用の行列
-    CubismMatrix44  _tmpMatrixForDraw;       ///< マスク計算用の行列
-    csmRectF        _tmpBoundsOnModel;       ///< マスク配置計算用の矩形
-
+    void SetupClippingContext(CubismModel& model, CubismRenderer_Metal* renderer, CubismOffscreenSurface_Metal* lastColorBuffer, csmRectF lastViewport);
 };
 
 /**
  * @brief   クリッピングマスクのコンテキスト
  */
-class CubismClippingContext
+class CubismClippingContext_Metal : public CubismClippingContext
 {
     friend class CubismClippingManager_Metal;
     friend class CubismShader_Metal;
     friend class CubismRenderer_Metal;
 
-private:
+public:
     /**
      * @brief   引数付きコンストラクタ
      *
      */
-    CubismClippingContext(CubismClippingManager_Metal* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
+    CubismClippingContext_Metal(CubismClippingManager<CubismClippingContext_Metal, CubismOffscreenSurface_Metal>* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
 
     /**
      * @brief   デストラクタ
      */
-    virtual ~CubismClippingContext();
-
-    /**
-     * @brief   このマスクにクリップされる描画オブジェクトを追加する
-     *
-     * @param[in]   drawableIndex   ->  クリッピング対象に追加する描画オブジェクトのインデックス
-     */
-    void AddClippedDrawable(csmInt32 drawableIndex);
+    virtual ~CubismClippingContext_Metal();
 
     /**
      * @brief   このマスクを管理するマネージャのインスタンスを取得する。
      *
      * @return  クリッピングマネージャのインスタンス
      */
-    CubismClippingManager_Metal* GetClippingManager();
-
-    csmBool _isUsing;                                ///< 現在の描画状態でマスクの準備が必要ならtrue
-    const csmInt32* _clippingIdList;                 ///< クリッピングマスクのIDリスト
-    csmInt32 _clippingIdCount;                       ///< クリッピングマスクの数
-    csmInt32 _layoutChannelNo;                       ///< RGBAのいずれのチャンネルにこのクリップを配置するか(0:R , 1:G , 2:B , 3:A)
-    csmRectF* _layoutBounds;                         ///< マスク用チャンネルのどの領域にマスクを入れるか(View座標-1..1, UVは0..1に直す)
-    csmRectF* _allClippedDrawRect;                   ///< このクリッピングで、クリッピングされる全ての描画オブジェクトの囲み矩形（毎回更新）
-    CubismMatrix44 _matrixForMask;                   ///< マスクの位置計算結果を保持する行列
-    CubismMatrix44 _matrixForDraw;                   ///< 描画オブジェクトの位置計算結果を保持する行列
-    csmVector<csmInt32>* _clippedDrawableIndexList;  ///< このマスクにクリップされる描画オブジェクトのリスト
-    csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>* _clippingCommandBufferList;
-    csmInt32 _bufferIndex;                           ///< このマスクが割り当てられるレンダーテクスチャ（フレームバッファ）やカラーバッファのインデックス
-
-    CubismClippingManager_Metal* _owner;        ///< このマスクを管理しているマネージャのインスタンス
-};
-
-/**
- * @brief   Metal用のシェーダプログラムを生成・破棄するクラス<br>
- *           シングルトンなクラスであり、CubismShader_Metal::GetInstance()からアクセスする。
- *
- */
-class CubismShader_Metal
-{
-    friend class CubismRenderer_Metal;
+    CubismClippingManager<CubismClippingContext_Metal, CubismOffscreenSurface_Metal>* GetClippingManager();
 
 private:
-    /**
-     * @brief   インスタンスを取得する（シングルトン）。
-     *
-     * @return  インスタンスのポインタ
-     */
-    static CubismShader_Metal* GetInstance();
-
-    /**
-     * @brief   インスタンスを解放する（シングルトン）。
-     */
-    static void DeleteInstance();
-
-    struct ShaderProgram
-    {
-        id <MTLFunction> vertexFunction;
-        id <MTLFunction> fragmentFunction;
-    };
-
-    /**
-    * @bref    シェーダープログラムとシェーダ変数のアドレスを保持する構造体
-    *
-    */
-    struct CubismShaderSet
-    {
-        ShaderProgram *ShaderProgram; ///< シェーダプログラムのアドレス
-        id<MTLRenderPipelineState> RenderPipelineState;
-        id<MTLDepthStencilState> DepthStencilState;
-        id<MTLSamplerState> SamplerState;
-    };
-
-    /**
-     * @brief   privateなコンストラクタ
-     */
-    CubismShader_Metal();
-
-    /**
-     * @brief   privateなデストラクタ
-     */
-    virtual ~CubismShader_Metal();
-
-    /**
-     * @brief   シェーダプログラムの一連のセットアップを実行する
-     *
-     * @param[in]   renderer              ->  レンダラのインスタンス
-     * @param[in]   textureId             ->  GPUのテクスチャID
-     * @param[in]   vertexCount           ->  ポリゴンメッシュの頂点数
-     * @param[in]   vertexArray           ->  ポリゴンメッシュの頂点配列
-     * @param[in]   uvArray               ->  uv配列
-     * @param[in]   opacity               ->  不透明度
-     * @param[in]   colorBlendMode        ->  カラーブレンディングのタイプ
-     * @param[in]   baseColor             ->  ベースカラー
-     * @param[in]   isPremultipliedAlpha  ->  乗算済みアルファかどうか
-     * @param[in]   matrix4x4             ->  Model-View-Projection行列
-     * @param[in]   invertedMask           ->  マスクを反転して使用するフラグ
-     * @param[in]   renderEncoder           ->  MTLRenderCommandEncoder
-     */
-    void SetupShaderProgram(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, CubismRenderer_Metal* renderer, id <MTLTexture> texture
-                            , csmFloat32 opacity
-                            , CubismRenderer::CubismBlendMode colorBlendMode
-                            , CubismRenderer::CubismTextureColor baseColor
-                            , CubismRenderer::CubismTextureColor multiplyColor
-                            , CubismRenderer::CubismTextureColor screenColor
-                            , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
-                            , csmBool invertedMask
-                            , id <MTLRenderCommandEncoder> renderEncoder);
-
-    /**
-     * @brief   シェーダプログラムを初期化する
-     */
-    void GenerateShaders(CubismRenderer_Metal* renderer);
-
-    /**
-     * @brief   シェーダプログラムをロードしてアドレス返す。
-     *
-     * @param[in]   vertShaderSrc   ->  頂点シェーダのソース
-     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのソース
-     *
-     * @return  シェーダプログラムのアドレス
-     */
-    ShaderProgram* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
-    id<MTLRenderPipelineState> MakeRenderPipelineState(id<MTLDevice> device, ShaderProgram* shaderProgram, int blendMode);
-    id<MTLDepthStencilState> MakeDepthStencilState(id<MTLDevice> device);
-    id<MTLSamplerState> MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer);
-
-    id<MTLLibrary> _shaderLib;
-
-    csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
-
+    csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>* _clippingCommandBufferList;
+    CubismClippingManager<CubismClippingContext_Metal, CubismOffscreenSurface_Metal>* _owner;        ///< このマスクを管理しているマネージャのインスタンス
 };
 
 /**
@@ -320,7 +101,7 @@ private:
     csmBool _lastBlend;                   ///< モデル描画直前のGL_SCISSOR_TESTパラメータ
     csmBool _lastStencilTest;             ///< モデル描画直前のGL_STENCIL_TESTパラメータ
     csmBool _lastDepthTest;               ///< モデル描画直前のGL_DEPTH_TESTパラメータ
-    CubismOffscreenFrame_Metal* _lastColorBuffer;                         ///< モデル描画直前のフレームバッファ
+    CubismOffscreenSurface_Metal* _lastColorBuffer;                         ///< モデル描画直前のフレームバッファ
     id <MTLTexture> _lastDepthBuffer;
     id <MTLTexture> _lastStencilBuffer;
     csmRectF _lastViewport;                 ///< モデル描画直前のビューポート
@@ -365,11 +146,18 @@ public:
      *
      * @return  テクスチャのアドレスのリスト
      */
-    const csmMap<csmInt32, id <MTLTexture>>& GetBindedTextures() const;
+    const csmMap< csmInt32, id <MTLTexture> >& GetBindedTextures() const;
+
+    /**
+     * @brief   指定したIDにバインドされたテクスチャを取得する
+     *
+     * @return  テクスチャ
+     */
+    id <MTLTexture> GetBindedTextureId(csmInt32 textureId);
 
     /**
      * @brief  クリッピングマスクバッファのサイズを設定する<br>
-     *         マスク用のFrameBufferを破棄・再作成するため処理コストは高い。
+     *         マスク用のOffscreenSurfaceを破棄・再作成するため処理コストは高い。
      *
      * @param[in]  size -> クリッピングマスクバッファのサイズ
      *
@@ -393,12 +181,12 @@ public:
     CubismVector2 GetClippingMaskBufferSize() const;
 
     /**
-     * @brief  オフスクリーンフレームバッファを取得する
+     * @brief  オフスクリーンサーフェイスバッファを取得する
      *
-     * @return オフスクリーンフレームバッファへの参照
+     * @return オフスクリーンサーフェイスバッファへの参照
      *
      */
-    CubismOffscreenFrame_Metal* GetOffScreenFrameBuffer(csmInt32 index);
+    CubismOffscreenSurface_Metal* GetOffscreenSurface(csmInt32 index);
 
     CubismCommandBuffer_Metal* GetCommandBuffer()
     {
@@ -423,32 +211,17 @@ protected:
     void DoDrawModel();
 
     /**
-     * @brief   [オーバーライド]<br>
-     *           描画オブジェクト（アートメッシュ）を描画する。<br>
+     * @brief    描画オブジェクト（アートメッシュ）を描画する。<br>
      *           ポリゴンメッシュとテクスチャ番号をセットで渡す。
      *
-     * @param[in]   textureNo       ->  描画するテクスチャ番号
-     * @param[in]   indexCount      ->  描画オブジェクトのインデックス値
-     * @param[in]   vertexCount     ->  ポリゴンメッシュの頂点数
-     * @param[in]   indexArray      ->  ポリゴンメッシュのインデックス配列
-     * @param[in]   vertexArray     ->  ポリゴンメッシュの頂点配列
-     * @param[in]   uvArray         ->  uv配列
-     * @param[in]   opacity         ->  不透明度
-     * @param[in]   colorBlendMode  ->  カラー合成タイプ
-     * @param[in]   invertedMask     ->  マスク使用時のマスクの反転使用
-     * @param[in]   drawableIndex     ->  DrawCommandBuffer番号
+     * @param[in]   textureNo         ->  描画するテクスチャ番号
      * @param[in]   renderEncoder     ->  MTLRenderCommandEncoder
-     *
+     * @param[in]   model             ->  描画対象モデル
+     * @param[in]   index             ->  描画オブジェクトのインデックス
      */
-
-    void DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount, csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray, csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask);
-
-    void DrawMeshMetal(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
-                  , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
-                  , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
-                  , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask
-                  , csmInt32 drawableIndex
-                  , id <MTLRenderCommandEncoder> renderEncoder);
+    void DrawMeshMetal(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer
+                    , id <MTLRenderCommandEncoder> renderEncoder
+                    , const CubismModel& model, const csmInt32 index);
 
     CubismCommandBuffer_Metal::DrawCommandBuffer* GetDrawCommandBufferData(csmInt32 drawableIndex);
 
@@ -494,37 +267,44 @@ private:
     /**
      * @brief   マスクテクスチャに描画するクリッピングコンテキストをセットする。
      */
-    void SetClippingContextBufferForMask(CubismClippingContext* clip);
+    void SetClippingContextBufferForMask(CubismClippingContext_Metal* clip);
 
     /**
      * @brief   マスクテクスチャに描画するクリッピングコンテキストを取得する。
      *
      * @return  マスクテクスチャに描画するクリッピングコンテキスト
      */
-    CubismClippingContext* GetClippingContextBufferForMask() const;
+    CubismClippingContext_Metal* GetClippingContextBufferForMask() const;
 
     /**
      * @brief   画面上に描画するクリッピングコンテキストをセットする。
      */
-    void SetClippingContextBufferForDraw(CubismClippingContext* clip);
+    void SetClippingContextBufferForDraw(CubismClippingContext_Metal* clip);
 
     /**
      * @brief   画面上に描画するクリッピングコンテキストを取得する。
      *
      * @return  画面上に描画するクリッピングコンテキスト
      */
-    CubismClippingContext* GetClippingContextBufferForDraw() const;
+    CubismClippingContext_Metal* GetClippingContextBufferForDraw() const;
 
-    csmMap<csmInt32, id <MTLTexture>>            _textures;                      ///< モデルが参照するテクスチャとレンダラでバインドしているテクスチャとのマップ
-    csmVector<csmInt32>                 _sortedDrawableIndexList;       ///< 描画オブジェクトのインデックスを描画順に並べたリスト
-    CubismRendererProfile_Metal     _rendererProfile;               ///< Metalのステートを保持するオブジェクト
-    CubismClippingManager_Metal*    _clippingManager;               ///< クリッピングマスク管理オブジェクト
-    CubismClippingContext*              _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
-    CubismClippingContext*              _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
+    /**
+     * @brief  マスク生成時かを判定する
+     *
+     * @return  判定値
+     */
+    const inline csmBool IsGeneratingMask() const;
 
-    csmVector<CubismOffscreenFrame_Metal>   _offscreenFrameBuffers;          ///< マスク描画用のフレームバッファ
-    CubismCommandBuffer_Metal       _commandBuffer;
-    csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*>  _drawableDrawCommandBuffer;
+    csmMap< csmInt32, id <MTLTexture> > _textures;                      ///< モデルが参照するテクスチャとレンダラでバインドしているテクスチャとのマップ
+    csmVector<csmInt32> _sortedDrawableIndexList;       ///< 描画オブジェクトのインデックスを描画順に並べたリスト
+    CubismRendererProfile_Metal _rendererProfile;               ///< Metalのステートを保持するオブジェクト
+    CubismClippingManager_Metal* _clippingManager;               ///< クリッピングマスク管理オブジェクト
+    CubismClippingContext_Metal* _clippingContextBufferForMask;  ///< マスクテクスチャに描画するためのクリッピングコンテキスト
+    CubismClippingContext_Metal* _clippingContextBufferForDraw;  ///< 画面上描画するためのクリッピングコンテキスト
+
+    csmVector<CubismOffscreenSurface_Metal> _offscreenSurfaces;         ///< マスク描画用のフレームバッファ
+    CubismCommandBuffer_Metal _commandBuffer;
+    csmVector<CubismCommandBuffer_Metal::DrawCommandBuffer*> _drawableDrawCommandBuffer;
 };
 
 }}}}

--- a/src/Rendering/Metal/CubismShader_Metal.hpp
+++ b/src/Rendering/Metal/CubismShader_Metal.hpp
@@ -1,0 +1,120 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <MetalKit/MetalKit.h>
+#include "CubismFramework.hpp"
+#include "CubismRenderer_Metal.hpp"
+#include "CubismCommandBuffer_Metal.hpp"
+#include "Type/csmVector.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+// 前方宣言
+class CubismRenderer_Metal;
+
+/**
+ * @brief   Metal用のシェーダプログラムを生成・破棄するクラス<br>
+ *           シングルトンなクラスであり、CubismShader_Metal::GetInstance()からアクセスする。
+ *
+ */
+class CubismShader_Metal
+{
+public:
+    /**
+     * @brief   インスタンスを取得する（シングルトン）。
+     *
+     * @return  インスタンスのポインタ
+     */
+    static CubismShader_Metal* GetInstance();
+
+    /**
+     * @brief   インスタンスを解放する（シングルトン）。
+     */
+    static void DeleteInstance();
+
+    /**
+     * @brief   描画用のシェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   drawCommandBuffer     ->  コマンドバッファ
+     * @param[in]   renderEncoder         ->  MTLRenderCommandEncoder
+     * @param[in]   renderer              ->  レンダラのインスタンス
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index                 ->  描画オブジェクトのインデックス
+     */
+    void SetupShaderProgramForDraw(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
+                                , CubismRenderer_Metal* renderer, const CubismModel& model, const csmInt32 index);
+
+    /**
+     * @brief   マスク用のシェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   drawCommandBuffer     ->  コマンドバッファ
+     * @param[in]   renderEncoder         ->  MTLRenderCommandEncoder
+     * @param[in]   renderer              ->  レンダラのインスタンス
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index                 ->  描画オブジェクトのインデックス
+     */
+    void SetupShaderProgramForMask(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
+                                , CubismRenderer_Metal* renderer, const CubismModel& model, const csmInt32 index);
+
+private:
+    struct ShaderProgram
+    {
+        id <MTLFunction> vertexFunction;
+        id <MTLFunction> fragmentFunction;
+    };
+
+    /**
+    * @bref    シェーダープログラムとシェーダ変数のアドレスを保持する構造体
+    *
+    */
+    struct CubismShaderSet
+    {
+        ShaderProgram *ShaderProgram; ///< シェーダプログラムのアドレス
+        id<MTLRenderPipelineState> RenderPipelineState;
+        id<MTLDepthStencilState> DepthStencilState;
+        id<MTLSamplerState> SamplerState;
+    };
+
+    /**
+     * @brief   privateなコンストラクタ
+     */
+    CubismShader_Metal();
+
+    /**
+     * @brief   privateなデストラクタ
+     */
+    virtual ~CubismShader_Metal();
+
+    /**
+     * @brief   シェーダプログラムを初期化する
+     */
+    void GenerateShaders(CubismRenderer_Metal* renderer);
+
+    /**
+     * @brief   シェーダプログラムをロードしてアドレス返す。
+     *
+     * @param[in]   vertShaderSrc   ->  頂点シェーダのソース
+     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのソース
+     *
+     * @return  シェーダプログラムのアドレス
+     */
+    ShaderProgram* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
+    id<MTLRenderPipelineState> MakeRenderPipelineState(id<MTLDevice> device, ShaderProgram* shaderProgram, int blendMode);
+    id<MTLDepthStencilState> MakeDepthStencilState(id<MTLDevice> device);
+    id<MTLSamplerState> MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer);
+
+    id<MTLLibrary> _shaderLib;
+
+    csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
+
+};
+
+}}}}
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Metal/CubismShader_Metal.mm
+++ b/src/Rendering/Metal/CubismShader_Metal.mm
@@ -1,0 +1,509 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismShader_Metal.hpp"
+#include "CubismRenderer_Metal.hpp"
+#include "CubismRenderingInstanceSingleton_Metal.h"
+#include "MetalShaderTypes.h"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/*********************************************************************************************************************
+*                                       CubismShader_Metal
+********************************************************************************************************************/
+namespace {
+    const csmInt32 ShaderCount = 19; ///< シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
+    CubismShader_Metal* s_instance;
+}
+
+enum ShaderNames
+{
+    // SetupMask
+    ShaderNames_SetupMask,
+
+    //Normal
+    ShaderNames_Normal,
+    ShaderNames_NormalMasked,
+    ShaderNames_NormalMaskedInverted,
+    ShaderNames_NormalPremultipliedAlpha,
+    ShaderNames_NormalMaskedPremultipliedAlpha,
+    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
+
+    //Add
+    ShaderNames_Add,
+    ShaderNames_AddMasked,
+    ShaderNames_AddMaskedInverted,
+    ShaderNames_AddPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlphaInverted,
+
+    //Mult
+    ShaderNames_Mult,
+    ShaderNames_MultMasked,
+    ShaderNames_MultMaskedInverted,
+    ShaderNames_MultPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlphaInverted,
+};
+
+//// SetupMask
+static const csmChar* VertShaderSrcSetupMask = "VertShaderSrcSetupMask";
+
+static const csmChar* FragShaderSrcSetupMask = "FragShaderSrcSetupMask";
+
+//----- バーテックスシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* VertShaderSrc = "VertShaderSrc";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* VertShaderSrcMasked = "VertShaderSrcMasked";
+
+//----- フラグメントシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* FragShaderSrc = "FragShaderSrc";
+
+// Normal & Add & Mult 共通 （PremultipliedAlpha）
+static const csmChar* FragShaderSrcPremultipliedAlpha = "FragShaderSrcPremultipliedAlpha";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* FragShaderSrcMask = "FragShaderSrcMask";
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
+static const csmChar* FragShaderSrcMaskInverted = "FragShaderSrcMaskInverted";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskPremultipliedAlpha = "FragShaderSrcMaskPremultipliedAlpha";
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha = "FragShaderSrcMaskInvertedPremultipliedAlpha";
+
+CubismShader_Metal::CubismShader_Metal()
+{
+}
+
+CubismShader_Metal::~CubismShader_Metal()
+{
+}
+
+CubismShader_Metal* CubismShader_Metal::GetInstance()
+{
+    if (s_instance == NULL)
+    {
+        s_instance = CSM_NEW CubismShader_Metal();
+    }
+    return s_instance;
+}
+
+void CubismShader_Metal::DeleteInstance()
+{
+    if (s_instance)
+    {
+        CSM_DELETE_SELF(CubismShader_Metal, s_instance);
+        s_instance = NULL;
+    }
+}
+
+
+void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
+{
+    for (csmInt32 i = 0; i < ShaderCount; i++)
+    {
+        _shaderSets.PushBack(CSM_NEW CubismShaderSet());
+    }
+
+    //シェーダライブラリのロード（.metal）
+    CubismRenderingInstanceSingleton_Metal *single = [CubismRenderingInstanceSingleton_Metal sharedManager];
+    id <MTLDevice> device = [single getMTLDevice];
+    _shaderLib = [device newDefaultLibrary];
+
+    if(!_shaderLib)
+    {
+        NSLog(@" ERROR: Couldnt create a default shader library");
+        // assert here because if the shader libary isn't loading, nothing good will happen
+        return;
+    }
+
+    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+
+    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
+    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
+    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
+    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
+    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
+    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+
+    _shaderSets[0]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[0]->ShaderProgram, -1);
+    _shaderSets[0]->SamplerState = MakeSamplerState(device, renderer);
+
+    _shaderSets[1]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[1]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[2]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[2]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[3]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[3]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[4]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[4]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[5]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[5]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+    _shaderSets[6]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[6]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
+
+    _shaderSets[1]->DepthStencilState = MakeDepthStencilState(device);
+    _shaderSets[2]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[3]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[4]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[5]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[6]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+
+    _shaderSets[1]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[2]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[3]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[4]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[5]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[6]->SamplerState = _shaderSets[0]->SamplerState;
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    _shaderSets[7]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[7]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[8]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[8]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[9]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[9]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[10]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[10]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[11]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[11]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+    _shaderSets[12]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[12]->ShaderProgram, CubismRenderer::CubismBlendMode_Additive);
+
+    _shaderSets[7]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[8]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[9]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[10]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[11]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[12]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+
+    _shaderSets[7]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[8]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[9]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[10]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[11]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[12]->SamplerState = _shaderSets[0]->SamplerState;
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    _shaderSets[13]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[13]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[14]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[14]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[15]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[15]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[16]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[16]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[17]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[17]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+    _shaderSets[18]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[18]->ShaderProgram, CubismRenderer::CubismBlendMode_Multiplicative);
+
+    _shaderSets[13]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[14]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[15]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[16]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[17]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+    _shaderSets[18]->DepthStencilState = _shaderSets[1]->DepthStencilState;
+
+    _shaderSets[13]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[14]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[15]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[16]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[17]->SamplerState = _shaderSets[0]->SamplerState;
+    _shaderSets[18]->SamplerState = _shaderSets[0]->SamplerState;
+}
+
+void CubismShader_Metal::SetupShaderProgramForDraw(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
+                                                  , CubismRenderer_Metal* renderer, const CubismModel& model, const csmInt32 index)
+{
+    // シェーダー生成
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders(renderer);
+    }
+
+    // シェーダーセットの設定
+    const csmBool masked = renderer->GetClippingContextBufferForDraw() != NULL;
+    const csmBool invertedMask = model.GetDrawableInvertedMask(index);
+    const csmBool isPremultipliedAlpha = renderer->IsPremultipliedAlpha();
+    const csmInt32 offset = (masked ? ( invertedMask ? 2 : 1 ) : 0) + (isPremultipliedAlpha ? 3 : 0);
+
+    CubismShaderSet* shaderSet;
+
+    //_shaderSetsにshaderが入っていて、それをブレンドモードごとに切り替えている
+    switch (model.GetDrawableBlendMode(index))
+    {
+    case CubismRenderer::CubismBlendMode_Normal:
+    default:
+        shaderSet = _shaderSets[ShaderNames_Normal + offset];
+        break;
+
+    case CubismRenderer::CubismBlendMode_Additive:
+        shaderSet = _shaderSets[ShaderNames_Add + offset];
+        break;
+
+    case CubismRenderer::CubismBlendMode_Multiplicative:
+        shaderSet = _shaderSets[ShaderNames_Mult + offset];
+        break;
+    }
+
+    // 頂点配列の設定
+    [renderEncoder setVertexBuffer:(drawCommandBuffer->GetVertexBuffer()) offset:0 atIndex:MetalVertexInputIndexVertices];
+
+    // テクスチャ頂点の設定
+    [renderEncoder setVertexBuffer:(drawCommandBuffer->GetUvBuffer()) offset:0 atIndex:MetalVertexInputUVs];
+
+    if (masked)
+    {
+        CubismMaskedShaderUniforms maskedShaderUniforms;
+        CubismFragMaskedShaderUniforms fragMaskedShaderUniforms;
+
+        // frameBufferに書かれたテクスチャ
+        id <MTLTexture> tex = renderer->GetOffscreenSurface(renderer->GetClippingContextBufferForDraw()->_bufferIndex)->GetColorBuffer();
+
+        //テクスチャ設定
+        [renderEncoder setFragmentTexture:tex atIndex:1];
+
+        // 使用するカラーチャンネルを設定
+        const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+
+        fragMaskedShaderUniforms.channelFlag = (vector_float4){ colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
+        {
+            csmFloat32* srcArray = renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray();
+
+            maskedShaderUniforms.clipMatrix = simd::float4x4(
+                                simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                                simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                                simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                                simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+        }
+        {
+            //座標変換
+            CubismMatrix44 matrix4x4 = renderer->GetMvpMatrix();
+            csmFloat32* srcArray = matrix4x4.GetArray();
+            maskedShaderUniforms.matrix = simd::float4x4(
+                                                         simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                                                         simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                                                         simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                                                         simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+        }
+
+        //テクスチャ設定
+        const id <MTLTexture> texture = renderer->GetBindedTextureId(model.GetDrawableTextureIndex(index));
+        [renderEncoder setFragmentTexture:texture atIndex:0];
+
+        CubismRenderer::CubismTextureColor baseColor = renderer->GetModelColorWithOpacity(model.GetDrawableOpacity(index));
+        CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+        CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+        maskedShaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+        fragMaskedShaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+        fragMaskedShaderUniforms.multiplyColor = (vector_float4){ multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
+        fragMaskedShaderUniforms.screenColor = (vector_float4){ screenColor.R, screenColor.G, screenColor.B, screenColor.A };
+
+        // 転送
+        [renderEncoder setVertexBytes:&maskedShaderUniforms length:sizeof(CubismMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+        [renderEncoder setFragmentBytes:&fragMaskedShaderUniforms length:sizeof(CubismFragMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+        [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+
+    } else {
+        CubismNormalShaderUniforms normalShaderUniforms;
+
+        //テクスチャ設定
+        const id <MTLTexture> texture = renderer->GetBindedTextureId(model.GetDrawableTextureIndex(index));
+        [renderEncoder setFragmentTexture:texture atIndex:0];
+
+        //座標変換
+        CubismMatrix44 matrix4x4 = renderer->GetMvpMatrix();
+        csmFloat32* srcArray = matrix4x4.GetArray();
+        normalShaderUniforms.matrix = simd::float4x4(
+                                                     simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                                                     simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                                                     simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                                                     simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+
+        CubismRenderer::CubismTextureColor baseColor = renderer->GetModelColorWithOpacity(model.GetDrawableOpacity(index));
+        CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+        CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+        normalShaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
+        normalShaderUniforms.multiplyColor = (vector_float4){ multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
+        normalShaderUniforms.screenColor = (vector_float4){ screenColor.R, screenColor.G, screenColor.B, screenColor.A };
+
+        // 転送
+        [renderEncoder setVertexBytes:&normalShaderUniforms length:sizeof(CubismNormalShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+        [renderEncoder setFragmentBytes:&normalShaderUniforms length:sizeof(CubismNormalShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+        [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+    }
+
+    [renderEncoder setDepthStencilState:shaderSet->DepthStencilState];
+    drawCommandBuffer->GetCommandDraw()->SetRenderPipelineState(shaderSet->RenderPipelineState);
+}
+
+void CubismShader_Metal::SetupShaderProgramForMask(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
+                                                , CubismRenderer_Metal* renderer, const CubismModel& model, const csmInt32 index)
+{
+    // シェーダー生成
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders(renderer);
+    }
+
+    CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
+
+    // テクスチャ設定
+    const id <MTLTexture> texture = renderer->GetBindedTextureId(model.GetDrawableTextureIndex(index));
+    [renderEncoder setFragmentTexture:texture atIndex:0];
+
+    // 頂点・テクスチャバッファの設定
+    [renderEncoder setVertexBuffer:(drawCommandBuffer->GetVertexBuffer()) offset:0 atIndex:MetalVertexInputIndexVertices];
+    [renderEncoder setVertexBuffer:(drawCommandBuffer->GetUvBuffer()) offset:0 atIndex:MetalVertexInputUVs];
+
+    CubismSetupMaskedShaderUniforms maskedShaderUniforms;
+    const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
+    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    maskedShaderUniforms.channelFlag = (vector_float4){ colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
+
+    csmFloat32* srcArray = renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray();
+
+    maskedShaderUniforms.clipMatrix = simd::float4x4(
+                        simd::float4 {srcArray[0], srcArray[1], srcArray[2], srcArray[3]},
+                        simd::float4 {srcArray[4], srcArray[5], srcArray[6], srcArray[7]},
+                        simd::float4 {srcArray[8], srcArray[9], srcArray[10], srcArray[11]},
+                        simd::float4 {srcArray[12], srcArray[13], srcArray[14], srcArray[15]});
+
+    csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
+
+    maskedShaderUniforms.baseColor = (vector_float4){ rect->X * 2.0f - 1.0f,
+                                rect->Y * 2.0f - 1.0f,
+                                rect->GetRight() * 2.0f - 1.0f,
+                                rect->GetBottom() * 2.0f - 1.0f };
+
+    // 転送
+    [renderEncoder setVertexBytes:&maskedShaderUniforms length:sizeof(CubismSetupMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+    [renderEncoder setFragmentBytes:&maskedShaderUniforms length:sizeof(CubismSetupMaskedShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
+    [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+    drawCommandBuffer->GetCommandDraw()->SetRenderPipelineState(shaderSet->RenderPipelineState);
+}
+
+CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
+{
+    // Create shader program.
+    ShaderProgram *shaderProgram = new ShaderProgram;
+
+    //頂点シェーダの取得
+    NSString *vertShaderStr = [NSString stringWithCString: vertShaderSrc encoding:NSUTF8StringEncoding];
+
+    shaderProgram->vertexFunction = [_shaderLib newFunctionWithName:vertShaderStr];
+    if(!shaderProgram->vertexFunction)
+    {
+        delete shaderProgram;
+        NSLog(@">> ERROR: Couldn't load vertex function from default library");
+        return nil;
+    }
+
+    //フラグメントシェーダの取得
+    NSString *fragShaderStr = [NSString stringWithCString: fragShaderSrc encoding:NSUTF8StringEncoding];
+    shaderProgram->fragmentFunction = [_shaderLib newFunctionWithName:fragShaderStr];
+    if(!shaderProgram->fragmentFunction)
+    {
+        delete shaderProgram;
+        NSLog(@" ERROR: Couldn't load fragment function from default library");
+        return nil;
+    }
+
+    return shaderProgram;
+}
+
+id<MTLRenderPipelineState> CubismShader_Metal::MakeRenderPipelineState(id<MTLDevice> device, CubismShader_Metal::ShaderProgram* shaderProgram, int blendMode)
+{
+    MTLRenderPipelineDescriptor* renderPipelineDescriptor = [[[MTLRenderPipelineDescriptor alloc] init] autorelease];
+    NSError *error;
+
+    renderPipelineDescriptor.vertexFunction = shaderProgram->vertexFunction;
+    renderPipelineDescriptor.fragmentFunction = shaderProgram->fragmentFunction;
+    renderPipelineDescriptor.colorAttachments[0].blendingEnabled = true;
+
+    switch (blendMode)
+    {
+    default:
+            // only Setup masking
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceColor;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
+            break;
+
+    case CubismRenderer::CubismBlendMode_Normal:
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+
+        break;
+
+    case CubismRenderer::CubismBlendMode_Additive:
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+
+        break;
+
+    case CubismRenderer::CubismBlendMode_Multiplicative:
+            renderPipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorDestinationColor;
+            renderPipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+            renderPipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorZero;
+            renderPipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOne;
+            renderPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            renderPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+
+        break;
+    }
+
+    return [device newRenderPipelineStateWithDescriptor:renderPipelineDescriptor error:&error];
+}
+
+id<MTLDepthStencilState> CubismShader_Metal::MakeDepthStencilState(id<MTLDevice> device)
+{
+    MTLDepthStencilDescriptor* depthStencilDescriptor = [[[MTLDepthStencilDescriptor alloc] init] autorelease];
+
+    depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
+    depthStencilDescriptor.depthWriteEnabled = YES;
+
+    return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+}
+
+id<MTLSamplerState> CubismShader_Metal::MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer)
+{
+    MTLSamplerDescriptor* samplerDescriptor = [[[MTLSamplerDescriptor alloc] init] autorelease];
+
+    samplerDescriptor.rAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.sAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.tAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.minFilter = MTLSamplerMinMagFilterLinear;
+    samplerDescriptor.magFilter = MTLSamplerMinMagFilterLinear;
+    samplerDescriptor.mipFilter = MTLSamplerMipFilterLinear;
+
+    //異方性フィルタリング
+    if (renderer->GetAnisotropy() > 0.0f)
+    {
+        samplerDescriptor.maxAnisotropy = renderer->GetAnisotropy();
+    }
+
+    return [device newSamplerStateWithDescriptor:samplerDescriptor];
+}
+
+}}}}
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/OpenGL/CMakeLists.txt
+++ b/src/Rendering/OpenGL/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(${LIB_NAME}
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_OpenGLES2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_OpenGLES2.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_OpenGLES2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismShader_OpenGLES2.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_OpenGLES2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_OpenGLES2.hpp
 )

--- a/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.cpp
@@ -10,7 +10,7 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-CubismOffscreenFrame_OpenGLES2::CubismOffscreenFrame_OpenGLES2()
+CubismOffscreenSurface_OpenGLES2::CubismOffscreenSurface_OpenGLES2()
     : _renderTexture(0)
     , _colorBuffer(0)
     , _oldFBO(0)
@@ -21,7 +21,7 @@ CubismOffscreenFrame_OpenGLES2::CubismOffscreenFrame_OpenGLES2()
 }
 
 
-void CubismOffscreenFrame_OpenGLES2::BeginDraw(GLint restoreFBO)
+void CubismOffscreenSurface_OpenGLES2::BeginDraw(GLint restoreFBO)
 {
     if (_renderTexture == 0)
     {
@@ -42,7 +42,7 @@ void CubismOffscreenFrame_OpenGLES2::BeginDraw(GLint restoreFBO)
     glBindFramebuffer(GL_FRAMEBUFFER, _renderTexture);
 }
 
-void CubismOffscreenFrame_OpenGLES2::EndDraw()
+void CubismOffscreenSurface_OpenGLES2::EndDraw()
 {
     if (_renderTexture == 0)
     {
@@ -53,17 +53,17 @@ void CubismOffscreenFrame_OpenGLES2::EndDraw()
     glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
 }
 
-void CubismOffscreenFrame_OpenGLES2::Clear(float r, float g, float b, float a)
+void CubismOffscreenSurface_OpenGLES2::Clear(float r, float g, float b, float a)
 {
     // マスクをクリアする
     glClearColor(r,g,b,a);
     glClear(GL_COLOR_BUFFER_BIT);
 }
 
-csmBool CubismOffscreenFrame_OpenGLES2::CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, GLuint colorBuffer)
+csmBool CubismOffscreenSurface_OpenGLES2::CreateOffscreenSurface(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, GLuint colorBuffer)
 {
     // 一旦削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     do
     {
@@ -110,12 +110,12 @@ csmBool CubismOffscreenFrame_OpenGLES2::CreateOffscreenFrame(csmUint32 displayBu
     } while (0);
 
     // 失敗したので削除
-    DestroyOffscreenFrame();
+    DestroyOffscreenSurface();
 
     return false;
 }
 
-void CubismOffscreenFrame_OpenGLES2::DestroyOffscreenFrame()
+void CubismOffscreenSurface_OpenGLES2::DestroyOffscreenSurface()
 {
     if (!_isColorBufferInherited && (_colorBuffer != 0))
     {
@@ -130,27 +130,27 @@ void CubismOffscreenFrame_OpenGLES2::DestroyOffscreenFrame()
     }
 }
 
-GLuint CubismOffscreenFrame_OpenGLES2::GetRenderTexture() const
+GLuint CubismOffscreenSurface_OpenGLES2::GetRenderTexture() const
 {
     return _renderTexture;
 }
 
-GLuint CubismOffscreenFrame_OpenGLES2::GetColorBuffer() const
+GLuint CubismOffscreenSurface_OpenGLES2::GetColorBuffer() const
 {
     return _colorBuffer;
 }
 
-csmUint32 CubismOffscreenFrame_OpenGLES2::GetBufferWidth() const
+csmUint32 CubismOffscreenSurface_OpenGLES2::GetBufferWidth() const
 {
     return _bufferWidth;
 }
 
-csmUint32 CubismOffscreenFrame_OpenGLES2::GetBufferHeight() const
+csmUint32 CubismOffscreenSurface_OpenGLES2::GetBufferHeight() const
 {
     return _bufferHeight;
 }
 
-csmBool CubismOffscreenFrame_OpenGLES2::IsValid() const
+csmBool CubismOffscreenSurface_OpenGLES2::IsValid() const
 {
     return _renderTexture != 0;
 }

--- a/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp
@@ -44,11 +44,11 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /**
  * @brief  オフスクリーン描画用構造体
  */
-class CubismOffscreenFrame_OpenGLES2
+class CubismOffscreenSurface_OpenGLES2
 {
 public:
 
-    CubismOffscreenFrame_OpenGLES2();
+    CubismOffscreenSurface_OpenGLES2();
 
     /**
      * @brief   指定の描画ターゲットに向けて描画開始
@@ -74,17 +74,17 @@ public:
     void Clear(float r, float g, float b, float a);
 
     /**
-     *  @brief  CubismOffscreenFrame作成
+     *  @brief  CubismOffscreenSurface作成
      *  @param  displayBufferWidth     作成するバッファ幅
      *  @param  displayBufferHeight    作成するバッファ高さ
      *  @param  colorBuffer            0以外の場合、ピクセル格納領域としてcolorBufferを使用する
      */
-    csmBool CreateOffscreenFrame(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, GLuint colorBuffer = 0);
+    csmBool CreateOffscreenSurface(csmUint32 displayBufferWidth, csmUint32 displayBufferHeight, GLuint colorBuffer = 0);
 
     /**
-     * @brief   CubismOffscreenFrameの削除
+     * @brief   CubismOffscreenSurfaceの削除
      */
-    void DestroyOffscreenFrame();
+    void DestroyOffscreenSurface();
 
     /**
      * @brief   レンダーテクスチャメンバーへのアクセッサ

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -27,138 +27,6 @@ namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering 
 /*********************************************************************************************************************
 *                                      CubismClippingManager_OpenGLES2
 ********************************************************************************************************************/
-///< ファイルスコープの変数宣言
-namespace {
-const csmInt32 ColorChannelCount = 4;   // 実験時に1チャンネルの場合は1、RGBだけの場合は3、アルファも含める場合は4
-const csmInt32 ClippingMaskMaxCountOnDefault = 36;  // 通常のフレームバッファ1枚あたりのマスク最大数
-const csmInt32 ClippingMaskMaxCountOnMultiRenderTexture = 32;   // フレームバッファが2枚以上ある場合のフレームバッファ1枚あたりのマスク最大数
-}
-
-CubismClippingManager_OpenGLES2::CubismClippingManager_OpenGLES2() :
-                                                                   _clippingMaskBufferSize(256, 256)
-{
-    CubismRenderer::CubismTextureColor* tmp;
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 1.0f;
-    tmp->G = 0.0f;
-    tmp->B = 0.0f;
-    tmp->A = 0.0f;
-    _channelColors.PushBack(tmp);
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 0.0f;
-    tmp->G = 1.0f;
-    tmp->B = 0.0f;
-    tmp->A = 0.0f;
-    _channelColors.PushBack(tmp);
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 0.0f;
-    tmp->G = 0.0f;
-    tmp->B = 1.0f;
-    tmp->A = 0.0f;
-    _channelColors.PushBack(tmp);
-    tmp = CSM_NEW CubismRenderer::CubismTextureColor();
-    tmp->R = 0.0f;
-    tmp->G = 0.0f;
-    tmp->B = 0.0f;
-    tmp->A = 1.0f;
-    _channelColors.PushBack(tmp);
-
-}
-
-CubismClippingManager_OpenGLES2::~CubismClippingManager_OpenGLES2()
-{
-    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
-    {
-        if (_clippingContextListForMask[i]) CSM_DELETE_SELF(CubismClippingContext, _clippingContextListForMask[i]);
-        _clippingContextListForMask[i] = NULL;
-    }
-
-    // _clippingContextListForDrawは_clippingContextListForMaskにあるインスタンスを指している。上記の処理により要素ごとのDELETEは不要。
-    for (csmUint32 i = 0; i < _clippingContextListForDraw.GetSize(); i++)
-    {
-        _clippingContextListForDraw[i] = NULL;
-    }
-
-    for (csmUint32 i = 0; i < _channelColors.GetSize(); i++)
-    {
-        if (_channelColors[i]) CSM_DELETE(_channelColors[i]);
-        _channelColors[i] = NULL;
-    }
-
-    if (_clearedFrameBufferFlags.GetSize() != 0)
-    {
-        _clearedFrameBufferFlags.Clear();
-        _clearedFrameBufferFlags = NULL;
-    }
-}
-
-void CubismClippingManager_OpenGLES2::Initialize(CubismModel& model, csmInt32 drawableCount, const csmInt32** drawableMasks, const csmInt32* drawableMaskCounts, const csmInt32 maskBufferCount)
-{
-    _renderTextureCount = maskBufferCount;
-
-    // レンダーテクスチャのクリアフラグの設定
-    for (csmInt32 i = 0; i < _renderTextureCount; ++i)
-    {
-        _clearedFrameBufferFlags.PushBack(false);
-    }
-
-    //クリッピングマスクを使う描画オブジェクトを全て登録する
-    //クリッピングマスクは、通常数個程度に限定して使うものとする
-    for (csmInt32 i = 0; i < drawableCount; i++)
-    {
-        if (drawableMaskCounts[i] <= 0)
-        {
-            //クリッピングマスクが使用されていないアートメッシュ（多くの場合使用しない）
-            _clippingContextListForDraw.PushBack(NULL);
-            continue;
-        }
-
-        // 既にあるClipContextと同じかチェックする
-        CubismClippingContext* cc = FindSameClip(drawableMasks[i], drawableMaskCounts[i]);
-        if (cc == NULL)
-        {
-            // 同一のマスクが存在していない場合は生成する
-            cc = CSM_NEW CubismClippingContext(this, drawableMasks[i], drawableMaskCounts[i]);
-            _clippingContextListForMask.PushBack(cc);
-        }
-
-        cc->AddClippedDrawable(i);
-
-        _clippingContextListForDraw.PushBack(cc);
-    }
-}
-
-CubismClippingContext* CubismClippingManager_OpenGLES2::FindSameClip(const csmInt32* drawableMasks, csmInt32 drawableMaskCounts) const
-{
-    // 作成済みClippingContextと一致するか確認
-    for (csmUint32 i = 0; i < _clippingContextListForMask.GetSize(); i++)
-    {
-        CubismClippingContext* cc = _clippingContextListForMask[i];
-        const csmInt32 count = cc->_clippingIdCount;
-        if (count != drawableMaskCounts) continue; //個数が違う場合は別物
-        csmInt32 samecount = 0;
-
-        // 同じIDを持つか確認。配列の数が同じなので、一致した個数が同じなら同じ物を持つとする。
-        for (csmInt32 j = 0; j < count; j++)
-        {
-            const csmInt32 clipId = cc->_clippingIdList[j];
-            for (csmInt32 k = 0; k < count; k++)
-            {
-                if (drawableMasks[k] == clipId)
-                {
-                    samecount++;
-                    break;
-                }
-            }
-        }
-        if (samecount == count)
-        {
-            return cc;
-        }
-    }
-    return NULL; //見つからなかった
-}
-
 void CubismClippingManager_OpenGLES2::SetupClippingContext(CubismModel& model, CubismRenderer_OpenGLES2* renderer, GLint lastFBO, GLint lastViewport[4])
 {
     // 全てのクリッピングを用意する
@@ -167,7 +35,7 @@ void CubismClippingManager_OpenGLES2::SetupClippingContext(CubismModel& model, C
     for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
     {
         // １つのクリッピングマスクに関して
-        CubismClippingContext* cc = _clippingContextListForMask[clipIndex];
+        CubismClippingContext_OpenGLES2* cc = _clippingContextListForMask[clipIndex];
 
         // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
         CalcClippedDrawTotalBounds(model, cc);
@@ -178,503 +46,139 @@ void CubismClippingManager_OpenGLES2::SetupClippingContext(CubismModel& model, C
         }
     }
 
-    // マスク作成処理
-    if (usingClipCount > 0)
+    if (usingClipCount <= 0)
     {
-        if (!renderer->IsUsingHighPrecisionMask())
-        {
-            // 生成したFrameBufferと同じサイズでビューポートを設定
-            glViewport(0, 0, _clippingMaskBufferSize.X, _clippingMaskBufferSize.Y);
-
-            // 後の計算のためにインデックスの最初をセット
-            _currentOffscreenFrame = renderer->GetMaskBuffer(0);
-            // ----- マスク描画処理 -----
-            _currentOffscreenFrame->BeginDraw(lastFBO);
-
-            renderer->PreDraw(); // バッファをクリアする
-        }
-
-        // 各マスクのレイアウトを決定していく
-        SetupLayoutBounds(renderer->IsUsingHighPrecisionMask() ? 0 : usingClipCount);
-
-        // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
-        if (_clearedFrameBufferFlags.GetSize() != _renderTextureCount)
-        {
-            _clearedFrameBufferFlags.Clear();
-
-            for (csmInt32 i = 0; i < _renderTextureCount; ++i)
-            {
-                _clearedFrameBufferFlags.PushBack(false);
-            }
-        }
-        else
-        {
-            // マスクのクリアフラグを毎フレーム開始時に初期化
-            for (csmInt32 i = 0; i < _renderTextureCount; ++i)
-            {
-                _clearedFrameBufferFlags[i] = false;
-            }
-        }
-
-        // 実際にマスクを生成する
-        // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
-        for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
-        {
-            // --- 実際に１つのマスクを描く ---
-            CubismClippingContext* clipContext = _clippingContextListForMask[clipIndex];
-            csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
-            csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
-            const csmFloat32 MARGIN = 0.05f;
-            csmFloat32 scaleX = 0.0f;
-            csmFloat32 scaleY = 0.0f;
-
-            // clipContextに設定したオフスクリーンフレームをインデックスで取得
-            CubismOffscreenFrame_OpenGLES2* clipContextOffscreenFrame = renderer->GetMaskBuffer(clipContext->_bufferIndex);
-
-            // 現在のオフスクリーンフレームがclipContextのものと異なる場合
-            if (_currentOffscreenFrame != clipContextOffscreenFrame &&
-                !renderer->IsUsingHighPrecisionMask())
-            {
-                _currentOffscreenFrame->EndDraw();
-                _currentOffscreenFrame = clipContextOffscreenFrame;
-                // マスク用RenderTextureをactiveにセット
-                _currentOffscreenFrame->BeginDraw(lastFBO);
-
-                // バッファをクリアする。
-                renderer->PreDraw();
-            }
-
-            if (renderer->IsUsingHighPrecisionMask())
-            {
-                const csmFloat32 ppu = model.GetPixelsPerUnit();
-                const csmFloat32 maskPixelWidth = clipContext->GetClippingManager()->_clippingMaskBufferSize.X;
-                const csmFloat32 maskPixelHeight = clipContext->GetClippingManager()->_clippingMaskBufferSize.Y;
-                const csmFloat32 physicalMaskWidth = layoutBoundsOnTex01->Width * maskPixelWidth;
-                const csmFloat32 physicalMaskHeight = layoutBoundsOnTex01->Height * maskPixelHeight;
-
-
-                _tmpBoundsOnModel.SetRect(allClippedDrawRect);
-
-                if (_tmpBoundsOnModel.Width * ppu > physicalMaskWidth)
-                {
-                    _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, 0.0f);
-                    scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
-                }
-                else
-                {
-                    scaleX = ppu / physicalMaskWidth;
-                }
-
-                if (_tmpBoundsOnModel.Height * ppu > physicalMaskHeight)
-                {
-                    _tmpBoundsOnModel.Expand(0.0f, allClippedDrawRect->Height * MARGIN);
-                    scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
-                }
-                else
-                {
-                    scaleY = ppu / physicalMaskHeight;
-                }
-            }
-            else
-            {
-                // モデル座標上の矩形を、適宜マージンを付けて使う
-                _tmpBoundsOnModel.SetRect(allClippedDrawRect);
-                _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, allClippedDrawRect->Height * MARGIN);
-                //########## 本来は割り当てられた領域の全体を使わず必要最低限のサイズがよい
-                // シェーダ用の計算式を求める。回転を考慮しない場合は以下のとおり
-                // movePeriod' = movePeriod * scaleX + offX     [[ movePeriod' = (movePeriod - tmpBoundsOnModel.movePeriod)*scale + layoutBoundsOnTex01.movePeriod ]]
-                scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
-                scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
-            }
-
-            // マスク生成時に使う行列を求める
-            {
-                // シェーダに渡す行列を求める <<<<<<<<<<<<<<<<<<<<<<<< 要最適化（逆順に計算すればシンプルにできる）
-                _tmpMatrix.LoadIdentity();
-                {
-                    // Layout0..1 を -1..1に変換
-                    _tmpMatrix.TranslateRelative(-1.0f, -1.0f);
-                    _tmpMatrix.ScaleRelative(2.0f, 2.0f);
-                }
-                {
-                    // view to Layout0..1
-                    _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
-                    _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
-                    _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y); //new = [translate][scale][translate]
-                }
-                // tmpMatrixForMask が計算結果
-                _tmpMatrixForMask.SetMatrix(_tmpMatrix.GetArray());
-            }
-
-            //--------- draw時の mask 参照用行列を計算
-            {
-                // シェーダに渡す行列を求める <<<<<<<<<<<<<<<<<<<<<<<< 要最適化（逆順に計算すればシンプルにできる）
-                _tmpMatrix.LoadIdentity();
-                {
-                    _tmpMatrix.TranslateRelative(layoutBoundsOnTex01->X, layoutBoundsOnTex01->Y); //new = [translate]
-                    _tmpMatrix.ScaleRelative(scaleX, scaleY); //new = [translate][scale]
-                    _tmpMatrix.TranslateRelative(-_tmpBoundsOnModel.X, -_tmpBoundsOnModel.Y); //new = [translate][scale][translate]
-                }
-
-                _tmpMatrixForDraw.SetMatrix(_tmpMatrix.GetArray());
-            }
-
-            clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
-
-            clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
-
-            if (!renderer->IsUsingHighPrecisionMask())
-            {
-                const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
-                for (csmInt32 i = 0; i < clipDrawCount; i++)
-                {
-                    const csmInt32 clipDrawIndex = clipContext->_clippingIdList[i];
-
-                    // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
-                    if (!model.GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
-                    {
-                        continue;
-                    }
-
-                    renderer->IsCulling(model.GetDrawableCulling(clipDrawIndex) != 0);
-
-                    // マスクがクリアされていないなら処理する
-                    if (!_clearedFrameBufferFlags[clipContext->_bufferIndex])
-                    {
-                        // マスクをクリアする
-                        // 1が無効（描かれない）領域、0が有効（描かれる）領域。（シェーダーCd*Csで0に近い値をかけてマスクを作る。1をかけると何も起こらない）
-                        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
-                        glClear(GL_COLOR_BUFFER_BIT);
-                        _clearedFrameBufferFlags[clipContext->_bufferIndex] = true;
-                    }
-
-                    // 今回専用の変換を適用して描く
-                    // チャンネルも切り替える必要がある(A,R,G,B)
-                    renderer->SetClippingContextBufferForMask(clipContext);
-
-                    renderer->DrawMeshOpenGL(
-                        model.GetDrawableTextureIndex(clipDrawIndex),
-                        model.GetDrawableVertexIndexCount(clipDrawIndex),
-                        model.GetDrawableVertexCount(clipDrawIndex),
-                        const_cast<csmUint16*>(model.GetDrawableVertexIndices(clipDrawIndex)),
-                        const_cast<csmFloat32*>(model.GetDrawableVertices(clipDrawIndex)),
-                        reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(clipDrawIndex))),
-                        model.GetMultiplyColor(clipDrawIndex),
-                        model.GetScreenColor(clipDrawIndex),
-                        model.GetDrawableOpacity(clipDrawIndex),
-                        CubismRenderer::CubismBlendMode_Normal,   //クリッピングは通常描画を強制
-                        false   // マスク生成時はクリッピングの反転使用は全く関係がない
-                    );
-                }
-            }
-        }
-
-        if (!renderer->IsUsingHighPrecisionMask())
-        {
-            // --- 後処理 ---
-            _currentOffscreenFrame->EndDraw();
-            renderer->SetClippingContextBufferForMask(NULL);
-            glViewport(lastViewport[0], lastViewport[1], lastViewport[2], lastViewport[3]);
-        }
-    }
-}
-
-void CubismClippingManager_OpenGLES2::CalcClippedDrawTotalBounds(CubismModel& model, CubismClippingContext* clippingContext)
-{
-    // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
-    csmFloat32 clippedDrawTotalMinX = FLT_MAX, clippedDrawTotalMinY = FLT_MAX;
-    csmFloat32 clippedDrawTotalMaxX = -FLT_MAX, clippedDrawTotalMaxY = -FLT_MAX;
-
-    // このマスクが実際に必要か判定する
-    // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある
-
-    const csmInt32 clippedDrawCount = clippingContext->_clippedDrawableIndexList->GetSize();
-    for (csmInt32 clippedDrawableIndex = 0; clippedDrawableIndex < clippedDrawCount; clippedDrawableIndex++)
-    {
-        // マスクを使用する描画オブジェクトの描画される矩形を求める
-        const csmInt32 drawableIndex = (*clippingContext->_clippedDrawableIndexList)[clippedDrawableIndex];
-
-        const csmInt32 drawableVertexCount = model.GetDrawableVertexCount(drawableIndex);
-        csmFloat32* drawableVertexes = const_cast<csmFloat32*>(model.GetDrawableVertices(drawableIndex));
-
-        csmFloat32 minX = FLT_MAX, minY = FLT_MAX;
-        csmFloat32 maxX = -FLT_MAX, maxY = -FLT_MAX;
-
-        csmInt32 loop = drawableVertexCount * Constant::VertexStep;
-        for (csmInt32 pi = Constant::VertexOffset; pi < loop; pi += Constant::VertexStep)
-        {
-            csmFloat32 x = drawableVertexes[pi];
-            csmFloat32 y = drawableVertexes[pi + 1];
-            if (x < minX) minX = x;
-            if (x > maxX) maxX = x;
-            if (y < minY) minY = y;
-            if (y > maxY) maxY = y;
-        }
-
-        //
-        if (minX == FLT_MAX) continue; //有効な点がひとつも取れなかったのでスキップする
-
-        // 全体の矩形に反映
-        if (minX < clippedDrawTotalMinX) clippedDrawTotalMinX = minX;
-        if (minY < clippedDrawTotalMinY) clippedDrawTotalMinY = minY;
-        if (maxX > clippedDrawTotalMaxX) clippedDrawTotalMaxX = maxX;
-        if (maxY > clippedDrawTotalMaxY) clippedDrawTotalMaxY = maxY;
-    }
-    if (clippedDrawTotalMinX == FLT_MAX)
-    {
-        clippingContext->_allClippedDrawRect->X = 0.0f;
-        clippingContext->_allClippedDrawRect->Y = 0.0f;
-        clippingContext->_allClippedDrawRect->Width = 0.0f;
-        clippingContext->_allClippedDrawRect->Height = 0.0f;
-        clippingContext->_isUsing = false;
-    }
-    else
-    {
-        clippingContext->_isUsing = true;
-        csmFloat32 w = clippedDrawTotalMaxX - clippedDrawTotalMinX;
-        csmFloat32 h = clippedDrawTotalMaxY - clippedDrawTotalMinY;
-        clippingContext->_allClippedDrawRect->X = clippedDrawTotalMinX;
-        clippingContext->_allClippedDrawRect->Y = clippedDrawTotalMinY;
-        clippingContext->_allClippedDrawRect->Width = w;
-        clippingContext->_allClippedDrawRect->Height = h;
-    }
-}
-
-void CubismClippingManager_OpenGLES2::SetupLayoutBounds(csmInt32 usingClipCount) const
-{
-    const csmInt32 useClippingMaskMaxCount = _renderTextureCount <= 1
-        ? ClippingMaskMaxCountOnDefault
-        : ClippingMaskMaxCountOnMultiRenderTexture * _renderTextureCount;
-
-    if (usingClipCount <= 0 || usingClipCount > useClippingMaskMaxCount)
-    {
-        if (usingClipCount > useClippingMaskMaxCount)
-        {
-            // マスクの制限数の警告を出す
-            csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-            CubismLogError("not supported mask count : %d\n[Details] render texture count : %d\n, mask count : %d"
-                , count, _renderTextureCount, usingClipCount);
-        }
-
-        // この場合は一つのマスクターゲットを毎回クリアして使用する
-        for (csmUint32 index = 0; index < _clippingContextListForMask.GetSize(); index++)
-        {
-            CubismClippingContext* cc = _clippingContextListForMask[index];
-            cc->_layoutChannelNo = 0; // どうせ毎回消すので固定で良い
-            cc->_layoutBounds->X = 0.0f;
-            cc->_layoutBounds->Y = 0.0f;
-            cc->_layoutBounds->Width = 1.0f;
-            cc->_layoutBounds->Height = 1.0f;
-            cc->_bufferIndex = 0;
-        }
         return;
     }
 
-    // レンダーテクスチャが1枚なら9分割する（最大36枚）
-    const csmInt32 layoutCountMaxValue = _renderTextureCount <= 1 ? 9 : 8;
+    // マスク作成処理
+    // 生成したOffscreenSurfaceと同じサイズでビューポートを設定
+    glViewport(0, 0, _clippingMaskBufferSize.X, _clippingMaskBufferSize.Y);
 
-    // ひとつのRenderTextureを極力いっぱいに使ってマスクをレイアウトする
-    // マスクグループの数が4以下ならRGBA各チャンネルに１つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する
-    const csmInt32 countPerSheetDiv = usingClipCount / _renderTextureCount; // レンダーテクスチャ1枚あたり何枚割り当てるか
-    const csmInt32 countPerSheetMod = usingClipCount % _renderTextureCount; // この番号のレンダーテクスチャまでに一つずつ配分する
+    // 後の計算のためにインデックスの最初をセット
+    _currentMaskBuffer = renderer->GetMaskBuffer(0);
+    // ----- マスク描画処理 -----
+    _currentMaskBuffer->BeginDraw(lastFBO);
 
-    // RGBAを順番に使っていく。
-    const csmInt32 div = countPerSheetDiv / ColorChannelCount; //１チャンネルに配置する基本のマスク個数
-    const csmInt32 mod = countPerSheetDiv % ColorChannelCount; //余り、この番号のチャンネルまでに１つずつ配分する
+    renderer->PreDraw(); // バッファをクリアする
 
-    // RGBAそれぞれのチャンネルを用意していく(0:R , 1:G , 2:B, 3:A, )
-    csmInt32 curClipIndex = 0; //順番に設定していく
+    // 各マスクのレイアウトを決定していく
+    SetupLayoutBounds(usingClipCount);
 
-    for (csmInt32 renderTextureNo = 0; renderTextureNo < _renderTextureCount; renderTextureNo++)
+    // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
+    if (_clearedMaskBufferFlags.GetSize() != _renderTextureCount)
     {
-        for (csmInt32 channelNo = 0; channelNo < ColorChannelCount; channelNo++)
+        _clearedMaskBufferFlags.Clear();
+
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
         {
-            // このチャンネルにレイアウトする数
-            csmInt32 layoutCount = div + (channelNo < mod ? 1 : 0);
-
-            // このレンダーテクスチャにまだ割り当てられていなければ追加する
-            const csmInt32 checkChannelNo = mod + 1 >= ColorChannelCount ? 0 : mod + 1;
-            if (layoutCount < layoutCountMaxValue && channelNo == checkChannelNo)
-            {
-                layoutCount += renderTextureNo < countPerSheetMod ? 1 : 0;
-            }
-
-            // 分割方法を決定する
-            if (layoutCount == 0)
-            {
-                // 何もしない
-            }
-            else if (layoutCount == 1)
-            {
-                //全てをそのまま使う
-                CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                cc->_layoutChannelNo = channelNo;
-                cc->_layoutBounds->X = 0.0f;
-                cc->_layoutBounds->Y = 0.0f;
-                cc->_layoutBounds->Width = 1.0f;
-                cc->_layoutBounds->Height = 1.0f;
-                cc->_bufferIndex = renderTextureNo;
-            }
-            else if (layoutCount == 2)
-            {
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    const csmInt32 xpos = i % 2;
-
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = channelNo;
-
-                    cc->_layoutBounds->X = xpos * 0.5f;
-                    cc->_layoutBounds->Y = 0.0f;
-                    cc->_layoutBounds->Width = 0.5f;
-                    cc->_layoutBounds->Height = 1.0f;
-                    cc->_bufferIndex = renderTextureNo;
-                    //UVを2つに分解して使う
-                }
-            }
-            else if (layoutCount <= 4)
-            {
-                //4分割して使う
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    const csmInt32 xpos = i % 2;
-                    const csmInt32 ypos = i / 2;
-
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = channelNo;
-
-                    cc->_layoutBounds->X = xpos * 0.5f;
-                    cc->_layoutBounds->Y = ypos * 0.5f;
-                    cc->_layoutBounds->Width = 0.5f;
-                    cc->_layoutBounds->Height = 0.5f;
-                    cc->_bufferIndex = renderTextureNo;
-                }
-            }
-            else if (layoutCount <= layoutCountMaxValue)
-            {
-                //9分割して使う
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    const csmInt32 xpos = i % 3;
-                    const csmInt32 ypos = i / 3;
-
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = channelNo;
-
-                    cc->_layoutBounds->X = xpos / 3.0f;
-                    cc->_layoutBounds->Y = ypos / 3.0f;
-                    cc->_layoutBounds->Width = 1.0f / 3.0f;
-                    cc->_layoutBounds->Height = 1.0f / 3.0f;
-                    cc->_bufferIndex = renderTextureNo;
-                }
-            }
-            // マスクの制限枚数を超えた場合の処理
-            else
-            {
-                csmInt32 count = usingClipCount - useClippingMaskMaxCount;
-
-
-                CubismLogError("not supported mask count : %d\n[Details] render texture count: %d\n, mask count : "
-                    , count, _renderTextureCount, usingClipCount);
-
-                // 開発モードの場合は停止させる
-                CSM_ASSERT(0);
-
-                // 引き続き実行する場合、 SetupShaderProgramでオーバーアクセスが発生するので仕方なく適当に入れておく
-                // もちろん描画結果はろくなことにならない
-                for (csmInt32 i = 0; i < layoutCount; i++)
-                {
-                    CubismClippingContext* cc = _clippingContextListForMask[curClipIndex++];
-                    cc->_layoutChannelNo = 0;
-                    cc->_layoutBounds->X = 0.0f;
-                    cc->_layoutBounds->Y = 0.0f;
-                    cc->_layoutBounds->Width = 1.0f;
-                    cc->_layoutBounds->Height = 1.0f;
-                    cc->_bufferIndex = 0;
-                }
-            }
+            _clearedMaskBufferFlags.PushBack(false);
         }
     }
-}
+    else
+    {
+        // マスクのクリアフラグを毎フレーム開始時に初期化
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+        {
+            _clearedMaskBufferFlags[i] = false;
+        }
+    }
 
-CubismRenderer::CubismTextureColor* CubismClippingManager_OpenGLES2::GetChannelFlagAsColor(csmInt32 channelNo)
-{
-    return _channelColors[channelNo];
-}
+    // 実際にマスクを生成する
+    // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // --- 実際に１つのマスクを描く ---
+        CubismClippingContext_OpenGLES2* clipContext = _clippingContextListForMask[clipIndex];
+        csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+        csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
+        const csmFloat32 MARGIN = 0.05f;
 
-csmVector<CubismClippingContext*>* CubismClippingManager_OpenGLES2::GetClippingContextListForDraw()
-{
-    return &_clippingContextListForDraw;
-}
+        // clipContextに設定したオフスクリーンサーフェイスをインデックスで取得
+        CubismOffscreenSurface_OpenGLES2* clipContextOffscreenSurface = renderer->GetMaskBuffer(clipContext->_bufferIndex);
 
-void CubismClippingManager_OpenGLES2::SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height)
-{
-    _clippingMaskBufferSize = CubismVector2(width, height);
-}
+        // 現在のオフスクリーンサーフェイスがclipContextのものと異なる場合
+        if (_currentMaskBuffer != clipContextOffscreenSurface)
+        {
+            _currentMaskBuffer->EndDraw();
+            _currentMaskBuffer = clipContextOffscreenSurface;
+            // マスク用RenderTextureをactiveにセット
+            _currentMaskBuffer->BeginDraw(lastFBO);
 
-CubismVector2 CubismClippingManager_OpenGLES2::GetClippingMaskBufferSize() const
-{
-    return _clippingMaskBufferSize;
-}
+            // バッファをクリアする。
+            renderer->PreDraw();
+        }
 
-csmInt32 CubismClippingManager_OpenGLES2::GetRenderTextureCount()
-{
-    return _renderTextureCount;
+        // モデル座標上の矩形を、適宜マージンを付けて使う
+        _tmpBoundsOnModel.SetRect(allClippedDrawRect);
+        _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, allClippedDrawRect->Height * MARGIN);
+        //########## 本来は割り当てられた領域の全体を使わず必要最低限のサイズがよい
+        // シェーダ用の計算式を求める。回転を考慮しない場合は以下のとおり
+        // movePeriod' = movePeriod * scaleX + offX     [[ movePeriod' = (movePeriod - tmpBoundsOnModel.movePeriod)*scale + layoutBoundsOnTex01.movePeriod ]]
+        csmFloat32 scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
+        csmFloat32 scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
+
+        // マスク生成時に使う行列を求める
+        createMatrixForMask(false, layoutBoundsOnTex01, scaleX, scaleY);
+
+        clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
+        clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
+
+        // 実際の描画を行う
+        const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
+        for (csmInt32 i = 0; i < clipDrawCount; i++)
+        {
+            const csmInt32 clipDrawIndex = clipContext->_clippingIdList[i];
+
+            // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
+            if (!model.GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
+            {
+                continue;
+            }
+
+            renderer->IsCulling(model.GetDrawableCulling(clipDrawIndex) != 0);
+
+            // マスクがクリアされていないなら処理する
+            if (!_clearedMaskBufferFlags[clipContext->_bufferIndex])
+            {
+                // マスクをクリアする
+                // 1が無効（描かれない）領域、0が有効（描かれる）領域。（シェーダーCd*Csで0に近い値をかけてマスクを作る。1をかけると何も起こらない）
+                glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+                glClear(GL_COLOR_BUFFER_BIT);
+                _clearedMaskBufferFlags[clipContext->_bufferIndex] = true;
+            }
+
+            // 今回専用の変換を適用して描く
+            // チャンネルも切り替える必要がある(A,R,G,B)
+            renderer->SetClippingContextBufferForMask(clipContext);
+
+            renderer->DrawMeshOpenGL(model, clipDrawIndex);
+        }
+    }
+
+    // --- 後処理 ---
+    _currentMaskBuffer->EndDraw();
+    renderer->SetClippingContextBufferForMask(NULL);
+    glViewport(lastViewport[0], lastViewport[1], lastViewport[2], lastViewport[3]);
 }
 
 /*********************************************************************************************************************
-*                                      CubismClippingContext
+*                                      CubismClippingContext_OpenGLES2
 ********************************************************************************************************************/
-CubismClippingContext::CubismClippingContext(CubismClippingManager_OpenGLES2* manager, const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+CubismClippingContext_OpenGLES2::CubismClippingContext_OpenGLES2(CubismClippingManager<CubismClippingContext_OpenGLES2, CubismOffscreenSurface_OpenGLES2>* manager, CubismModel& model, const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+    : CubismClippingContext(clippingDrawableIndices, clipCount)
 {
     _owner = manager;
-
-    // クリップしている（＝マスク用の）Drawableのインデックスリスト
-    _clippingIdList = clippingDrawableIndices;
-
-    // マスクの数
-    _clippingIdCount = clipCount;
-
-    _layoutChannelNo = 0;
-
-    _allClippedDrawRect = CSM_NEW csmRectF();
-    _layoutBounds = CSM_NEW csmRectF();
-
-    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
 }
 
-CubismClippingContext::~CubismClippingContext()
+CubismClippingContext_OpenGLES2::~CubismClippingContext_OpenGLES2()
 {
-    if (_layoutBounds != NULL)
-    {
-        CSM_DELETE(_layoutBounds);
-        _layoutBounds = NULL;
-    }
-
-    if (_allClippedDrawRect != NULL)
-    {
-        CSM_DELETE(_allClippedDrawRect);
-        _allClippedDrawRect = NULL;
-    }
-
-    if (_clippedDrawableIndexList != NULL)
-    {
-        CSM_DELETE(_clippedDrawableIndexList);
-        _clippedDrawableIndexList = NULL;
-    }
 }
 
-void CubismClippingContext::AddClippedDrawable(csmInt32 drawableIndex)
-{
-    _clippedDrawableIndexList->PushBack(drawableIndex);
-}
-
-CubismClippingManager_OpenGLES2* CubismClippingContext::GetClippingManager()
+CubismClippingManager<CubismClippingContext_OpenGLES2, CubismOffscreenSurface_OpenGLES2>* CubismClippingContext_OpenGLES2::GetClippingManager()
 {
     return _owner;
 }
-
-
 
 /*********************************************************************************************************************
 *                                      CubismDrawProfile_OpenGL
@@ -765,1058 +269,6 @@ void CubismRendererProfile_OpenGLES2::Restore()
     // restore blending
     glBlendFuncSeparate(_lastBlending[0], _lastBlending[1], _lastBlending[2], _lastBlending[3]);
 }
-
-
-/*********************************************************************************************************************
-*                                       CubismShader_OpenGLES2
-********************************************************************************************************************/
-namespace {
-    const csmInt32 ShaderCount = 19; ///< シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
-    CubismShader_OpenGLES2* s_instance;
-}
-
-enum ShaderNames
-{
-    // SetupMask
-    ShaderNames_SetupMask,
-
-    //Normal
-    ShaderNames_Normal,
-    ShaderNames_NormalMasked,
-    ShaderNames_NormalMaskedInverted,
-    ShaderNames_NormalPremultipliedAlpha,
-    ShaderNames_NormalMaskedPremultipliedAlpha,
-    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
-
-    //Add
-    ShaderNames_Add,
-    ShaderNames_AddMasked,
-    ShaderNames_AddMaskedInverted,
-    ShaderNames_AddPremultipliedAlpha,
-    ShaderNames_AddMaskedPremultipliedAlpha,
-    ShaderNames_AddMaskedPremultipliedAlphaInverted,
-
-    //Mult
-    ShaderNames_Mult,
-    ShaderNames_MultMasked,
-    ShaderNames_MultMaskedInverted,
-    ShaderNames_MultPremultipliedAlpha,
-    ShaderNames_MultMaskedPremultipliedAlpha,
-    ShaderNames_MultMaskedPremultipliedAlphaInverted,
-};
-
-void CubismShader_OpenGLES2::ReleaseShaderProgram()
-{
-    for (csmUint32 i = 0; i < _shaderSets.GetSize(); i++)
-    {
-        if (_shaderSets[i]->ShaderProgram)
-        {
-            glDeleteProgram(_shaderSets[i]->ShaderProgram);
-            _shaderSets[i]->ShaderProgram = 0;
-            CSM_DELETE(_shaderSets[i]);
-        }
-    }
-}
-
-// SetupMask
-static const csmChar* VertShaderSrcSetupMask =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-#else
-        "#version 120\n"
-#endif
-        "attribute vec4 a_position;"
-        "attribute vec2 a_texCoord;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
-        "uniform mat4 u_clipMatrix;"
-        "void main()"
-        "{"
-        "gl_Position = u_clipMatrix * a_position;"
-        "v_myPos = u_clipMatrix * a_position;"
-        "v_texCoord = a_texCoord;"
-        "v_texCoord.y = 1.0 - v_texCoord.y;"
-        "}";
-static const csmChar* FragShaderSrcSetupMask =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "void main()"
-        "{"
-        "float isInside = "
-        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcSetupMaskTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "void main()"
-        "{"
-        "float isInside = "
-        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-        "}";
-#endif
-
-//----- バーテックスシェーダプログラム -----
-// Normal & Add & Mult 共通
-static const csmChar* VertShaderSrc =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-#else
-        "#version 120\n"
-#endif
-        "attribute vec4 a_position;" //v.vertex
-        "attribute vec2 a_texCoord;" //v.texcoord
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform mat4 u_matrix;"
-        "void main()"
-        "{"
-        "gl_Position = u_matrix * a_position;"
-        "v_texCoord = a_texCoord;"
-        "v_texCoord.y = 1.0 - v_texCoord.y;"
-        "}";
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* VertShaderSrcMasked =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-#else
-        "#version 120\n"
-#endif
-        "attribute vec4 a_position;"
-        "attribute vec2 a_texCoord;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform mat4 u_matrix;"
-        "uniform mat4 u_clipMatrix;"
-        "void main()"
-        "{"
-        "gl_Position = u_matrix * a_position;"
-        "v_clipPos = u_clipMatrix * a_position;"
-        "v_texCoord = a_texCoord;"
-        "v_texCoord.y = 1.0 - v_texCoord.y;"
-        "}";
-
-//----- フラグメントシェーダプログラム -----
-// Normal & Add & Mult 共通
-static const csmChar* FragShaderSrc =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 color = texColor * u_baseColor;"
-        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 color = texColor * u_baseColor;"
-        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通 （PremultipliedAlpha）
-static const csmChar* FragShaderSrcPremultipliedAlpha =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "gl_FragColor = texColor * u_baseColor;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "gl_FragColor = texColor * u_baseColor;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* FragShaderSrcMask =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
-static const csmChar* FragShaderSrcMaskInverted =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskInvertedTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-CubismShader_OpenGLES2::CubismShader_OpenGLES2()
-{ }
-
-CubismShader_OpenGLES2::~CubismShader_OpenGLES2()
-{
-    ReleaseShaderProgram();
-}
-
-CubismShader_OpenGLES2* CubismShader_OpenGLES2::GetInstance()
-{
-    if (s_instance == NULL)
-    {
-        s_instance = CSM_NEW CubismShader_OpenGLES2();
-    }
-    return s_instance;
-}
-
-void CubismShader_OpenGLES2::DeleteInstance()
-{
-    if (s_instance)
-    {
-        CSM_DELETE_SELF(CubismShader_OpenGLES2, s_instance);
-        s_instance = NULL;
-    }
-}
-
-#ifdef CSM_TARGET_ANDROID_ES2
-csmBool CubismShader_OpenGLES2::s_extMode = false;
-csmBool CubismShader_OpenGLES2::s_extPAMode = false;
-void CubismShader_OpenGLES2::SetExtShaderMode(csmBool extMode, csmBool extPAMode) {
-    s_extMode = extMode;
-    s_extPAMode = extPAMode;
-}
-#endif
-
-void CubismShader_OpenGLES2::GenerateShaders()
-{
-    for (csmInt32 i = 0; i < ShaderCount; i++)
-    {
-        _shaderSets.PushBack(CSM_NEW CubismShaderSet());
-    }
-
-#ifdef CSM_TARGET_ANDROID_ES2
-    if (s_extMode)
-    {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskTegra);
-
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcTegra);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskTegra);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedTegra);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlphaTegra);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlphaTegra);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlphaTegra);
-    }
-    else
-    {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
-
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
-    }
-
-    // 加算も通常と同じシェーダーを利用する
-    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-    // 乗算も通常と同じシェーダーを利用する
-    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-#else
-
-    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
-
-    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
-    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
-    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
-    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
-    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
-    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
-
-    // 加算も通常と同じシェーダーを利用する
-    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-
-    // 乗算も通常と同じシェーダーを利用する
-    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
-    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
-    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
-    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
-    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
-    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
-#endif
-
-    // SetupMask
-    _shaderSets[0]->AttributePositionLocation = glGetAttribLocation(_shaderSets[0]->ShaderProgram, "a_position");
-    _shaderSets[0]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[0]->ShaderProgram, "a_texCoord");
-    _shaderSets[0]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "s_texture0");
-    _shaderSets[0]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[0]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_channelFlag");
-    _shaderSets[0]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_baseColor");
-    _shaderSets[0]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[0]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_screenColor");
-
-    // 通常
-    _shaderSets[1]->AttributePositionLocation = glGetAttribLocation(_shaderSets[1]->ShaderProgram, "a_position");
-    _shaderSets[1]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[1]->ShaderProgram, "a_texCoord");
-    _shaderSets[1]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "s_texture0");
-    _shaderSets[1]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_matrix");
-    _shaderSets[1]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_baseColor");
-    _shaderSets[1]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[1]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_screenColor");
-
-    // 通常（クリッピング）
-    _shaderSets[2]->AttributePositionLocation = glGetAttribLocation(_shaderSets[2]->ShaderProgram, "a_position");
-    _shaderSets[2]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[2]->ShaderProgram, "a_texCoord");
-    _shaderSets[2]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "s_texture0");
-    _shaderSets[2]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "s_texture1");
-    _shaderSets[2]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_matrix");
-    _shaderSets[2]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[2]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_channelFlag");
-    _shaderSets[2]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_baseColor");
-    _shaderSets[2]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[2]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_screenColor");
-
-    // 通常（クリッピング・反転）
-    _shaderSets[3]->AttributePositionLocation = glGetAttribLocation(_shaderSets[3]->ShaderProgram, "a_position");
-    _shaderSets[3]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[3]->ShaderProgram, "a_texCoord");
-    _shaderSets[3]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "s_texture0");
-    _shaderSets[3]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "s_texture1");
-    _shaderSets[3]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_matrix");
-    _shaderSets[3]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[3]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_channelFlag");
-    _shaderSets[3]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_baseColor");
-    _shaderSets[3]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[3]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_screenColor");
-
-    // 通常（PremultipliedAlpha）
-    _shaderSets[4]->AttributePositionLocation = glGetAttribLocation(_shaderSets[4]->ShaderProgram, "a_position");
-    _shaderSets[4]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[4]->ShaderProgram, "a_texCoord");
-    _shaderSets[4]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "s_texture0");
-    _shaderSets[4]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_matrix");
-    _shaderSets[4]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_baseColor");
-    _shaderSets[4]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[4]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_screenColor");
-
-    // 通常（クリッピング、PremultipliedAlpha）
-    _shaderSets[5]->AttributePositionLocation = glGetAttribLocation(_shaderSets[5]->ShaderProgram, "a_position");
-    _shaderSets[5]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[5]->ShaderProgram, "a_texCoord");
-    _shaderSets[5]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "s_texture0");
-    _shaderSets[5]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "s_texture1");
-    _shaderSets[5]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_matrix");
-    _shaderSets[5]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[5]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_channelFlag");
-    _shaderSets[5]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_baseColor");
-    _shaderSets[5]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[5]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_screenColor");
-
-    // 通常（クリッピング・反転、PremultipliedAlpha）
-    _shaderSets[6]->AttributePositionLocation = glGetAttribLocation(_shaderSets[6]->ShaderProgram, "a_position");
-    _shaderSets[6]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[6]->ShaderProgram, "a_texCoord");
-    _shaderSets[6]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "s_texture0");
-    _shaderSets[6]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "s_texture1");
-    _shaderSets[6]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_matrix");
-    _shaderSets[6]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[6]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_channelFlag");
-    _shaderSets[6]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_baseColor");
-    _shaderSets[6]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[6]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_screenColor");
-
-    // 加算
-    _shaderSets[7]->AttributePositionLocation = glGetAttribLocation(_shaderSets[7]->ShaderProgram, "a_position");
-    _shaderSets[7]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[7]->ShaderProgram, "a_texCoord");
-    _shaderSets[7]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "s_texture0");
-    _shaderSets[7]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_matrix");
-    _shaderSets[7]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_baseColor");
-    _shaderSets[7]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[7]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_screenColor");
-
-    // 加算（クリッピング）
-    _shaderSets[8]->AttributePositionLocation = glGetAttribLocation(_shaderSets[8]->ShaderProgram, "a_position");
-    _shaderSets[8]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[8]->ShaderProgram, "a_texCoord");
-    _shaderSets[8]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "s_texture0");
-    _shaderSets[8]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "s_texture1");
-    _shaderSets[8]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_matrix");
-    _shaderSets[8]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[8]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_channelFlag");
-    _shaderSets[8]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_baseColor");
-    _shaderSets[8]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[8]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_screenColor");
-
-    // 加算（クリッピング・反転）
-    _shaderSets[9]->AttributePositionLocation = glGetAttribLocation(_shaderSets[9]->ShaderProgram, "a_position");
-    _shaderSets[9]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[9]->ShaderProgram, "a_texCoord");
-    _shaderSets[9]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "s_texture0");
-    _shaderSets[9]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "s_texture1");
-    _shaderSets[9]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_matrix");
-    _shaderSets[9]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[9]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_channelFlag");
-    _shaderSets[9]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_baseColor");
-    _shaderSets[9]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[9]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_screenColor");
-
-    // 加算（PremultipliedAlpha）
-    _shaderSets[10]->AttributePositionLocation = glGetAttribLocation(_shaderSets[10]->ShaderProgram, "a_position");
-    _shaderSets[10]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[10]->ShaderProgram, "a_texCoord");
-    _shaderSets[10]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "s_texture0");
-    _shaderSets[10]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_matrix");
-    _shaderSets[10]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_baseColor");
-    _shaderSets[10]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[10]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_screenColor");
-
-    // 加算（クリッピング、PremultipliedAlpha）
-    _shaderSets[11]->AttributePositionLocation = glGetAttribLocation(_shaderSets[11]->ShaderProgram, "a_position");
-    _shaderSets[11]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[11]->ShaderProgram, "a_texCoord");
-    _shaderSets[11]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "s_texture0");
-    _shaderSets[11]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "s_texture1");
-    _shaderSets[11]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_matrix");
-    _shaderSets[11]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[11]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_channelFlag");
-    _shaderSets[11]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_baseColor");
-    _shaderSets[11]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[11]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_screenColor");
-
-    // 加算（クリッピング・反転、PremultipliedAlpha）
-    _shaderSets[12]->AttributePositionLocation = glGetAttribLocation(_shaderSets[12]->ShaderProgram, "a_position");
-    _shaderSets[12]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[12]->ShaderProgram, "a_texCoord");
-    _shaderSets[12]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "s_texture0");
-    _shaderSets[12]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "s_texture1");
-    _shaderSets[12]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_matrix");
-    _shaderSets[12]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[12]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_channelFlag");
-    _shaderSets[12]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_baseColor");
-    _shaderSets[12]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[12]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_screenColor");
-
-    // 乗算
-    _shaderSets[13]->AttributePositionLocation = glGetAttribLocation(_shaderSets[13]->ShaderProgram, "a_position");
-    _shaderSets[13]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[13]->ShaderProgram, "a_texCoord");
-    _shaderSets[13]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "s_texture0");
-    _shaderSets[13]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_matrix");
-    _shaderSets[13]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_baseColor");
-    _shaderSets[13]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[13]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_screenColor");
-
-    // 乗算（クリッピング）
-    _shaderSets[14]->AttributePositionLocation = glGetAttribLocation(_shaderSets[14]->ShaderProgram, "a_position");
-    _shaderSets[14]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[14]->ShaderProgram, "a_texCoord");
-    _shaderSets[14]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "s_texture0");
-    _shaderSets[14]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "s_texture1");
-    _shaderSets[14]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_matrix");
-    _shaderSets[14]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[14]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_channelFlag");
-    _shaderSets[14]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_baseColor");
-    _shaderSets[14]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[14]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_screenColor");
-
-    // 乗算（クリッピング・反転）
-    _shaderSets[15]->AttributePositionLocation = glGetAttribLocation(_shaderSets[15]->ShaderProgram, "a_position");
-    _shaderSets[15]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[15]->ShaderProgram, "a_texCoord");
-    _shaderSets[15]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "s_texture0");
-    _shaderSets[15]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "s_texture1");
-    _shaderSets[15]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_matrix");
-    _shaderSets[15]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[15]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_channelFlag");
-    _shaderSets[15]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_baseColor");
-    _shaderSets[15]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[15]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_screenColor");
-
-    // 乗算（PremultipliedAlpha）
-    _shaderSets[16]->AttributePositionLocation = glGetAttribLocation(_shaderSets[16]->ShaderProgram, "a_position");
-    _shaderSets[16]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[16]->ShaderProgram, "a_texCoord");
-    _shaderSets[16]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "s_texture0");
-    _shaderSets[16]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_matrix");
-    _shaderSets[16]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_baseColor");
-    _shaderSets[16]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[16]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_screenColor");
-
-    // 乗算（クリッピング、PremultipliedAlpha）
-    _shaderSets[17]->AttributePositionLocation = glGetAttribLocation(_shaderSets[17]->ShaderProgram, "a_position");
-    _shaderSets[17]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[17]->ShaderProgram, "a_texCoord");
-    _shaderSets[17]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "s_texture0");
-    _shaderSets[17]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "s_texture1");
-    _shaderSets[17]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_matrix");
-    _shaderSets[17]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[17]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_channelFlag");
-    _shaderSets[17]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_baseColor");
-    _shaderSets[17]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[17]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_screenColor");
-
-    // 乗算（クリッピング・反転、PremultipliedAlpha）
-    _shaderSets[18]->AttributePositionLocation = glGetAttribLocation(_shaderSets[18]->ShaderProgram, "a_position");
-    _shaderSets[18]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[18]->ShaderProgram, "a_texCoord");
-    _shaderSets[18]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "s_texture0");
-    _shaderSets[18]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "s_texture1");
-    _shaderSets[18]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_matrix");
-    _shaderSets[18]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_clipMatrix");
-    _shaderSets[18]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_channelFlag");
-    _shaderSets[18]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_baseColor");
-    _shaderSets[18]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[18]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_screenColor");
-}
-
-void CubismShader_OpenGLES2::SetupShaderProgram(CubismRenderer_OpenGLES2* renderer, GLuint textureId
-                                                , csmInt32 vertexCount, csmFloat32* vertexArray
-                                                , csmFloat32* uvArray, csmFloat32 opacity
-                                                , CubismRenderer::CubismBlendMode colorBlendMode
-                                                , CubismRenderer::CubismTextureColor baseColor
-                                                , CubismRenderer::CubismTextureColor multiplyColor
-                                                , CubismRenderer::CubismTextureColor screenColor
-                                                , csmBool isPremultipliedAlpha, CubismMatrix44 matrix4x4
-                                                , csmBool invertedMask)
-{
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders();
-    }
-
-    // Blending
-    csmInt32 SRC_COLOR;
-    csmInt32 DST_COLOR;
-    csmInt32 SRC_ALPHA;
-    csmInt32 DST_ALPHA;
-
-    if (renderer->GetClippingContextBufferForMask() != NULL) // マスク生成時
-    {
-        CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
-        glUseProgram(shaderSet->ShaderProgram);
-
-        //テクスチャ設定
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, textureId);
-        glUniform1i(shaderSet->SamplerTexture0Location, 0);
-
-        // 頂点配列の設定
-        glEnableVertexAttribArray(shaderSet->AttributePositionLocation);
-        glVertexAttribPointer(shaderSet->AttributePositionLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, vertexArray);
-        // テクスチャ頂点の設定
-        glEnableVertexAttribArray(shaderSet->AttributeTexCoordLocation);
-        glVertexAttribPointer(shaderSet->AttributeTexCoordLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, uvArray);
-
-        // チャンネル
-        const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
-        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
-        glUniform4f(shaderSet->UnifromChannelFlagLocation, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
-
-        glUniformMatrix4fv(shaderSet->UniformClipMatrixLocation, 1, GL_FALSE, renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray());
-
-        csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
-
-        glUniform4f(shaderSet->UniformBaseColorLocation,
-                    rect->X * 2.0f - 1.0f,
-                    rect->Y * 2.0f - 1.0f,
-                    rect->GetRight() * 2.0f - 1.0f,
-                    rect->GetBottom() * 2.0f - 1.0f);
-        glUniform4f(shaderSet->UniformMultiplyColorLocation, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A);
-        glUniform4f(shaderSet->UniformScreenColorLocation, screenColor.R, screenColor.G, screenColor.B, screenColor.A);
-
-        SRC_COLOR = GL_ZERO;
-        DST_COLOR = GL_ONE_MINUS_SRC_COLOR;
-        SRC_ALPHA = GL_ZERO;
-        DST_ALPHA = GL_ONE_MINUS_SRC_ALPHA;
-    }
-    else // マスク生成以外の場合
-    {
-        const csmBool masked = renderer->GetClippingContextBufferForDraw() != NULL;  // この描画オブジェクトはマスク対象か
-        const csmInt32 offset = (masked ? ( invertedMask ? 2 : 1 ) : 0) + (isPremultipliedAlpha ? 3 : 0);
-
-        CubismShaderSet* shaderSet;
-        switch (colorBlendMode)
-        {
-        case CubismRenderer::CubismBlendMode_Normal:
-        default:
-            shaderSet = _shaderSets[ShaderNames_Normal + offset];
-            SRC_COLOR = GL_ONE;
-            DST_COLOR = GL_ONE_MINUS_SRC_ALPHA;
-            SRC_ALPHA = GL_ONE;
-            DST_ALPHA = GL_ONE_MINUS_SRC_ALPHA;
-            break;
-
-        case CubismRenderer::CubismBlendMode_Additive:
-            shaderSet = _shaderSets[ShaderNames_Add + offset];
-            SRC_COLOR = GL_ONE;
-            DST_COLOR = GL_ONE;
-            SRC_ALPHA = GL_ZERO;
-            DST_ALPHA = GL_ONE;
-            break;
-
-        case CubismRenderer::CubismBlendMode_Multiplicative:
-            shaderSet = _shaderSets[ShaderNames_Mult + offset];
-            SRC_COLOR = GL_DST_COLOR;
-            DST_COLOR = GL_ONE_MINUS_SRC_ALPHA;
-            SRC_ALPHA = GL_ZERO;
-            DST_ALPHA = GL_ONE;
-            break;
-        }
-
-        glUseProgram(shaderSet->ShaderProgram);
-
-        // 頂点配列の設定
-        glEnableVertexAttribArray(shaderSet->AttributePositionLocation);
-        glVertexAttribPointer(shaderSet->AttributePositionLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, vertexArray);
-        // テクスチャ頂点の設定
-        glEnableVertexAttribArray(shaderSet->AttributeTexCoordLocation);
-        glVertexAttribPointer(shaderSet->AttributeTexCoordLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, uvArray);
-
-        if (masked)
-        {
-            glActiveTexture(GL_TEXTURE1);
-
-            // frameBufferに書かれたテクスチャ
-            GLuint tex = renderer->GetMaskBuffer(renderer->GetClippingContextBufferForDraw()->_bufferIndex)->GetColorBuffer();
-
-            glBindTexture(GL_TEXTURE_2D, tex);
-            glUniform1i(shaderSet->SamplerTexture1Location, 1);
-
-            // View座標をClippingContextの座標に変換するための行列を設定
-            glUniformMatrix4fv(shaderSet->UniformClipMatrixLocation, 1, 0, renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray());
-
-            // 使用するカラーチャンネルを設定
-            const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
-            CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
-            glUniform4f(shaderSet->UnifromChannelFlagLocation, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
-        }
-
-        //テクスチャ設定
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, textureId);
-        glUniform1i(shaderSet->SamplerTexture0Location, 0);
-
-        //座標変換
-        glUniformMatrix4fv(shaderSet->UniformMatrixLocation, 1, 0, matrix4x4.GetArray()); //
-
-        glUniform4f(shaderSet->UniformBaseColorLocation, baseColor.R, baseColor.G, baseColor.B, baseColor.A);
-        glUniform4f(shaderSet->UniformMultiplyColorLocation, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A);
-        glUniform4f(shaderSet->UniformScreenColorLocation, screenColor.R, screenColor.G, screenColor.B, screenColor.A);
-    }
-
-    glBlendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
-}
-
-csmBool CubismShader_OpenGLES2::CompileShaderSource(GLuint* outShader, GLenum shaderType, const csmChar* shaderSource)
-{
-    GLint status;
-    const GLchar* source = shaderSource;
-
-    *outShader = glCreateShader(shaderType);
-    glShaderSource(*outShader, 1, &source, NULL);
-    glCompileShader(*outShader);
-
-    GLint logLength;
-    glGetShaderiv(*outShader, GL_INFO_LOG_LENGTH, &logLength);
-    if (logLength > 0)
-    {
-        GLchar* log = reinterpret_cast<GLchar*>(CSM_MALLOC(logLength));
-        glGetShaderInfoLog(*outShader, logLength, &logLength, log);
-        CubismLogError("Shader compile log: %s", log);
-        CSM_FREE(log);
-    }
-
-    glGetShaderiv(*outShader, GL_COMPILE_STATUS, &status);
-    if (status == GL_FALSE)
-    {
-        glDeleteShader(*outShader);
-        return false;
-    }
-
-    return true;
-}
-
-csmBool CubismShader_OpenGLES2::LinkProgram(GLuint shaderProgram)
-{
-    GLint status;
-    glLinkProgram(shaderProgram);
-
-    GLint logLength;
-    glGetProgramiv(shaderProgram, GL_INFO_LOG_LENGTH, &logLength);
-    if (logLength > 0)
-    {
-        GLchar* log = reinterpret_cast<GLchar*>(CSM_MALLOC(logLength));
-        glGetProgramInfoLog(shaderProgram, logLength, &logLength, log);
-        CubismLogError("Program link log: %s", log);
-        CSM_FREE(log);
-    }
-
-    glGetProgramiv(shaderProgram, GL_LINK_STATUS, &status);
-    if (status == GL_FALSE)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-csmBool CubismShader_OpenGLES2::ValidateProgram(GLuint shaderProgram)
-{
-    GLint logLength, status;
-
-    glValidateProgram(shaderProgram);
-    glGetProgramiv(shaderProgram, GL_INFO_LOG_LENGTH, &logLength);
-    if (logLength > 0)
-    {
-        GLchar* log = reinterpret_cast<GLchar*>(CSM_MALLOC(logLength));
-        glGetProgramInfoLog(shaderProgram, logLength, &logLength, log);
-        CubismLogError("Validate program log: %s", log);
-        CSM_FREE(log);
-    }
-
-    glGetProgramiv(shaderProgram, GL_VALIDATE_STATUS, &status);
-    if (status == GL_FALSE)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-GLuint CubismShader_OpenGLES2::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
-{
-    GLuint vertShader, fragShader;
-
-    // Create shader program.
-    GLuint shaderProgram = glCreateProgram();
-
-    if (!CompileShaderSource(&vertShader, GL_VERTEX_SHADER, vertShaderSrc))
-    {
-        CubismLogError("Vertex shader compile error!");
-        return 0;
-    }
-
-    // Create and compile fragment shader.
-    if (!CompileShaderSource(&fragShader, GL_FRAGMENT_SHADER, fragShaderSrc))
-    {
-        CubismLogError("Fragment shader compile error!");
-        return 0;
-    }
-
-    // Attach vertex shader to program.
-    glAttachShader(shaderProgram, vertShader);
-
-    // Attach fragment shader to program.
-    glAttachShader(shaderProgram, fragShader);
-
-    // Link program.
-    if (!LinkProgram(shaderProgram))
-    {
-        CubismLogError("Failed to link program: %d", shaderProgram);
-
-        if (vertShader)
-        {
-            glDeleteShader(vertShader);
-            vertShader = 0;
-        }
-        if (fragShader)
-        {
-            glDeleteShader(fragShader);
-            fragShader = 0;
-        }
-        if (shaderProgram)
-        {
-            glDeleteProgram(shaderProgram);
-            shaderProgram = 0;
-        }
-
-        return 0;
-    }
-
-    // Release vertex and fragment shaders.
-    if (vertShader)
-    {
-        glDetachShader(shaderProgram, vertShader);
-        glDeleteShader(vertShader);
-    }
-
-    if (fragShader)
-    {
-        glDetachShader(shaderProgram, fragShader);
-        glDeleteShader(fragShader);
-    }
-
-    return shaderProgram;
-}
-
 
 /*********************************************************************************************************************
  *                                      CubismRenderer_OpenGLES2
@@ -1989,14 +441,14 @@ CubismRenderer_OpenGLES2::~CubismRenderer_OpenGLES2()
 {
     CSM_DELETE_SELF(CubismClippingManager_OpenGLES2, _clippingManager);
 
-    for (csmInt32 i = 0; i < _offscreenFrameBuffers.GetSize(); ++i)
+    for (csmInt32 i = 0; i < _offscreenSurfaces.GetSize(); ++i)
     {
-        if (_offscreenFrameBuffers[i].IsValid())
+        if (_offscreenSurfaces[i].IsValid())
         {
-            _offscreenFrameBuffers[i].DestroyOffscreenFrame();
+            _offscreenSurfaces[i].DestroyOffscreenSurface();
         }
     }
-    _offscreenFrameBuffers.Clear();
+    _offscreenSurfaces.Clear();
 }
 
 void CubismRenderer_OpenGLES2::DoStaticRelease()
@@ -2027,18 +479,15 @@ void CubismRenderer_OpenGLES2::Initialize(CubismModel* model, csmInt32 maskBuffe
         _clippingManager = CSM_NEW CubismClippingManager_OpenGLES2();  //クリッピングマスク・バッファ前処理方式を初期化
         _clippingManager->Initialize(
             *model,
-            model->GetDrawableCount(),
-            model->GetDrawableMasks(),
-            model->GetDrawableMaskCounts(),
             maskBufferCount
         );
 
-        _offscreenFrameBuffers.Clear();
+        _offscreenSurfaces.Clear();
         for (csmInt32 i = 0; i < maskBufferCount; ++i)
         {
-            CubismOffscreenFrame_OpenGLES2 offscreenSurface;
-            offscreenSurface.CreateOffscreenFrame(_clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
-            _offscreenFrameBuffers.PushBack(offscreenSurface);
+            CubismOffscreenSurface_OpenGLES2 offscreenSurface;
+            offscreenSurface.CreateOffscreenSurface(_clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
+            _offscreenSurfaces.PushBack(offscreenSurface);
         }
 
     }
@@ -2091,15 +540,22 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
         // サイズが違う場合はここで作成しなおし
         for (csmInt32 i = 0; i < _clippingManager->GetRenderTextureCount(); ++i)
         {
-            if (_offscreenFrameBuffers[i].GetBufferWidth() != static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().X) ||
-                _offscreenFrameBuffers[i].GetBufferHeight() != static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().Y))
+            if (_offscreenSurfaces[i].GetBufferWidth() != static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().X) ||
+                _offscreenSurfaces[i].GetBufferHeight() != static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().Y))
             {
-                _offscreenFrameBuffers[i].CreateOffscreenFrame(
+                _offscreenSurfaces[i].CreateOffscreenSurface(
                     static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().X), static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().Y));
             }
         }
 
-        _clippingManager->SetupClippingContext(*GetModel(), this, _rendererProfile._lastFBO, _rendererProfile._lastViewport);
+        if (IsUsingHighPrecisionMask())
+        {
+           _clippingManager->SetupMatrixForHighPrecision(*GetModel(), false);
+        }
+        else
+        {
+           _clippingManager->SetupClippingContext(*GetModel(), this, _rendererProfile._lastFBO, _rendererProfile._lastViewport);
+        }
     }
 
     // 上記クリッピング処理内でも一度PreDrawを呼ぶので注意!!
@@ -2127,7 +583,7 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
         }
 
         // クリッピングマスク
-        CubismClippingContext* clipContext = (_clippingManager != NULL)
+        CubismClippingContext_OpenGLES2* clipContext = (_clippingManager != NULL)
             ? (*_clippingManager->GetClippingContextListForDraw())[drawableIndex]
             : NULL;
 
@@ -2135,7 +591,7 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
         {
             if(clipContext->_isUsing) // 書くことになっていた
             {
-                // 生成したFrameBufferと同じサイズでビューポートを設定
+                // 生成したOffscreenSurfaceと同じサイズでビューポートを設定
                 glViewport(0, 0, _clippingManager->GetClippingMaskBufferSize().X, _clippingManager->GetClippingMaskBufferSize().Y);
 
                 PreDraw(); // バッファをクリアする
@@ -2168,19 +624,7 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
                     // チャンネルも切り替える必要がある(A,R,G,B)
                     SetClippingContextBufferForMask(clipContext);
 
-                    DrawMeshOpenGL(
-                        GetModel()->GetDrawableTextureIndex(clipDrawIndex),
-                        GetModel()->GetDrawableVertexIndexCount(clipDrawIndex),
-                        GetModel()->GetDrawableVertexCount(clipDrawIndex),
-                        const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(clipDrawIndex)),
-                        const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(clipDrawIndex)),
-                        reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(clipDrawIndex))),
-                        GetModel()->GetMultiplyColor(clipDrawIndex),
-                        GetModel()->GetScreenColor(clipDrawIndex),
-                        GetModel()->GetDrawableOpacity(clipDrawIndex),
-                        CubismRenderer::CubismBlendMode_Normal,   //クリッピングは通常描画を強制
-                        false // マスク生成時はクリッピングの反転使用は全く関係がない
-                    );
+                    DrawMeshOpenGL(*GetModel(), clipDrawIndex);
                 }
             }
 
@@ -2199,37 +643,14 @@ void CubismRenderer_OpenGLES2::DoDrawModel()
 
         IsCulling(GetModel()->GetDrawableCulling(drawableIndex) != 0);
 
-        DrawMeshOpenGL(
-            GetModel()->GetDrawableTextureIndex(drawableIndex),
-            GetModel()->GetDrawableVertexIndexCount(drawableIndex),
-            GetModel()->GetDrawableVertexCount(drawableIndex),
-            const_cast<csmUint16*>(GetModel()->GetDrawableVertexIndices(drawableIndex)),
-            const_cast<csmFloat32*>(GetModel()->GetDrawableVertices(drawableIndex)),
-            reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(GetModel()->GetDrawableVertexUvs(drawableIndex))),
-            GetModel()->GetMultiplyColor(drawableIndex),
-            GetModel()->GetScreenColor(drawableIndex),
-            GetModel()->GetDrawableOpacity(drawableIndex),
-            GetModel()->GetDrawableBlendMode(drawableIndex),
-            GetModel()->GetDrawableInvertedMask(drawableIndex) // マスクを反転使用するか
-        );
+        DrawMeshOpenGL(*GetModel(), drawableIndex);
     }
 
     PostDraw();
 
 }
 
-void CubismRenderer_OpenGLES2::DrawMesh(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
-    , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
-    , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask)
-{
-    CubismLogWarning("Use 'DrawMeshOpenGL' function");
-    CSM_ASSERT(0);
-}
-
-void CubismRenderer_OpenGLES2::DrawMeshOpenGL(csmInt32 textureNo, csmInt32 indexCount, csmInt32 vertexCount
-                                        , csmUint16* indexArray, csmFloat32* vertexArray, csmFloat32* uvArray
-                                        , const CubismTextureColor& multiplyColor, const CubismTextureColor& screenColor
-                                        , csmFloat32 opacity, CubismBlendMode colorBlendMode, csmBool invertedMask)
+void CubismRenderer_OpenGLES2::DrawMeshOpenGL(const CubismModel& model, const csmInt32 index)
 {
 
 #ifdef CSM_TARGET_WIN_GL
@@ -2237,7 +658,7 @@ void CubismRenderer_OpenGLES2::DrawMeshOpenGL(csmInt32 textureNo, csmInt32 index
 #endif
 
 #ifndef CSM_DEBUG
-    if (_textures[textureNo] == 0) return;    // モデルが参照するテクスチャがバインドされていない場合は描画をスキップする
+    if (_textures[model.GetDrawableTextureIndex(index)] == 0) return;    // モデルが参照するテクスチャがバインドされていない場合は描画をスキップする
 #endif
 
     // 裏面描画の有効・無効
@@ -2252,40 +673,20 @@ void CubismRenderer_OpenGLES2::DrawMeshOpenGL(csmInt32 textureNo, csmInt32 index
 
     glFrontFace(GL_CCW);    // Cubism SDK OpenGLはマスク・アートメッシュ共にCCWが表面
 
-    CubismTextureColor modelColorRGBA = GetModelColor();
-
-    if (GetClippingContextBufferForMask() == NULL) // マスク生成時以外
+    if (IsGeneratingMask())  // マスク生成時
     {
-        modelColorRGBA.A *= opacity;
-        if (IsPremultipliedAlpha())
-        {
-            modelColorRGBA.R *= modelColorRGBA.A;
-            modelColorRGBA.G *= modelColorRGBA.A;
-            modelColorRGBA.B *= modelColorRGBA.A;
-        }
+        CubismShader_OpenGLES2::GetInstance()->SetupShaderProgramForMask(this, model, index);
     }
-
-    GLuint drawTextureId;   // シェーダに渡すテクスチャID
-
-    // テクスチャマップからバインド済みテクスチャIDを取得
-    // バインドされていなければダミーのテクスチャIDをセットする
-    if(_textures[textureNo] != 0)
-    {
-        drawTextureId = _textures[textureNo];
+    else{
+        CubismShader_OpenGLES2::GetInstance()->SetupShaderProgramForDraw(this, model, index);
     }
-    else
-    {
-        drawTextureId = -1;
-    }
-
-    CubismShader_OpenGLES2::GetInstance()->SetupShaderProgram(
-        this, drawTextureId, vertexCount, vertexArray, uvArray
-        , opacity, colorBlendMode, modelColorRGBA, multiplyColor, screenColor, IsPremultipliedAlpha()
-        , GetMvpMatrix(), invertedMask
-    );
 
     // ポリゴンメッシュを描画する
-    glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_SHORT, indexArray);
+    {
+        csmInt32 indexCount = model.GetDrawableVertexIndexCount(index);
+        csmUint16* indexArray = const_cast<csmUint16*>(model.GetDrawableVertexIndices(index));
+        glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_SHORT, indexArray);
+    }
 
     // 後処理
     glUseProgram(0);
@@ -2323,7 +724,7 @@ void CubismRenderer_OpenGLES2::SetClippingMaskBufferSize(csmFloat32 width, csmFl
     // インスタンス破棄前にレンダーテクスチャの数を保存
     const csmInt32 renderTextureCount = _clippingManager->GetRenderTextureCount();
 
-    //FrameBufferのサイズを変更するためにインスタンスを破棄・再作成する
+    //OffscreenSurfaceのサイズを変更するためにインスタンスを破棄・再作成する
     CSM_DELETE_SELF(CubismClippingManager_OpenGLES2, _clippingManager);
 
     _clippingManager = CSM_NEW CubismClippingManager_OpenGLES2();
@@ -2332,9 +733,6 @@ void CubismRenderer_OpenGLES2::SetClippingMaskBufferSize(csmFloat32 width, csmFl
 
     _clippingManager->Initialize(
         *GetModel(),
-        GetModel()->GetDrawableCount(),
-        GetModel()->GetDrawableMasks(),
-        GetModel()->GetDrawableMaskCounts(),
         renderTextureCount
     );
 }
@@ -2349,29 +747,39 @@ CubismVector2 CubismRenderer_OpenGLES2::GetClippingMaskBufferSize() const
     return _clippingManager->GetClippingMaskBufferSize();
 }
 
-CubismOffscreenFrame_OpenGLES2* CubismRenderer_OpenGLES2::GetMaskBuffer(csmInt32 index)
+CubismOffscreenSurface_OpenGLES2* CubismRenderer_OpenGLES2::GetMaskBuffer(csmInt32 index)
 {
-    return &_offscreenFrameBuffers[index];
+    return &_offscreenSurfaces[index];
 }
 
-void CubismRenderer_OpenGLES2::SetClippingContextBufferForMask(CubismClippingContext* clip)
+void CubismRenderer_OpenGLES2::SetClippingContextBufferForMask(CubismClippingContext_OpenGLES2* clip)
 {
     _clippingContextBufferForMask = clip;
 }
 
-CubismClippingContext* CubismRenderer_OpenGLES2::GetClippingContextBufferForMask() const
+CubismClippingContext_OpenGLES2* CubismRenderer_OpenGLES2::GetClippingContextBufferForMask() const
 {
     return _clippingContextBufferForMask;
 }
 
-void CubismRenderer_OpenGLES2::SetClippingContextBufferForDraw(CubismClippingContext* clip)
+void CubismRenderer_OpenGLES2::SetClippingContextBufferForDraw(CubismClippingContext_OpenGLES2* clip)
 {
     _clippingContextBufferForDraw = clip;
 }
 
-CubismClippingContext* CubismRenderer_OpenGLES2::GetClippingContextBufferForDraw() const
+CubismClippingContext_OpenGLES2* CubismRenderer_OpenGLES2::GetClippingContextBufferForDraw() const
 {
     return _clippingContextBufferForDraw;
+}
+
+const csmBool inline CubismRenderer_OpenGLES2::IsGeneratingMask() const
+{
+    return (GetClippingContextBufferForMask() != NULL);
+}
+
+GLuint CubismRenderer_OpenGLES2::GetBindedTextureId(csmInt32 textureId)
+{
+    return (_textures[textureId] != 0) ? _textures[textureId] : -1;
 }
 
 }}}}

--- a/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
@@ -1,0 +1,1103 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismShader_OpenGLES2.hpp"
+#include <float.h>
+#include "Type/csmRectF.hpp"
+
+#ifdef CSM_TARGET_WIN_GL
+#include <Windows.h>
+#endif
+
+#define CSM_FRAGMENT_SHADER_FP_PRECISION_HIGH "highp"
+#define CSM_FRAGMENT_SHADER_FP_PRECISION_MID "mediump"
+#define CSM_FRAGMENT_SHADER_FP_PRECISION_LOW "lowp"
+
+#define CSM_FRAGMENT_SHADER_FP_PRECISION CSM_FRAGMENT_SHADER_FP_PRECISION_HIGH
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/*********************************************************************************************************************
+*                                       CubismShader_OpenGLES2
+********************************************************************************************************************/
+namespace {
+    const csmInt32 ShaderCount = 19; ///< シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
+    CubismShader_OpenGLES2* s_instance;
+}
+
+enum ShaderNames
+{
+    // SetupMask
+    ShaderNames_SetupMask,
+
+    //Normal
+    ShaderNames_Normal,
+    ShaderNames_NormalMasked,
+    ShaderNames_NormalMaskedInverted,
+    ShaderNames_NormalPremultipliedAlpha,
+    ShaderNames_NormalMaskedPremultipliedAlpha,
+    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
+
+    //Add
+    ShaderNames_Add,
+    ShaderNames_AddMasked,
+    ShaderNames_AddMaskedInverted,
+    ShaderNames_AddPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlphaInverted,
+
+    //Mult
+    ShaderNames_Mult,
+    ShaderNames_MultMasked,
+    ShaderNames_MultMaskedInverted,
+    ShaderNames_MultPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlphaInverted,
+};
+
+// SetupMask
+static const csmChar* VertShaderSrcSetupMask =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+#else
+        "#version 120\n"
+#endif
+        "attribute vec4 a_position;"
+        "attribute vec2 a_texCoord;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_myPos;"
+        "uniform mat4 u_clipMatrix;"
+        "void main()"
+        "{"
+        "gl_Position = u_clipMatrix * a_position;"
+        "v_myPos = u_clipMatrix * a_position;"
+        "v_texCoord = a_texCoord;"
+        "v_texCoord.y = 1.0 - v_texCoord.y;"
+        "}";
+static const csmChar* FragShaderSrcSetupMask =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_myPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "void main()"
+        "{"
+        "float isInside = "
+        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
+        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
+        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
+        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
+
+        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcSetupMaskTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_myPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "void main()"
+        "{"
+        "float isInside = "
+        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
+        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
+        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
+        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
+
+        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
+        "}";
+#endif
+
+//----- バーテックスシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* VertShaderSrc =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+#else
+        "#version 120\n"
+#endif
+        "attribute vec4 a_position;" //v.vertex
+        "attribute vec2 a_texCoord;" //v.texcoord
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform mat4 u_matrix;"
+        "void main()"
+        "{"
+        "gl_Position = u_matrix * a_position;"
+        "v_texCoord = a_texCoord;"
+        "v_texCoord.y = 1.0 - v_texCoord.y;"
+        "}";
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* VertShaderSrcMasked =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+#else
+        "#version 120\n"
+#endif
+        "attribute vec4 a_position;"
+        "attribute vec2 a_texCoord;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform mat4 u_matrix;"
+        "uniform mat4 u_clipMatrix;"
+        "void main()"
+        "{"
+        "gl_Position = u_matrix * a_position;"
+        "v_clipPos = u_clipMatrix * a_position;"
+        "v_texCoord = a_texCoord;"
+        "v_texCoord.y = 1.0 - v_texCoord.y;"
+        "}";
+
+//----- フラグメントシェーダプログラム -----
+// Normal & Add & Mult 共通
+static const csmChar* FragShaderSrc =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform sampler2D s_texture0;" //_MainTex
+        "uniform vec4 u_baseColor;" //v2f.color
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 color = texColor * u_baseColor;"
+        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform sampler2D s_texture0;" //_MainTex
+        "uniform vec4 u_baseColor;" //v2f.color
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 color = texColor * u_baseColor;"
+        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
+        "}";
+#endif
+
+// Normal & Add & Mult 共通 （PremultipliedAlpha）
+static const csmChar* FragShaderSrcPremultipliedAlpha =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform sampler2D s_texture0;" //_MainTex
+        "uniform vec4 u_baseColor;" //v2f.color
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+        "gl_FragColor = texColor * u_baseColor;"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;" //v2f.texcoord
+        "uniform sampler2D s_texture0;" //_MainTex
+        "uniform vec4 u_baseColor;" //v2f.color
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+        "gl_FragColor = texColor * u_baseColor;"
+        "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+static const csmChar* FragShaderSrcMask =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * maskVal;"
+        "gl_FragColor = col_formask;"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * maskVal;"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
+static const csmChar* FragShaderSrcMaskInverted =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * (1.0 - maskVal);"
+        "gl_FragColor = col_formask;"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskInvertedTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * (1.0 - maskVal);"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * maskVal;"
+        "gl_FragColor = col_formask;"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * maskVal;"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
+#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2)
+        "#version 100\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+#else
+        "#version 120\n"
+#endif
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * (1.0 - maskVal);"
+        "gl_FragColor = col_formask;"
+        "}";
+#if defined(CSM_TARGET_ANDROID_ES2)
+static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
+        "#version 100\n"
+        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
+        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
+        "varying vec2 v_texCoord;"
+        "varying vec4 v_clipPos;"
+        "uniform sampler2D s_texture0;"
+        "uniform sampler2D s_texture1;"
+        "uniform vec4 u_channelFlag;"
+        "uniform vec4 u_baseColor;"
+        "uniform vec4 u_multiplyColor;"
+        "uniform vec4 u_screenColor;"
+        "void main()"
+        "{"
+        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
+        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
+        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
+        "vec4 col_formask = texColor * u_baseColor;"
+        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
+        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
+        "col_formask = col_formask * (1.0 - maskVal);"
+        "gl_FragColor = col_formask;"
+        "}";
+#endif
+
+void CubismShader_OpenGLES2::ReleaseShaderProgram()
+{
+    for (csmUint32 i = 0; i < _shaderSets.GetSize(); i++)
+    {
+        if (_shaderSets[i]->ShaderProgram)
+        {
+            glDeleteProgram(_shaderSets[i]->ShaderProgram);
+            _shaderSets[i]->ShaderProgram = 0;
+            CSM_DELETE(_shaderSets[i]);
+        }
+    }
+}
+
+CubismShader_OpenGLES2::CubismShader_OpenGLES2()
+{ }
+
+CubismShader_OpenGLES2::~CubismShader_OpenGLES2()
+{
+    ReleaseShaderProgram();
+}
+
+CubismShader_OpenGLES2* CubismShader_OpenGLES2::GetInstance()
+{
+    if (s_instance == NULL)
+    {
+        s_instance = CSM_NEW CubismShader_OpenGLES2();
+    }
+    return s_instance;
+}
+
+void CubismShader_OpenGLES2::DeleteInstance()
+{
+    if (s_instance)
+    {
+        CSM_DELETE_SELF(CubismShader_OpenGLES2, s_instance);
+        s_instance = NULL;
+    }
+}
+
+#ifdef CSM_TARGET_ANDROID_ES2
+csmBool CubismShader_OpenGLES2::s_extMode = false;
+csmBool CubismShader_OpenGLES2::s_extPAMode = false;
+void CubismShader_OpenGLES2::SetExtShaderMode(csmBool extMode, csmBool extPAMode) {
+    s_extMode = extMode;
+    s_extPAMode = extPAMode;
+}
+#endif
+
+void CubismShader_OpenGLES2::GenerateShaders()
+{
+    for (csmInt32 i = 0; i < ShaderCount; i++)
+    {
+        _shaderSets.PushBack(CSM_NEW CubismShaderSet());
+    }
+
+#ifdef CSM_TARGET_ANDROID_ES2
+    if (s_extMode)
+    {
+        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskTegra);
+
+        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcTegra);
+        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskTegra);
+        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedTegra);
+        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlphaTegra);
+        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlphaTegra);
+        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlphaTegra);
+    }
+    else
+    {
+        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+
+        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
+        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
+        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
+        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
+        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
+        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+    }
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+#else
+
+    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+
+    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
+    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
+    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
+    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
+    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
+    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+
+    // 加算も通常と同じシェーダーを利用する
+    _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[8]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[9]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[10]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[11]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[12]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+
+    // 乗算も通常と同じシェーダーを利用する
+    _shaderSets[13]->ShaderProgram = _shaderSets[1]->ShaderProgram;
+    _shaderSets[14]->ShaderProgram = _shaderSets[2]->ShaderProgram;
+    _shaderSets[15]->ShaderProgram = _shaderSets[3]->ShaderProgram;
+    _shaderSets[16]->ShaderProgram = _shaderSets[4]->ShaderProgram;
+    _shaderSets[17]->ShaderProgram = _shaderSets[5]->ShaderProgram;
+    _shaderSets[18]->ShaderProgram = _shaderSets[6]->ShaderProgram;
+#endif
+
+    // SetupMask
+    _shaderSets[0]->AttributePositionLocation = glGetAttribLocation(_shaderSets[0]->ShaderProgram, "a_position");
+    _shaderSets[0]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[0]->ShaderProgram, "a_texCoord");
+    _shaderSets[0]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "s_texture0");
+    _shaderSets[0]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[0]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_channelFlag");
+    _shaderSets[0]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_baseColor");
+    _shaderSets[0]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[0]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[0]->ShaderProgram, "u_screenColor");
+
+    // 通常
+    _shaderSets[1]->AttributePositionLocation = glGetAttribLocation(_shaderSets[1]->ShaderProgram, "a_position");
+    _shaderSets[1]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[1]->ShaderProgram, "a_texCoord");
+    _shaderSets[1]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "s_texture0");
+    _shaderSets[1]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_matrix");
+    _shaderSets[1]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_baseColor");
+    _shaderSets[1]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[1]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[1]->ShaderProgram, "u_screenColor");
+
+    // 通常（クリッピング）
+    _shaderSets[2]->AttributePositionLocation = glGetAttribLocation(_shaderSets[2]->ShaderProgram, "a_position");
+    _shaderSets[2]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[2]->ShaderProgram, "a_texCoord");
+    _shaderSets[2]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "s_texture0");
+    _shaderSets[2]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "s_texture1");
+    _shaderSets[2]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_matrix");
+    _shaderSets[2]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[2]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_channelFlag");
+    _shaderSets[2]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_baseColor");
+    _shaderSets[2]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[2]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[2]->ShaderProgram, "u_screenColor");
+
+    // 通常（クリッピング・反転）
+    _shaderSets[3]->AttributePositionLocation = glGetAttribLocation(_shaderSets[3]->ShaderProgram, "a_position");
+    _shaderSets[3]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[3]->ShaderProgram, "a_texCoord");
+    _shaderSets[3]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "s_texture0");
+    _shaderSets[3]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "s_texture1");
+    _shaderSets[3]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_matrix");
+    _shaderSets[3]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[3]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_channelFlag");
+    _shaderSets[3]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_baseColor");
+    _shaderSets[3]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[3]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[3]->ShaderProgram, "u_screenColor");
+
+    // 通常（PremultipliedAlpha）
+    _shaderSets[4]->AttributePositionLocation = glGetAttribLocation(_shaderSets[4]->ShaderProgram, "a_position");
+    _shaderSets[4]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[4]->ShaderProgram, "a_texCoord");
+    _shaderSets[4]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "s_texture0");
+    _shaderSets[4]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_matrix");
+    _shaderSets[4]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_baseColor");
+    _shaderSets[4]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[4]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[4]->ShaderProgram, "u_screenColor");
+
+    // 通常（クリッピング、PremultipliedAlpha）
+    _shaderSets[5]->AttributePositionLocation = glGetAttribLocation(_shaderSets[5]->ShaderProgram, "a_position");
+    _shaderSets[5]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[5]->ShaderProgram, "a_texCoord");
+    _shaderSets[5]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "s_texture0");
+    _shaderSets[5]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "s_texture1");
+    _shaderSets[5]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_matrix");
+    _shaderSets[5]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[5]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_channelFlag");
+    _shaderSets[5]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_baseColor");
+    _shaderSets[5]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[5]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[5]->ShaderProgram, "u_screenColor");
+
+    // 通常（クリッピング・反転、PremultipliedAlpha）
+    _shaderSets[6]->AttributePositionLocation = glGetAttribLocation(_shaderSets[6]->ShaderProgram, "a_position");
+    _shaderSets[6]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[6]->ShaderProgram, "a_texCoord");
+    _shaderSets[6]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "s_texture0");
+    _shaderSets[6]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "s_texture1");
+    _shaderSets[6]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_matrix");
+    _shaderSets[6]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[6]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_channelFlag");
+    _shaderSets[6]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_baseColor");
+    _shaderSets[6]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[6]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[6]->ShaderProgram, "u_screenColor");
+
+    // 加算
+    _shaderSets[7]->AttributePositionLocation = glGetAttribLocation(_shaderSets[7]->ShaderProgram, "a_position");
+    _shaderSets[7]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[7]->ShaderProgram, "a_texCoord");
+    _shaderSets[7]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "s_texture0");
+    _shaderSets[7]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_matrix");
+    _shaderSets[7]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_baseColor");
+    _shaderSets[7]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[7]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[7]->ShaderProgram, "u_screenColor");
+
+    // 加算（クリッピング）
+    _shaderSets[8]->AttributePositionLocation = glGetAttribLocation(_shaderSets[8]->ShaderProgram, "a_position");
+    _shaderSets[8]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[8]->ShaderProgram, "a_texCoord");
+    _shaderSets[8]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "s_texture0");
+    _shaderSets[8]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "s_texture1");
+    _shaderSets[8]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_matrix");
+    _shaderSets[8]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[8]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_channelFlag");
+    _shaderSets[8]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_baseColor");
+    _shaderSets[8]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[8]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[8]->ShaderProgram, "u_screenColor");
+
+    // 加算（クリッピング・反転）
+    _shaderSets[9]->AttributePositionLocation = glGetAttribLocation(_shaderSets[9]->ShaderProgram, "a_position");
+    _shaderSets[9]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[9]->ShaderProgram, "a_texCoord");
+    _shaderSets[9]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "s_texture0");
+    _shaderSets[9]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "s_texture1");
+    _shaderSets[9]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_matrix");
+    _shaderSets[9]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[9]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_channelFlag");
+    _shaderSets[9]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_baseColor");
+    _shaderSets[9]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[9]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[9]->ShaderProgram, "u_screenColor");
+
+    // 加算（PremultipliedAlpha）
+    _shaderSets[10]->AttributePositionLocation = glGetAttribLocation(_shaderSets[10]->ShaderProgram, "a_position");
+    _shaderSets[10]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[10]->ShaderProgram, "a_texCoord");
+    _shaderSets[10]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "s_texture0");
+    _shaderSets[10]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_matrix");
+    _shaderSets[10]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_baseColor");
+    _shaderSets[10]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[10]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[10]->ShaderProgram, "u_screenColor");
+
+    // 加算（クリッピング、PremultipliedAlpha）
+    _shaderSets[11]->AttributePositionLocation = glGetAttribLocation(_shaderSets[11]->ShaderProgram, "a_position");
+    _shaderSets[11]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[11]->ShaderProgram, "a_texCoord");
+    _shaderSets[11]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "s_texture0");
+    _shaderSets[11]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "s_texture1");
+    _shaderSets[11]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_matrix");
+    _shaderSets[11]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[11]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_channelFlag");
+    _shaderSets[11]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_baseColor");
+    _shaderSets[11]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[11]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[11]->ShaderProgram, "u_screenColor");
+
+    // 加算（クリッピング・反転、PremultipliedAlpha）
+    _shaderSets[12]->AttributePositionLocation = glGetAttribLocation(_shaderSets[12]->ShaderProgram, "a_position");
+    _shaderSets[12]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[12]->ShaderProgram, "a_texCoord");
+    _shaderSets[12]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "s_texture0");
+    _shaderSets[12]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "s_texture1");
+    _shaderSets[12]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_matrix");
+    _shaderSets[12]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[12]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_channelFlag");
+    _shaderSets[12]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_baseColor");
+    _shaderSets[12]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[12]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[12]->ShaderProgram, "u_screenColor");
+
+    // 乗算
+    _shaderSets[13]->AttributePositionLocation = glGetAttribLocation(_shaderSets[13]->ShaderProgram, "a_position");
+    _shaderSets[13]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[13]->ShaderProgram, "a_texCoord");
+    _shaderSets[13]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "s_texture0");
+    _shaderSets[13]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_matrix");
+    _shaderSets[13]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_baseColor");
+    _shaderSets[13]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[13]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[13]->ShaderProgram, "u_screenColor");
+
+    // 乗算（クリッピング）
+    _shaderSets[14]->AttributePositionLocation = glGetAttribLocation(_shaderSets[14]->ShaderProgram, "a_position");
+    _shaderSets[14]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[14]->ShaderProgram, "a_texCoord");
+    _shaderSets[14]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "s_texture0");
+    _shaderSets[14]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "s_texture1");
+    _shaderSets[14]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_matrix");
+    _shaderSets[14]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[14]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_channelFlag");
+    _shaderSets[14]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_baseColor");
+    _shaderSets[14]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[14]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[14]->ShaderProgram, "u_screenColor");
+
+    // 乗算（クリッピング・反転）
+    _shaderSets[15]->AttributePositionLocation = glGetAttribLocation(_shaderSets[15]->ShaderProgram, "a_position");
+    _shaderSets[15]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[15]->ShaderProgram, "a_texCoord");
+    _shaderSets[15]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "s_texture0");
+    _shaderSets[15]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "s_texture1");
+    _shaderSets[15]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_matrix");
+    _shaderSets[15]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[15]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_channelFlag");
+    _shaderSets[15]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_baseColor");
+    _shaderSets[15]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[15]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[15]->ShaderProgram, "u_screenColor");
+
+    // 乗算（PremultipliedAlpha）
+    _shaderSets[16]->AttributePositionLocation = glGetAttribLocation(_shaderSets[16]->ShaderProgram, "a_position");
+    _shaderSets[16]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[16]->ShaderProgram, "a_texCoord");
+    _shaderSets[16]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "s_texture0");
+    _shaderSets[16]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_matrix");
+    _shaderSets[16]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_baseColor");
+    _shaderSets[16]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[16]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[16]->ShaderProgram, "u_screenColor");
+
+    // 乗算（クリッピング、PremultipliedAlpha）
+    _shaderSets[17]->AttributePositionLocation = glGetAttribLocation(_shaderSets[17]->ShaderProgram, "a_position");
+    _shaderSets[17]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[17]->ShaderProgram, "a_texCoord");
+    _shaderSets[17]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "s_texture0");
+    _shaderSets[17]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "s_texture1");
+    _shaderSets[17]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_matrix");
+    _shaderSets[17]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[17]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_channelFlag");
+    _shaderSets[17]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_baseColor");
+    _shaderSets[17]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[17]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[17]->ShaderProgram, "u_screenColor");
+
+    // 乗算（クリッピング・反転、PremultipliedAlpha）
+    _shaderSets[18]->AttributePositionLocation = glGetAttribLocation(_shaderSets[18]->ShaderProgram, "a_position");
+    _shaderSets[18]->AttributeTexCoordLocation = glGetAttribLocation(_shaderSets[18]->ShaderProgram, "a_texCoord");
+    _shaderSets[18]->SamplerTexture0Location = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "s_texture0");
+    _shaderSets[18]->SamplerTexture1Location = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "s_texture1");
+    _shaderSets[18]->UniformMatrixLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_matrix");
+    _shaderSets[18]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_clipMatrix");
+    _shaderSets[18]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_channelFlag");
+    _shaderSets[18]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_baseColor");
+    _shaderSets[18]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_multiplyColor");
+    _shaderSets[18]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[18]->ShaderProgram, "u_screenColor");
+}
+
+void CubismShader_OpenGLES2::SetupShaderProgramForDraw(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const csmInt32 index)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders();
+    }
+
+    // Blending
+    csmInt32 SRC_COLOR;
+    csmInt32 DST_COLOR;
+    csmInt32 SRC_ALPHA;
+    csmInt32 DST_ALPHA;
+
+    // _shaderSets用のオフセット計算
+    const csmBool masked = renderer->GetClippingContextBufferForDraw() != NULL;  // この描画オブジェクトはマスク対象か
+    const csmBool invertedMask = model.GetDrawableInvertedMask(index);
+    const csmBool isPremultipliedAlpha = renderer->IsPremultipliedAlpha();
+    const csmInt32 offset = (masked ? ( invertedMask ? 2 : 1 ) : 0) + (isPremultipliedAlpha ? 3 : 0);
+
+    // シェーダーセット
+    CubismShaderSet* shaderSet;
+    switch (model.GetDrawableBlendMode(index))
+    {
+    case CubismRenderer::CubismBlendMode_Normal:
+    default:
+        shaderSet = _shaderSets[ShaderNames_Normal + offset];
+        SRC_COLOR = GL_ONE;
+        DST_COLOR = GL_ONE_MINUS_SRC_ALPHA;
+        SRC_ALPHA = GL_ONE;
+        DST_ALPHA = GL_ONE_MINUS_SRC_ALPHA;
+        break;
+
+    case CubismRenderer::CubismBlendMode_Additive:
+        shaderSet = _shaderSets[ShaderNames_Add + offset];
+        SRC_COLOR = GL_ONE;
+        DST_COLOR = GL_ONE;
+        SRC_ALPHA = GL_ZERO;
+        DST_ALPHA = GL_ONE;
+        break;
+
+    case CubismRenderer::CubismBlendMode_Multiplicative:
+        shaderSet = _shaderSets[ShaderNames_Mult + offset];
+        SRC_COLOR = GL_DST_COLOR;
+        DST_COLOR = GL_ONE_MINUS_SRC_ALPHA;
+        SRC_ALPHA = GL_ZERO;
+        DST_ALPHA = GL_ONE;
+        break;
+    }
+
+    glUseProgram(shaderSet->ShaderProgram);
+
+    // 頂点配列の設定
+    const csmFloat32* vertexArray = model.GetDrawableVertices(index);
+    glEnableVertexAttribArray(shaderSet->AttributePositionLocation);
+    glVertexAttribPointer(shaderSet->AttributePositionLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, vertexArray);
+
+    // テクスチャ頂点の設定
+    const csmFloat32* uvArray = reinterpret_cast<const csmFloat32*>(model.GetDrawableVertexUvs(index));
+    glEnableVertexAttribArray(shaderSet->AttributeTexCoordLocation);
+    glVertexAttribPointer(shaderSet->AttributeTexCoordLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, uvArray);
+
+    if (masked)
+    {
+        glActiveTexture(GL_TEXTURE1);
+
+        // frameBufferに書かれたテクスチャ
+        GLuint tex = renderer->GetMaskBuffer(renderer->GetClippingContextBufferForDraw()->_bufferIndex)->GetColorBuffer();
+
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glUniform1i(shaderSet->SamplerTexture1Location, 1);
+
+        // View座標をClippingContextの座標に変換するための行列を設定
+        glUniformMatrix4fv(shaderSet->UniformClipMatrixLocation, 1, 0, renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray());
+
+        // 使用するカラーチャンネルを設定
+        const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        glUniform4f(shaderSet->UnifromChannelFlagLocation, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
+    }
+
+    //テクスチャ設定
+    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
+    const GLuint textureId = renderer->GetBindedTextureId(textureNo);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, textureId);
+    glUniform1i(shaderSet->SamplerTexture0Location, 0);
+
+    //座標変換
+    CubismMatrix44 matrix4x4 = renderer->GetMvpMatrix();
+    glUniformMatrix4fv(shaderSet->UniformMatrixLocation, 1, 0, matrix4x4.GetArray()); //
+
+    //ベース色の取得
+    CubismRenderer::CubismTextureColor baseColor = renderer->GetModelColorWithOpacity(model.GetDrawableOpacity(index));
+    const CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+    const CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+
+    glUniform4f(shaderSet->UniformBaseColorLocation, baseColor.R, baseColor.G, baseColor.B, baseColor.A);
+    glUniform4f(shaderSet->UniformMultiplyColorLocation, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A);
+    glUniform4f(shaderSet->UniformScreenColorLocation, screenColor.R, screenColor.G, screenColor.B, screenColor.A);
+
+    glBlendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
+}
+
+void CubismShader_OpenGLES2::SetupShaderProgramForMask(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const csmInt32 index)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        GenerateShaders();
+    }
+
+    // Blending
+    csmInt32 SRC_COLOR;
+    csmInt32 DST_COLOR;
+    csmInt32 SRC_ALPHA;
+    csmInt32 DST_ALPHA;
+
+    CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
+    glUseProgram(shaderSet->ShaderProgram);
+
+    //テクスチャ設定
+    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
+    const GLuint textureId = renderer->GetBindedTextureId(textureNo);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, textureId);
+    glUniform1i(shaderSet->SamplerTexture0Location, 0);
+
+    // 頂点配列の設定
+    const csmFloat32* vertexArray = model.GetDrawableVertices(index);
+    glEnableVertexAttribArray(shaderSet->AttributePositionLocation);
+    glVertexAttribPointer(shaderSet->AttributePositionLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, vertexArray);
+
+    // テクスチャ頂点の設定
+    const csmFloat32* uvArray = reinterpret_cast<const csmFloat32*>(model.GetDrawableVertexUvs(index));
+    glEnableVertexAttribArray(shaderSet->AttributeTexCoordLocation);
+    glVertexAttribPointer(shaderSet->AttributeTexCoordLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, uvArray);
+
+    // チャンネル
+    const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
+    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    glUniform4f(shaderSet->UnifromChannelFlagLocation, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
+
+    glUniformMatrix4fv(shaderSet->UniformClipMatrixLocation, 1, GL_FALSE, renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray());
+
+    csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
+
+    glUniform4f(shaderSet->UniformBaseColorLocation,
+                rect->X * 2.0f - 1.0f,
+                rect->Y * 2.0f - 1.0f,
+                rect->GetRight() * 2.0f - 1.0f,
+                rect->GetBottom() * 2.0f - 1.0f);
+
+    const CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+    const CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+    glUniform4f(shaderSet->UniformMultiplyColorLocation, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A);
+    glUniform4f(shaderSet->UniformScreenColorLocation, screenColor.R, screenColor.G, screenColor.B, screenColor.A);
+
+    SRC_COLOR = GL_ZERO;
+    DST_COLOR = GL_ONE_MINUS_SRC_COLOR;
+    SRC_ALPHA = GL_ZERO;
+    DST_ALPHA = GL_ONE_MINUS_SRC_ALPHA;
+
+    glBlendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
+}
+
+csmBool CubismShader_OpenGLES2::CompileShaderSource(GLuint* outShader, GLenum shaderType, const csmChar* shaderSource)
+{
+    GLint status;
+    const GLchar* source = shaderSource;
+
+    *outShader = glCreateShader(shaderType);
+    glShaderSource(*outShader, 1, &source, NULL);
+    glCompileShader(*outShader);
+
+    GLint logLength;
+    glGetShaderiv(*outShader, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength > 0)
+    {
+        GLchar* log = reinterpret_cast<GLchar*>(CSM_MALLOC(logLength));
+        glGetShaderInfoLog(*outShader, logLength, &logLength, log);
+        CubismLogError("Shader compile log: %s", log);
+        CSM_FREE(log);
+    }
+
+    glGetShaderiv(*outShader, GL_COMPILE_STATUS, &status);
+    if (status == GL_FALSE)
+    {
+        glDeleteShader(*outShader);
+        return false;
+    }
+
+    return true;
+}
+
+csmBool CubismShader_OpenGLES2::LinkProgram(GLuint shaderProgram)
+{
+    GLint status;
+    glLinkProgram(shaderProgram);
+
+    GLint logLength;
+    glGetProgramiv(shaderProgram, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength > 0)
+    {
+        GLchar* log = reinterpret_cast<GLchar*>(CSM_MALLOC(logLength));
+        glGetProgramInfoLog(shaderProgram, logLength, &logLength, log);
+        CubismLogError("Program link log: %s", log);
+        CSM_FREE(log);
+    }
+
+    glGetProgramiv(shaderProgram, GL_LINK_STATUS, &status);
+    if (status == GL_FALSE)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+csmBool CubismShader_OpenGLES2::ValidateProgram(GLuint shaderProgram)
+{
+    GLint logLength, status;
+
+    glValidateProgram(shaderProgram);
+    glGetProgramiv(shaderProgram, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength > 0)
+    {
+        GLchar* log = reinterpret_cast<GLchar*>(CSM_MALLOC(logLength));
+        glGetProgramInfoLog(shaderProgram, logLength, &logLength, log);
+        CubismLogError("Validate program log: %s", log);
+        CSM_FREE(log);
+    }
+
+    glGetProgramiv(shaderProgram, GL_VALIDATE_STATUS, &status);
+    if (status == GL_FALSE)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+GLuint CubismShader_OpenGLES2::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
+{
+    GLuint vertShader, fragShader;
+
+    // Create shader program.
+    GLuint shaderProgram = glCreateProgram();
+
+    if (!CompileShaderSource(&vertShader, GL_VERTEX_SHADER, vertShaderSrc))
+    {
+        CubismLogError("Vertex shader compile error!");
+        return 0;
+    }
+
+    // Create and compile fragment shader.
+    if (!CompileShaderSource(&fragShader, GL_FRAGMENT_SHADER, fragShaderSrc))
+    {
+        CubismLogError("Fragment shader compile error!");
+        return 0;
+    }
+
+    // Attach vertex shader to program.
+    glAttachShader(shaderProgram, vertShader);
+
+    // Attach fragment shader to program.
+    glAttachShader(shaderProgram, fragShader);
+
+    // Link program.
+    if (!LinkProgram(shaderProgram))
+    {
+        CubismLogError("Failed to link program: %d", shaderProgram);
+
+        if (vertShader)
+        {
+            glDeleteShader(vertShader);
+            vertShader = 0;
+        }
+        if (fragShader)
+        {
+            glDeleteShader(fragShader);
+            fragShader = 0;
+        }
+        if (shaderProgram)
+        {
+            glDeleteProgram(shaderProgram);
+            shaderProgram = 0;
+        }
+
+        return 0;
+    }
+
+    // Release vertex and fragment shaders.
+    if (vertShader)
+    {
+        glDetachShader(shaderProgram, vertShader);
+        glDeleteShader(vertShader);
+    }
+
+    if (fragShader)
+    {
+        glDetachShader(shaderProgram, fragShader);
+        glDeleteShader(fragShader);
+    }
+
+    return shaderProgram;
+}
+
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/OpenGL/CubismShader_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismShader_OpenGLES2.hpp
@@ -1,0 +1,182 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "CubismFramework.hpp"
+#include "CubismRenderer_OpenGLES2.hpp"
+
+#ifdef CSM_TARGET_ANDROID_ES2
+#include <jni.h>
+#include <errno.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#endif
+
+#ifdef CSM_TARGET_IPHONE_ES2
+#include <OpenGLES/ES2/gl.h>
+#include <OpenGLES/ES2/glext.h>
+#endif
+
+#if defined(CSM_TARGET_WIN_GL) || defined(CSM_TARGET_LINUX_GL)
+#include <GL/glew.h>
+#include <GL/gl.h>
+#endif
+
+#ifdef CSM_TARGET_MAC_GL
+#ifndef CSM_TARGET_COCOS
+#include <GL/glew.h>
+#endif
+#include <OpenGL/gl.h>
+#endif
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+class CubismRenderer_OpenGLES2;
+
+/**
+ * @brief   OpenGLES2用のシェーダプログラムを生成・破棄するクラス<br>
+ *           シングルトンなクラスであり、CubismShader_OpenGLES2::GetInstance()からアクセスする。
+ *
+ */
+class CubismShader_OpenGLES2
+{
+public:
+    /**
+     * @brief   インスタンスを取得する（シングルトン）。
+     *
+     * @return  インスタンスのポインタ
+     */
+    static CubismShader_OpenGLES2* GetInstance();
+
+    /**
+     * @brief   インスタンスを解放する（シングルトン）。
+     */
+    static void DeleteInstance();
+
+    /**
+     * @brief   描画用のシェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   renderer              ->  レンダラー
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index                 ->  描画対象のメッシュのインデックス
+     */
+    void SetupShaderProgramForDraw(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const csmInt32 index);
+
+    /**
+     * @brief   マスク用のシェーダプログラムの一連のセットアップを実行する
+     *
+     * @param[in]   renderer              ->  レンダラー
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index                 ->  描画対象のメッシュのインデックス
+     */
+    void SetupShaderProgramForMask(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const csmInt32 index);
+
+private:
+    /**
+    * @bref    シェーダープログラムとシェーダ変数のアドレスを保持する構造体
+    *
+    */
+    struct CubismShaderSet
+    {
+        GLuint ShaderProgram;               ///< シェーダプログラムのアドレス
+        GLuint AttributePositionLocation;   ///< シェーダプログラムに渡す変数のアドレス(Position)
+        GLuint AttributeTexCoordLocation;   ///< シェーダプログラムに渡す変数のアドレス(TexCoord)
+        GLint UniformMatrixLocation;        ///< シェーダプログラムに渡す変数のアドレス(Matrix)
+        GLint UniformClipMatrixLocation;    ///< シェーダプログラムに渡す変数のアドレス(ClipMatrix)
+        GLint SamplerTexture0Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture0)
+        GLint SamplerTexture1Location;      ///< シェーダプログラムに渡す変数のアドレス(Texture1)
+        GLint UniformBaseColorLocation;     ///< シェーダプログラムに渡す変数のアドレス(BaseColor)
+        GLint UniformMultiplyColorLocation; ///< シェーダプログラムに渡す変数のアドレス(MultiplyColor)
+        GLint UniformScreenColorLocation;   ///< シェーダプログラムに渡す変数のアドレス(ScreenColor)
+        GLint UnifromChannelFlagLocation;   ///< シェーダプログラムに渡す変数のアドレス(ChannelFlag)
+    };
+
+    /**
+     * @brief   privateなコンストラクタ
+     */
+    CubismShader_OpenGLES2();
+
+    /**
+     * @brief   privateなデストラクタ
+     */
+    virtual ~CubismShader_OpenGLES2();
+
+    /**
+     * @brief   シェーダプログラムを解放する
+     */
+    void ReleaseShaderProgram();
+
+    /**
+     * @brief   シェーダプログラムを初期化する
+     */
+    void GenerateShaders();
+
+    /**
+     * @brief   シェーダプログラムをロードしてアドレス返す。
+     *
+     * @param[in]   vertShaderSrc   ->  頂点シェーダのソース
+     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのソース
+     *
+     * @return  シェーダプログラムのアドレス
+     */
+    GLuint LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
+
+    /**
+     * @brief   シェーダプログラムをコンパイルする
+     *
+     * @param[out]  outShader       ->  コンパイルされたシェーダプログラムのアドレス
+     * @param[in]   shaderType      ->  シェーダタイプ(Vertex/Fragment)
+     * @param[in]   shaderSource    ->  シェーダソースコード
+     *
+     * @retval      true         ->      コンパイル成功
+     * @retval      false        ->      コンパイル失敗
+     */
+    csmBool CompileShaderSource(GLuint* outShader, GLenum shaderType, const csmChar* shaderSource);
+
+    /**
+     * @brief   シェーダプログラムをリンクする
+     *
+     * @param[in]   shaderProgram   ->  リンクするシェーダプログラムのアドレス
+     *
+     * @retval      true            ->  リンク成功
+     * @retval      false           ->  リンク失敗
+     */
+    csmBool LinkProgram(GLuint shaderProgram);
+
+    /**
+     * @brief   シェーダプログラムを検証する
+     *
+     * @param[in]   shaderProgram   ->  検証するシェーダプログラムのアドレス
+     *
+     * @retval      true            ->  正常
+     * @retval      false           ->  異常
+     */
+    csmBool ValidateProgram(GLuint shaderProgram);
+
+#ifdef CSM_TARGET_ANDROID_ES2
+public:
+    /**
+     * @brief   Tegraプロセッサ対応。拡張方式による描画の有効・無効
+     *
+     * @param[in]   extMode     ->  trueなら拡張方式で描画する
+     * @param[in]   extPAMode   ->  trueなら拡張方式のPA設定を有効にする
+     */
+    static void SetExtShaderMode(csmBool extMode, csmBool extPAMode);
+
+private:
+    static csmBool  s_extMode;      ///< Tegra対応.拡張方式で描画
+    static csmBool  s_extPAMode;    ///< 拡張方式のPA設定用の変数
+#endif
+
+    csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
+
+};
+
+}}}}
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/CMakeLists.txt
+++ b/src/Rendering/Vulkan/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(${LIB_NAME}
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismClass_Vulkan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismClass_Vulkan.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_Vulkan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenSurface_Vulkan.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Vulkan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismRenderer_Vulkan.hpp
+)

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
@@ -1,0 +1,314 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismClass_Vulkan.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/*********************************************************************************************************************
+*                                      CubismBufferVulkan
+********************************************************************************************************************/
+CubismBufferVulkan::CubismBufferVulkan():
+                                        buffer(VK_NULL_HANDLE)
+                                        , memory(VK_NULL_HANDLE)
+                                        , mapped()
+{ }
+
+csmUint32 CubismBufferVulkan::FindMemoryType(VkPhysicalDevice physicalDevice, csmUint32 typeFilter, VkMemoryPropertyFlags properties)
+{
+    VkPhysicalDeviceMemoryProperties memProperties;
+    vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
+
+    for (csmUint32 i = 0; i < memProperties.memoryTypeCount; i++)
+    {
+        if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
+        {
+            return i;
+        }
+    }
+    CubismLogError("failed to find suitable memory type!");
+    return 0;
+}
+
+void CubismBufferVulkan::CreateBuffer(VkDevice device, VkPhysicalDevice physicalDevice, VkDeviceSize size,
+                                      VkBufferUsageFlags usage, VkMemoryPropertyFlags properties)
+{
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = size;
+    bufferInfo.usage = usage;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    if (vkCreateBuffer(device, &bufferInfo, nullptr, &buffer) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create buffer!");
+    }
+
+    VkMemoryRequirements memRequirements{};
+    vkGetBufferMemoryRequirements(device, buffer, &memRequirements);
+
+    VkMemoryAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memRequirements.size;
+    allocInfo.memoryTypeIndex = FindMemoryType(physicalDevice, memRequirements.memoryTypeBits, properties);
+
+    if (vkAllocateMemory(device, &allocInfo, nullptr, &memory) != VK_SUCCESS)
+    {
+        CubismLogError("failed to allocate buffer memory!");
+    }
+
+    vkBindBufferMemory(device, buffer, memory, 0);
+}
+
+void CubismBufferVulkan::Map(VkDevice device, VkDeviceSize size)
+{
+    vkMapMemory(device, memory, 0, size, 0, &mapped);
+}
+
+void CubismBufferVulkan::MemCpy(const void* src, VkDeviceSize size) const
+{
+    memcpy(mapped, src, (size_t)size);
+}
+
+void CubismBufferVulkan::UnMap(VkDevice device) const
+{
+    vkUnmapMemory(device, memory);
+}
+
+void CubismBufferVulkan::Destroy(VkDevice device)
+{
+    vkDestroyBuffer(device, buffer, nullptr);
+    vkFreeMemory(device, memory, nullptr);
+}
+
+/*********************************************************************************************************************
+*                                      CubismImageVulkan
+********************************************************************************************************************/
+CubismImageVulkan::CubismImageVulkan():
+                                      image(VK_NULL_HANDLE)
+                                      , memory(VK_NULL_HANDLE)
+                                      , view(VK_NULL_HANDLE)
+                                      , sampler(VK_NULL_HANDLE)
+                                      , currentLayout(VK_IMAGE_LAYOUT_UNDEFINED)
+{ }
+
+csmUint32 CubismImageVulkan::FindMemoryType(VkPhysicalDevice physicalDevice, csmUint32 typeFilter, VkMemoryPropertyFlags properties)
+{
+    VkPhysicalDeviceMemoryProperties memProperties;
+    vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
+
+    for (csmUint32 i = 0; i < memProperties.memoryTypeCount; i++)
+    {
+        if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
+        {
+            return i;
+        }
+    }
+    CubismLogError("failed to find suitable memory type!");
+    return 0;
+}
+
+void CubismImageVulkan::CreateImage(
+    VkDevice device, VkPhysicalDevice physicalDevice,
+    csmInt32 w, csmInt32 h,
+    csmInt32 mipLevel, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage)
+{
+    width = w;
+    height = h;
+
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.extent.width = w;
+    imageInfo.extent.height = h;
+    imageInfo.extent.depth = 1;
+    imageInfo.mipLevels = mipLevel;
+    imageInfo.arrayLayers = 1;
+    imageInfo.format = format;
+    imageInfo.tiling = tiling;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageInfo.usage = usage;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    if (vkCreateImage(device, &imageInfo, nullptr, &image) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create image!");
+    }
+
+    VkMemoryRequirements memRequirements;
+    vkGetImageMemoryRequirements(device, image, &memRequirements);
+
+    VkMemoryAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memRequirements.size;
+    allocInfo.memoryTypeIndex = FindMemoryType(physicalDevice, memRequirements.memoryTypeBits,
+                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    if (vkAllocateMemory(device, &allocInfo, nullptr, &memory) != VK_SUCCESS)
+    {
+        CubismLogError("failed to allocate image memory!");
+    }
+
+    vkBindImageMemory(device, image, memory, 0);
+}
+
+void CubismImageVulkan::CreateView(VkDevice device, VkFormat format, VkImageAspectFlags aspectFlags, csmInt32 mipLevel)
+{
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = image;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = format;
+    viewInfo.subresourceRange.aspectMask = aspectFlags;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = mipLevel;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(device, &viewInfo, nullptr, &view) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create texture image view!");
+    }
+}
+
+void CubismImageVulkan::CreateSampler(VkDevice device, float maxAnistropy,
+                                      csmUint32 mipLevel)
+{
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = VK_FILTER_LINEAR;
+    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.anisotropyEnable = VK_TRUE;
+    samplerInfo.maxAnisotropy = maxAnistropy;
+    samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    samplerInfo.unnormalizedCoordinates = VK_FALSE;
+    samplerInfo.compareEnable = VK_FALSE;
+    samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    samplerInfo.minLod = 0.0f;
+    samplerInfo.maxLod = static_cast<csmFloat32>(mipLevel);
+    samplerInfo.mipLodBias = 0.0f;
+
+    if (vkCreateSampler(device, &samplerInfo, nullptr, &sampler) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create texture sampler!");
+    }
+}
+
+void CubismImageVulkan::SetImageLayout(VkCommandBuffer commandBuffer, VkImageLayout newLayout, csmUint32 mipLevels)
+{
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = currentLayout;
+    barrier.newLayout = newLayout;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = mipLevels;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+
+    VkPipelineStageFlags sourceStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    VkPipelineStageFlags destinationStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    switch (currentLayout)
+    {
+    case VK_IMAGE_LAYOUT_UNDEFINED:
+        barrier.srcAccessMask = 0;
+        break;
+
+    case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+        barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+        barrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+        barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        break;
+
+    default:
+        break;
+    }
+
+    switch (newLayout)
+    {
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+        break;
+
+    default:
+        break;
+    }
+
+    vkCmdPipelineBarrier(
+        commandBuffer,
+        sourceStage,
+        destinationStage,
+        0,
+        0,
+        nullptr,
+        0,
+        nullptr,
+        1,
+        &barrier
+    );
+
+    currentLayout = newLayout;
+}
+
+void CubismImageVulkan::Destroy(VkDevice device)
+{
+    if (image != VK_NULL_HANDLE)
+    {
+        vkDestroyImage(device, image, nullptr);
+        image = VK_NULL_HANDLE;
+    }
+    if (memory != VK_NULL_HANDLE)
+    {
+        vkDestroyImageView(device, view, nullptr);
+    }
+    if (view != VK_NULL_HANDLE)
+    {
+        vkFreeMemory(device, memory, nullptr);
+        view = VK_NULL_HANDLE;
+    }
+    if (sampler != VK_NULL_HANDLE)
+    {
+        vkDestroySampler(device, sampler, nullptr);
+        sampler = VK_NULL_HANDLE;
+    }
+}
+
+}}}

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.hpp
@@ -1,0 +1,204 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+#include <fstream>
+#include <vulkan/vulkan.h>
+#include "CubismFramework.hpp"
+#include "Type/csmVector.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+/**
+ * @brief   バッファを扱うクラス
+ */
+class CubismBufferVulkan
+{
+public:
+    /**
+     * @brief   コンストラクタ
+     */
+    CubismBufferVulkan();
+
+    /**
+     * @brief   物理デバイスのメモリタイプのインデックスを探す
+     *
+     * @param[in]  physicalDevice -> 物理デバイス
+     * @param[in]  typeFilter     -> メモリタイプが存在していたら設定されるビットマスク
+     * @param[in]  properties     -> メモリがデバイスにアクセスするときのタイプ
+     */
+    csmUint32 FindMemoryType(VkPhysicalDevice physicalDevice, csmUint32 typeFilter, VkMemoryPropertyFlags properties);
+
+    /**
+     * @brief   バッファを作成する
+     *
+     * @param[in]  device          -> デバイス
+     * @param[in]  physicalDevice  -> 物理デバイス
+     * @param[in]  size            -> バッファサイズ
+     * @param[in]  usage           -> バッファの使用法を指定するビットマスク
+     * @param[in]  properties      -> メモリがデバイスにアクセスする際のタイプ
+     */
+    void CreateBuffer(VkDevice device, VkPhysicalDevice physicalDevice, VkDeviceSize size, VkBufferUsageFlags usage,
+                      VkMemoryPropertyFlags properties);
+
+    /**
+     * @brief   メモリをアドレス空間にマップし、そのアドレスポインタを取得する
+     *
+     * @param[in]  device  -> デバイス
+     * @param[in]  size    -> マップするサイズ
+     */
+    void Map(VkDevice device, VkDeviceSize size);
+
+    /**
+     * @brief   メモリブロックをコピーする
+     *
+     * @param[in]  src  -> コピーするデータ
+     * @param[in]  size -> コピーするサイズ
+     */
+    void MemCpy(const void* src, VkDeviceSize size) const;
+
+    /**
+     * @brief   メモリのマップを解除する
+     *
+     * @param[in]  device  -> デバイス
+     */
+    void UnMap(VkDevice device) const;
+
+    /**
+     * @brief   リソースを破棄する
+     *
+     * @param[in]  device  -> デバイス
+     */
+    void Destroy(VkDevice device);
+
+    /**
+     * @brief   バッファを取得する
+     *
+     * @return バッファ
+     */
+    VkBuffer GetBuffer() const { return buffer; }
+
+private:
+    VkBuffer buffer; ///< バッファ
+    VkDeviceMemory memory; ///< メモリ
+    void* mapped; ///< マップ領域へのアドレス
+};
+
+/**
+ * @brief   イメージを扱うクラス
+ */
+class CubismImageVulkan
+{
+public:
+    /**
+     * @brief   コンストラクタ
+     */
+    CubismImageVulkan();
+
+    /**
+     * @brief   物理デバイスのメモリタイプのインデックスを探す
+     *
+     * @param[in]  physicalDevice -> 物理デバイス
+     * @param[in]  typeFilter     -> メモリタイプが存在していたら設定されるビットマスク
+     * @param[in]  properties     -> メモリがデバイスにアクセスするときのタイプ
+     */
+    csmUint32 FindMemoryType(VkPhysicalDevice physicalDevice, csmUint32 typeFilter, VkMemoryPropertyFlags properties);
+
+    /**
+     * @brief   イメージを作成する
+     *
+     * @param[in]  device          -> デバイス
+     * @param[in]  physicalDevice  -> 物理デバイス
+     * @param[in]  w           -> 横幅
+     * @param[in]  h          -> 高さ
+     * @param[in]  mipLevel        -> ミップマップのレベル
+     * @param[in]  format          -> フォーマット
+     * @param[in]  tiling          -> タイリング配置の設定
+     * @param[in]  usage           -> イメージの使用目的を指定するビットマスク
+     */
+    void CreateImage(VkDevice device, VkPhysicalDevice physicalDevice,
+                     csmInt32 w, csmInt32 h,
+                     csmInt32 mipLevel, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage);
+
+    /**
+     * @brief   ビューを作成する
+     *
+     * @param[in]  device          -> デバイス
+     * @param[in]  format          -> フォーマット
+     * @param[in]  aspectFlags     -> どのアスペクトマスクがビューに含まれるかを指定するビットマスク
+     * @param[in]  mipLevel        -> ミップマップのレベル
+     */
+    void CreateView(VkDevice device, VkFormat format, VkImageAspectFlags aspectFlags, csmInt32 mipLevel);
+
+    /**
+     * @brief   サンプラーを作成する
+     *
+     * @param[in]  device          -> デバイス
+     * @param[in]  maxAnistropy    -> 異方性の値の最大値
+     * @param[in]  mipLevel        -> ミップマップのレベル
+     */
+    void CreateSampler(VkDevice device, float maxAnistropy, csmUint32 mipLevel);
+
+    /**
+     * @brief   イメージのレイアウトを変更する
+     *
+     * @param[in]  commandBuffer  -> コマンドバッファ
+     * @param[in]  newLayout      -> 新しいレイアウト
+     * @param[in]  mipLevels      -> ミップマップのレベル
+     */
+    void SetImageLayout(VkCommandBuffer commandBuffer, VkImageLayout newLayout, csmUint32 mipLevels);
+
+    /**
+     * @brief   リソースを破棄する
+     *
+     * @param[in]  device  -> デバイス
+     */
+    void Destroy(VkDevice device);
+
+    /**
+     * @brief   イメージを取得する
+     *
+     * @return イメージ
+     */
+    VkImage GetImage() const { return image; }
+
+    /**
+     * @brief   ビューを取得する
+     *
+     * @return ビュー
+     */
+    VkImageView GetView() const { return view; }
+
+    /**
+     * @brief   サンプラーを取得する
+     *
+     * @return サンプラー
+     */
+    VkSampler GetSampler() const { return sampler; }
+
+    /**
+     * @brief   widthを取得する
+     *
+     * @return width
+     */
+    csmInt32 GetWidth() const { return width; }
+
+    /**
+     * @brief   heightを取得する
+     *
+     * @return height
+     */
+    csmInt32 GetHeight() const { return height; }
+
+private:
+    VkImage image; ///< バッファ
+    VkDeviceMemory memory; ///< メモリ
+    VkImageView view; ///< ビュー
+    VkSampler sampler; ///< サンプラー
+    VkImageLayout currentLayout; ///< 現在のイメージレイアウト
+    csmInt32 width, height;
+};
+}}}

--- a/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.cpp
@@ -1,0 +1,141 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismOffscreenSurface_Vulkan.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+CubismOffscreenSurface_Vulkan::CubismOffscreenSurface_Vulkan()
+    : _bufferWidth(0)
+    , _bufferHeight(0)
+{ }
+
+void CubismOffscreenSurface_Vulkan::BeginDraw(VkCommandBuffer commandBuffer, csmFloat32 r, csmFloat32 g, csmFloat32 b,
+                                            csmFloat32 a)
+{
+    VkRenderingAttachmentInfoKHR colorAttachment{};
+    colorAttachment.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO_KHR;
+    colorAttachment.imageView = _colorImage->GetView();
+    colorAttachment.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL_KHR;
+    colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    colorAttachment.clearValue = {{r, g, b, a}};
+
+    VkRenderingAttachmentInfoKHR depthStencilAttachment{};
+    depthStencilAttachment.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO_KHR;
+    depthStencilAttachment.imageView = _depthImage->GetView();
+    depthStencilAttachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    depthStencilAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depthStencilAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthStencilAttachment.clearValue = {1.0f, 0};
+
+    VkExtent2D extent;
+    extent.height = _bufferHeight;
+    extent.width = _bufferWidth;
+
+    VkRenderingInfo renderingInfo{};
+    renderingInfo.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
+    renderingInfo.renderArea = {{0, 0}, {extent}};
+    renderingInfo.layerCount = 1;
+    renderingInfo.colorAttachmentCount = 1;
+    renderingInfo.pColorAttachments = &colorAttachment;
+    renderingInfo.pDepthAttachment = &depthStencilAttachment;
+
+    vkCmdBeginRendering(commandBuffer, &renderingInfo);
+}
+
+void CubismOffscreenSurface_Vulkan::EndDraw(VkCommandBuffer commandBuffer)
+{
+    vkCmdEndRendering(commandBuffer);
+
+    // レイアウト変更
+    VkImageMemoryBarrier memoryBarrier{};
+    memoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    memoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    memoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    memoryBarrier.image = _colorImage->GetImage();
+    memoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &memoryBarrier);
+}
+
+void CubismOffscreenSurface_Vulkan::CreateOffscreenSurface(
+    VkDevice device, VkPhysicalDevice physicalDevice,
+    csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
+    VkFormat surfaceFormat, VkFormat depthFormat)
+{
+    _colorImage = new CubismImageVulkan;
+    _colorImage->CreateImage(device, physicalDevice, displayBufferWidth, displayBufferHeight,
+                             1, surfaceFormat, VK_IMAGE_TILING_OPTIMAL,
+                             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                             VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    _colorImage->CreateView(device, surfaceFormat, VK_IMAGE_ASPECT_COLOR_BIT, 1);
+    _colorImage->CreateSampler(device, 1.0, 1);
+
+    _depthImage = new CubismImageVulkan;
+    _depthImage->CreateImage(device, physicalDevice, displayBufferWidth, displayBufferHeight,
+                             1, depthFormat, VK_IMAGE_TILING_OPTIMAL,
+                             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    _depthImage->CreateView(device, depthFormat, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 1);
+
+    _bufferWidth = displayBufferWidth;
+    _bufferHeight = displayBufferHeight;
+}
+
+void CubismOffscreenSurface_Vulkan::DestroyOffscreenSurface(VkDevice device)
+{
+    if (_colorImage != VK_NULL_HANDLE)
+    {
+        _colorImage->Destroy(device);
+        _colorImage = VK_NULL_HANDLE;
+    }
+    if (_depthImage != VK_NULL_HANDLE)
+    {
+        _depthImage->Destroy(device);
+        _depthImage = VK_NULL_HANDLE;
+    }
+}
+
+VkImage CubismOffscreenSurface_Vulkan::GetTextureImage() const
+{
+    return _colorImage->GetImage();
+}
+
+VkImageView CubismOffscreenSurface_Vulkan::GetTextureView() const
+{
+    return _colorImage->GetView();
+}
+
+VkSampler CubismOffscreenSurface_Vulkan::GetTextureSampler() const
+{
+    return _colorImage->GetSampler();
+}
+
+csmUint32 CubismOffscreenSurface_Vulkan::GetBufferWidth() const
+{
+    return _bufferWidth;
+}
+
+csmUint32 CubismOffscreenSurface_Vulkan::GetBufferHeight() const
+{
+    return _bufferHeight;
+}
+
+csmBool CubismOffscreenSurface_Vulkan::IsValid() const
+{
+    if (_colorImage == VK_NULL_HANDLE || _depthImage == VK_NULL_HANDLE)
+    {
+        return false;
+    }
+
+    return true;
+}
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.hpp
@@ -1,0 +1,103 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+#include <vulkan/vulkan.h>
+#include "CubismFramework.hpp"
+#include "CubismClass_Vulkan.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+/**
+ * @brief  オフスクリーン描画用構造体
+ */
+class CubismOffscreenSurface_Vulkan
+{
+public:
+    CubismOffscreenSurface_Vulkan();
+
+    /**
+     * @brief   レンダリングターゲットのクリア
+     *           呼ぶ場合はBeginDrawの後で呼ぶこと
+     *
+     * @param[in]  commandBuffer   -> コマンドバッファ
+     * @param[in]   r              -> 赤(0.0~1.0)
+     * @param[in]   g              -> 緑(0.0~1.0)
+     * @param[in]   b              -> 青(0.0~1.0)
+     * @param[in]   a              -> α(0.0~1.0)
+     */
+    void BeginDraw(VkCommandBuffer commandBuffer, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a);
+
+    /**
+     * @brief   描画終了
+     *
+     *  @param[in]  commandBuffer                 -> コマンドバッファ
+     */
+    void EndDraw(VkCommandBuffer commandBuffer);
+
+    /**
+     *  @brief  CubismOffscreenSurfaceを作成する。
+     *
+     *  @param[in]  device                 -> 論理デバイス
+     *  @param[in]  physicalDevice         -> 物理デバイス
+     *  @param[in]  displayBufferWidth     -> オフスクリーンの横幅
+     *  @param[in]  displayBufferHeight    -> オフスクリーンの縦幅
+     *  @param[in]  surfaceFormat          -> サーフェスフォーマット
+     *  @param[in]  depthFormat            -> 深度フォーマット
+     */
+    void CreateOffscreenSurface(
+        VkDevice device, VkPhysicalDevice physicalDevice,
+        csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
+        VkFormat surfaceFormat, VkFormat depthFormat
+    );
+
+    /**
+     * @brief   CubismOffscreenSurfaceの削除
+     *
+     *  @param[in]  device                 -> デバイス
+     */
+    void DestroyOffscreenSurface(VkDevice device);
+
+    /**
+     * @brief   イメージへのアクセッサ
+     */
+    VkImage GetTextureImage() const;
+
+    /**
+     * @brief   テクスチャビューへのアクセッサ
+     */
+    VkImageView GetTextureView() const;
+
+    /**
+     * @brief   テクスチャサンプラーへのアクセッサ
+     */
+    VkSampler GetTextureSampler() const;
+
+    /**
+     * @brief   バッファ幅を返す
+     */
+    csmUint32 GetBufferWidth() const;
+
+    /**
+     * @brief   バッファ高さを返す
+     */
+    csmUint32 GetBufferHeight() const;
+
+    /**
+     * @brief   現在有効かどうかを返す
+     */
+    bool IsValid() const;
+
+private:
+    csmUint32 _bufferWidth; ///< オフスクリーンの横幅
+    csmUint32 _bufferHeight; ///< オフスクリーンの縦幅
+    CubismImageVulkan* _colorImage = VK_NULL_HANDLE; ///< カラーバッファ
+    CubismImageVulkan* _depthImage = VK_NULL_HANDLE; ///< 深度バッファ
+};
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/CubismRenderer_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismRenderer_Vulkan.cpp
@@ -1,0 +1,1515 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismRenderer_Vulkan.hpp"
+#include "Math/CubismMatrix44.hpp"
+#include "Type/csmVector.hpp"
+#include "Model/CubismModel.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+// 各種静的変数
+namespace {
+VkDevice s_device = VK_NULL_HANDLE;
+VkPhysicalDevice s_physicalDevice = VK_NULL_HANDLE;
+VkCommandPool s_commandPool = VK_NULL_HANDLE;
+VkQueue s_queue = VK_NULL_HANDLE;
+VkExtent2D s_swapchainExtent;
+VkFormat s_swapchainImageFormat;
+VkFormat s_imageFormat;
+VkImage s_swapchainImage;
+VkImageView s_swapchainImageView;
+VkFormat s_depthFormat;
+bool s_useRenderTarget = false;
+VkImage s_renderTargetImage;
+VkImageView s_renderTargetImageView;
+}
+
+VkViewport GetViewport(csmFloat32 width, csmFloat32 height, csmFloat32 minDepth, csmFloat32 maxDepth)
+{
+    VkViewport viewport{};
+    viewport.width = width;
+    viewport.height = height;
+    viewport.minDepth = minDepth;
+    viewport.maxDepth = maxDepth;
+    return viewport;
+}
+
+VkRect2D GetScissor(csmFloat32 offsetX, csmFloat32 offsetY, csmFloat32 width, csmFloat32 height)
+{
+    VkRect2D rect{};
+    rect.offset.x = offsetX;
+    rect.offset.y = offsetY;
+    rect.extent.height = height;
+    rect.extent.width = width;
+    return rect;
+}
+
+/*********************************************************************************************************************
+*                                      CubismClippingManager_Vulkan
+********************************************************************************************************************/
+
+void CubismClippingManager_Vulkan::SetupClippingContext(CubismModel& model, VkCommandBuffer commandBuffer,
+                                                        VkCommandBuffer updateCommandBuffer,
+                                                        CubismRenderer_Vulkan* renderer)
+{
+    // 全てのクリッピングを用意する
+    // 同じクリップ（複数の場合はまとめて１つのクリップ）を使う場合は１度だけ設定する
+    csmInt32 usingClipCount = 0;
+
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // １つのクリッピングマスクに関して
+        CubismClippingContext_Vulkan* cc = _clippingContextListForMask[clipIndex];
+
+        // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
+        CalcClippedDrawTotalBounds(model, cc);
+
+        if (cc->_isUsing)
+        {
+            usingClipCount++; //使用中としてカウント
+        }
+    }
+
+    if (usingClipCount <= 0)
+    {
+        return;
+    }
+
+    // マスク作成処理
+    // 後の計算のためにインデックスの最初をセット
+    _currentMaskBuffer = renderer->GetMaskBuffer(0);
+
+    // 1が無効（描かれない）領域、0が有効（描かれる）領域。（シェーダで Cd*Csで0に近い値をかけてマスクを作る。1をかけると何も起こらない）
+    _currentMaskBuffer->BeginDraw(commandBuffer, 1.0f, 1.0f, 1.0f, 1.0f);
+
+    // 生成したFrameBufferと同じサイズでビューポートを設定
+    const VkViewport viewport = GetViewport(
+        static_cast<csmFloat32>(_clippingMaskBufferSize.X),
+        static_cast<csmFloat32>(_clippingMaskBufferSize.Y),
+        0.0, 1.0
+    );
+    vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
+    const VkRect2D rect = GetScissor(
+        0.0, 0.0,
+        static_cast<csmFloat32>(_clippingMaskBufferSize.X),
+        static_cast<csmFloat32>(_clippingMaskBufferSize.Y)
+    );
+    vkCmdSetScissor(commandBuffer, 0, 1, &rect);
+
+    // 各マスクのレイアウトを決定していく
+    SetupLayoutBounds(usingClipCount);
+
+    // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
+    if (_clearedMaskBufferFlags.GetSize() != _renderTextureCount)
+    {
+        _clearedMaskBufferFlags.Clear();
+
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+        {
+            _clearedMaskBufferFlags.PushBack(false);
+        }
+    }
+    else
+    {
+        // マスクのクリアフラグを毎フレーム開始時に初期化
+        for (csmInt32 i = 0; i < _renderTextureCount; ++i)
+        {
+            _clearedMaskBufferFlags[i] = false;
+        }
+    }
+
+    // 実際にマスクを生成する
+    // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
+    for (csmUint32 clipIndex = 0; clipIndex < _clippingContextListForMask.GetSize(); clipIndex++)
+    {
+        // --- 実際に１つのマスクを描く ---
+        CubismClippingContext_Vulkan* clipContext = _clippingContextListForMask[clipIndex];
+        csmRectF* allClippedDrawRect = clipContext->_allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+        csmRectF* layoutBoundsOnTex01 = clipContext->_layoutBounds; //この中にマスクを収める
+        const csmFloat32 MARGIN = 0.05f;
+
+        // clipContextに設定したオフスクリーンサーフェイスをインデックスで取得
+        CubismOffscreenSurface_Vulkan* clipContextOffscreenSurface = renderer->GetMaskBuffer(clipContext->_bufferIndex);
+
+        // 現在のオフスクリーンサーフェイスがclipContextのものと異なる場合
+        if (_currentMaskBuffer != clipContextOffscreenSurface)
+        {
+            _currentMaskBuffer->EndDraw(commandBuffer);
+            _currentMaskBuffer = clipContextOffscreenSurface;
+            // マスク用RenderTextureをactiveにセット
+            _currentMaskBuffer->BeginDraw(commandBuffer, 1.0f, 1.0f, 1.0f, 1.0f);
+        }
+
+        // モデル座標上の矩形を、適宜マージンを付けて使う
+        _tmpBoundsOnModel.SetRect(allClippedDrawRect);
+        _tmpBoundsOnModel.Expand(allClippedDrawRect->Width * MARGIN, allClippedDrawRect->Height * MARGIN);
+        //########## 本来は割り当てられた領域の全体を使わず必要最低限のサイズがよい
+        // シェーダ用の計算式を求める。回転を考慮しない場合は以下のとおり
+        // movePeriod' = movePeriod * scaleX + offX     [[ movePeriod' = (movePeriod - tmpBoundsOnModel.movePeriod)*scale + layoutBoundsOnTex01.movePeriod ]]
+        csmFloat32 scaleX = layoutBoundsOnTex01->Width / _tmpBoundsOnModel.Width;
+        csmFloat32 scaleY = layoutBoundsOnTex01->Height / _tmpBoundsOnModel.Height;
+
+        // マスク生成時に使う行列を求める
+        createMatrixForMask(false, layoutBoundsOnTex01, scaleX, scaleY);
+
+        clipContext->_matrixForMask.SetMatrix(_tmpMatrixForMask.GetArray());
+        clipContext->_matrixForDraw.SetMatrix(_tmpMatrixForDraw.GetArray());
+
+        // 実際の描画を行う
+        const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
+        for (csmInt32 i = 0; i < clipDrawCount; i++)
+        {
+            const csmInt32 clipDrawIndex = clipContext->_clippingIdList[i];
+
+            // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
+            if (!model.GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
+            {
+                continue;
+            }
+
+            renderer->IsCulling(model.GetDrawableCulling(clipDrawIndex) != 0);
+
+            // レンダーパス開始時にマスクはクリアされているのでクリアする必要なし
+            // 今回専用の変換を適用して描く
+            // チャンネルも切り替える必要がある(A,R,G,B)
+            renderer->SetClippingContextBufferForMask(clipContext);
+            renderer->DrawMeshVulkan(model, clipDrawIndex, commandBuffer, updateCommandBuffer);
+        }
+    }
+    // --- 後処理 ---
+    _currentMaskBuffer->EndDraw(commandBuffer);
+    renderer->SetClippingContextBufferForMask(NULL);
+}
+
+/*********************************************************************************************************************
+*                                      CubismClippingContext_Vulkan
+********************************************************************************************************************/
+
+CubismClippingContext_Vulkan::CubismClippingContext_Vulkan(
+    CubismClippingManager<CubismClippingContext_Vulkan, CubismOffscreenSurface_Vulkan>* manager, CubismModel& model,
+    const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
+    : CubismClippingContext(clippingDrawableIndices, clipCount)
+{
+    _isUsing = false;
+
+    _owner = manager;
+
+    // クリップしている（＝マスク用の）Drawableのインデックスリスト
+    _clippingIdList = clippingDrawableIndices;
+
+    // マスクの数
+    _clippingIdCount = clipCount;
+
+    _layoutChannelNo = 0;
+
+    _allClippedDrawRect = CSM_NEW csmRectF();
+    _layoutBounds = CSM_NEW csmRectF();
+
+    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
+
+}
+
+CubismClippingContext_Vulkan::~CubismClippingContext_Vulkan()
+{}
+
+CubismClippingManager<CubismClippingContext_Vulkan, CubismOffscreenSurface_Vulkan>*
+CubismClippingContext_Vulkan::GetClippingManager()
+{
+    return _owner;
+}
+
+/*********************************************************************************************************************
+*                                      CubismPipeline_Vulkan
+********************************************************************************************************************/
+
+namespace {
+const csmInt32 ShaderCount = 19;
+///<シェーダの数 = マスク生成用 + (通常 + 加算 + 乗算) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
+CubismPipeline_Vulkan* s_pipelineManager;
+}
+
+CubismPipeline_Vulkan::CubismPipeline_Vulkan()
+{}
+
+CubismPipeline_Vulkan::~CubismPipeline_Vulkan()
+{
+    ReleaseShaderProgram();
+}
+
+VkShaderModule CubismPipeline_Vulkan::PipelineResource::CreateShaderModule(VkDevice device, std::string filename)
+{
+    std::ifstream file(filename, std::ios::ate | std::ios::binary);
+
+    if (!file.is_open())
+    {
+        CubismLogError("failed to open file!");
+    }
+
+    csmInt32 fileSize = (csmInt32)file.tellg();
+    csmVector<char> buffer(fileSize);
+
+    file.seekg(0);
+    file.read(buffer.GetPtr(), fileSize);
+    file.close();
+
+    VkShaderModuleCreateInfo createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    createInfo.codeSize = fileSize;
+    createInfo.pCode = reinterpret_cast<const csmUint32*>(buffer.GetPtr());
+
+    VkShaderModule shaderModule;
+    if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create shader module!");
+    }
+
+    return shaderModule;
+}
+
+void CubismPipeline_Vulkan::PipelineResource::CreateGraphicsPipeline(std::string vertFileName, std::string fragFileName,
+                                                                   VkDescriptorSetLayout descriptorSetLayout)
+{
+    VkShaderModule vertShaderModule = CreateShaderModule(s_device, vertFileName);
+    VkShaderModule fragShaderModule = CreateShaderModule(s_device, fragFileName);
+
+    _pipeline.Resize(4);
+    _pipelineLayout.Resize(4);
+
+    VkPipelineShaderStageCreateInfo vertShaderStageInfo{};
+    vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    vertShaderStageInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    vertShaderStageInfo.module = vertShaderModule;
+    vertShaderStageInfo.pName = "main";
+
+    VkPipelineShaderStageCreateInfo fragShaderStageInfo{};
+    fragShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    fragShaderStageInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    fragShaderStageInfo.module = fragShaderModule;
+    fragShaderStageInfo.pName = "main";
+
+    VkPipelineShaderStageCreateInfo shaderStages[] = {vertShaderStageInfo, fragShaderStageInfo};
+
+    VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
+    vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+    VkVertexInputBindingDescription bindingDescription = ModelVertex::GetBindingDescription();
+    VkVertexInputAttributeDescription attributeDescriptions[2];
+    ModelVertex::GetAttributeDescriptions(attributeDescriptions);
+    vertexInputInfo.vertexBindingDescriptionCount = 1;
+    vertexInputInfo.vertexAttributeDescriptionCount = sizeof(attributeDescriptions) / sizeof(attributeDescriptions[0]);
+    vertexInputInfo.pVertexBindingDescriptions = &bindingDescription;
+    vertexInputInfo.pVertexAttributeDescriptions = attributeDescriptions;
+
+    VkPipelineInputAssemblyStateCreateInfo inputAssembly{};
+    inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    inputAssembly.primitiveRestartEnable = VK_FALSE;
+
+    VkPipelineViewportStateCreateInfo viewportState{};
+    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewportState.viewportCount = 1;
+    viewportState.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rasterizer{};
+    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterizer.depthClampEnable = VK_FALSE;
+    rasterizer.rasterizerDiscardEnable = VK_FALSE;
+    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterizer.lineWidth = 1.0f;
+    rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+
+    VkPipelineMultisampleStateCreateInfo multisampling{};
+    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisampling.sampleShadingEnable = VK_FALSE;
+    multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    // 通常
+    VkPipelineColorBlendAttachmentState colorBlendAttachment{};
+    colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT
+            | VK_COLOR_COMPONENT_A_BIT;
+    colorBlendAttachment.blendEnable = VK_TRUE;
+    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+    colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+
+    VkPipelineColorBlendStateCreateInfo colorBlending{};
+    colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    colorBlending.logicOpEnable = VK_FALSE;
+    colorBlending.logicOp = VK_LOGIC_OP_COPY;
+    colorBlending.attachmentCount = 1;
+    colorBlending.pAttachments = &colorBlendAttachment;
+
+    VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipelineLayoutInfo.setLayoutCount = 1;
+    pipelineLayoutInfo.pSetLayouts = &descriptorSetLayout;
+
+    VkDynamicState dynamicState[3] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_CULL_MODE};
+
+    VkPipelineDynamicStateCreateInfo dynamicStateCI{};
+    dynamicStateCI.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamicStateCI.dynamicStateCount = sizeof(dynamicState) / sizeof(dynamicState[0]);
+    dynamicStateCI.pDynamicStates = dynamicState;
+
+    VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo{};
+    pipelineDepthStencilStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    pipelineDepthStencilStateCreateInfo.depthTestEnable = VK_TRUE;
+    pipelineDepthStencilStateCreateInfo.depthWriteEnable = VK_TRUE;
+    pipelineDepthStencilStateCreateInfo.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+    pipelineDepthStencilStateCreateInfo.back.compareOp = VK_COMPARE_OP_ALWAYS;
+
+    if (vkCreatePipelineLayout(s_device, &pipelineLayoutInfo, nullptr, &_pipelineLayout[Blend_Normal]) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create _pipeline layout!");
+    }
+
+    VkPipelineRenderingCreateInfo renderingInfo{};
+    renderingInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
+    renderingInfo.colorAttachmentCount = 1;
+    if (s_useRenderTarget)
+    {
+        renderingInfo.pColorAttachmentFormats = &s_imageFormat;
+    }
+    else
+    {
+        renderingInfo.pColorAttachmentFormats = &s_swapchainImageFormat;
+    }
+    renderingInfo.depthAttachmentFormat = s_depthFormat;
+
+    VkGraphicsPipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipelineInfo.stageCount = 2;
+    pipelineInfo.pStages = shaderStages;
+    pipelineInfo.pVertexInputState = &vertexInputInfo;
+    pipelineInfo.pInputAssemblyState = &inputAssembly;
+    pipelineInfo.pViewportState = &viewportState;
+    pipelineInfo.pRasterizationState = &rasterizer;
+    pipelineInfo.pMultisampleState = &multisampling;
+    pipelineInfo.pColorBlendState = &colorBlending;
+    pipelineInfo.layout = _pipelineLayout[Blend_Normal];
+    pipelineInfo.subpass = 0;
+    pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
+    pipelineInfo.pDynamicState = &dynamicStateCI;
+    pipelineInfo.pDepthStencilState = &pipelineDepthStencilStateCreateInfo;
+    pipelineInfo.pNext = &renderingInfo;
+
+    if (vkCreateGraphicsPipelines(s_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &_pipeline[Blend_Normal]) !=
+        VK_SUCCESS)
+    {
+        CubismLogError("failed to create graphics _pipeline!");
+    }
+
+    // 加算
+    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    if (vkCreatePipelineLayout(s_device, &pipelineLayoutInfo, nullptr, &_pipelineLayout[Blend_Add]) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create _pipeline layout!");
+    }
+    pipelineInfo.layout = _pipelineLayout[Blend_Add];
+    if (vkCreateGraphicsPipelines(s_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &_pipeline[Blend_Add]) !=
+        VK_SUCCESS)
+    {
+        CubismLogError("failed to create graphics _pipeline!");
+    }
+
+    // 乗算
+    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_DST_COLOR;
+    colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    if (vkCreatePipelineLayout(s_device, &pipelineLayoutInfo, nullptr, &_pipelineLayout[Blend_Mult]) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create _pipeline layout!");
+    }
+    pipelineInfo.layout = _pipelineLayout[Blend_Mult];
+    if (vkCreateGraphicsPipelines(s_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &_pipeline[Blend_Mult]) !=
+        VK_SUCCESS)
+    {
+        CubismLogError("failed to create graphics _pipeline!");
+    }
+
+    // マスク
+    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ZERO;
+    colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+    colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    if (vkCreatePipelineLayout(s_device, &pipelineLayoutInfo, nullptr, &_pipelineLayout[Blend_Mask]) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create _pipeline layout!");
+    }
+    renderingInfo.pColorAttachmentFormats = &s_imageFormat;
+    pipelineInfo.layout = _pipelineLayout[Blend_Mask];
+    if (vkCreateGraphicsPipelines(s_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &_pipeline[Blend_Mask]) !=
+        VK_SUCCESS)
+    {
+        CubismLogError("failed to create graphics _pipeline!");
+    }
+
+    vkDestroyShaderModule(s_device, vertShaderModule, nullptr);
+    vkDestroyShaderModule(s_device, fragShaderModule, nullptr);
+}
+
+void CubismPipeline_Vulkan::PipelineResource::Release()
+{
+    for (csmInt32 i = 0; i < 4; i++)
+    {
+        vkDestroyPipeline(s_device, _pipeline[i], nullptr);
+        vkDestroyPipelineLayout(s_device, _pipelineLayout[i], nullptr);
+    }
+    _pipeline.Clear();
+    _pipelineLayout.Clear();
+}
+
+void CubismPipeline_Vulkan::CreatePipelines(VkDescriptorSetLayout descriptorSetLayout)
+{
+    //パイプラインを作成済みの場合は生成する必要なし
+    if (_pipelineResource.GetSize() != 0)
+    {
+        return;
+    }
+
+    for (csmInt32 i = 0; i < ShaderCount; i++)
+    {
+        _pipelineResource.PushBack(CSM_NEW PipelineResource);
+    }
+
+    _pipelineResource[0]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrcSetupMask.spv", "FrameworkShaders/FragShaderSrcSetupMask.spv", descriptorSetLayout);
+    _pipelineResource[1]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrc.spv", "FrameworkShaders/FragShaderSrc.spv", descriptorSetLayout);
+    _pipelineResource[2]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrcMasked.spv", "FrameworkShaders/FragShaderSrcMask.spv", descriptorSetLayout);
+    _pipelineResource[3]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrcMasked.spv", "FrameworkShaders/FragShaderSrcMaskInverted.spv", descriptorSetLayout);
+    _pipelineResource[4]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrc.spv", "FrameworkShaders/FragShaderSrcPremultipliedAlpha.spv", descriptorSetLayout);
+    _pipelineResource[5]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrcMasked.spv", "FrameworkShaders/FragShaderSrcMaskPremultipliedAlpha.spv", descriptorSetLayout);
+    _pipelineResource[6]->CreateGraphicsPipeline("FrameworkShaders/VertShaderSrcMasked.spv", "FrameworkShaders/FragShaderSrcMaskInvertedPremultipliedAlpha.spv", descriptorSetLayout);
+
+    _pipelineResource[7] = _pipelineResource[1];
+    _pipelineResource[8] = _pipelineResource[2];
+    _pipelineResource[9] = _pipelineResource[3];
+    _pipelineResource[10] = _pipelineResource[4];
+    _pipelineResource[11] = _pipelineResource[5];
+    _pipelineResource[12] = _pipelineResource[6];
+
+    _pipelineResource[13] = _pipelineResource[1];
+    _pipelineResource[14] = _pipelineResource[2];
+    _pipelineResource[15] = _pipelineResource[3];
+    _pipelineResource[16] = _pipelineResource[4];
+    _pipelineResource[17] = _pipelineResource[5];
+    _pipelineResource[18] = _pipelineResource[6];
+}
+
+CubismPipeline_Vulkan* CubismPipeline_Vulkan::GetInstance()
+{
+    if (s_pipelineManager == NULL)
+    {
+        s_pipelineManager = CSM_NEW CubismPipeline_Vulkan();
+    }
+    return s_pipelineManager;
+}
+
+void CubismPipeline_Vulkan::ReleaseShaderProgram()
+{
+    for (csmInt32 i = 0; i < 7; i++)
+    {
+        _pipelineResource[i]->Release();
+    }
+}
+
+/*********************************************************************************************************************
+*                                       CubismRenderer_Vulkan
+********************************************************************************************************************/
+
+CubismRenderer* CubismRenderer::Create()
+{
+    return CSM_NEW CubismRenderer_Vulkan;
+}
+
+void CubismRenderer::StaticRelease()
+{
+    CubismRenderer_Vulkan::DoStaticRelease();
+}
+
+CubismRenderer_Vulkan::CubismRenderer_Vulkan() :
+                                               vkCmdSetCullModeEXT()
+                                               , _clippingManager(NULL)
+                                               , _clippingContextBufferForMask(NULL)
+                                               , _clippingContextBufferForDraw(NULL)
+                                               , _ubo()
+                                               , _descriptorPool(VK_NULL_HANDLE)
+                                               , _descriptorSetLayout(VK_NULL_HANDLE)
+                                               , _clearColor()
+{}
+
+CubismRenderer_Vulkan::~CubismRenderer_Vulkan()
+{
+    // オフスクリーンを作成していたのなら開放
+    for (csmInt32 i = 0; i < _offscreenFrameBuffers.GetSize(); i++)
+    {
+        _offscreenFrameBuffers[i].DestroyOffscreenSurface(s_device);
+    }
+    _offscreenFrameBuffers.Clear();
+
+    _depthImage.Destroy(s_device);
+    vkDestroySemaphore(s_device, _updateFinishedSemaphore, nullptr);
+    vkDestroyDescriptorPool(s_device, _descriptorPool, nullptr);
+    vkDestroyDescriptorSetLayout(s_device, _descriptorSetLayout, nullptr);
+
+    for (csmUint32 i = 0; i < _vertexBuffers.GetSize(); i++)
+    {
+        _vertexBuffers[i].Destroy(s_device);
+    }
+
+    for (csmUint32 i = 0; i < _stagingBuffers.GetSize(); i++)
+    {
+        _stagingBuffers[i].Destroy(s_device);
+    }
+
+    for (csmUint32 i = 0; i < _indexBuffers.GetSize(); i++)
+    {
+        _indexBuffers[i].Destroy(s_device);
+    }
+
+    for (csmInt32 i = 0; i < _descriptorSets.GetSize(); i++)
+    {
+        _descriptorSets[i].uniformBuffer.Destroy(s_device);
+    }
+
+    CSM_DELETE_SELF(CubismClippingManager_Vulkan, _clippingManager);
+}
+
+void CubismRenderer_Vulkan::DoStaticRelease()
+{
+    if (s_pipelineManager)
+    {
+        CSM_DELETE_SELF(CubismPipeline_Vulkan, s_pipelineManager);
+        s_pipelineManager = NULL;
+    }
+}
+
+VkCommandBuffer CubismRenderer_Vulkan::BeginSingleTimeCommands()
+{
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandPool = s_commandPool;
+    allocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer commandBuffer;
+    vkAllocateCommandBuffers(s_device, &allocInfo, &commandBuffer);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    vkBeginCommandBuffer(commandBuffer, &beginInfo);
+
+    return commandBuffer;
+}
+
+void CubismRenderer_Vulkan::SubmitCommand(VkCommandBuffer commandBuffer, VkSemaphore signalUpdateFinishedSemaphore, VkSemaphore waitUpdateFinishedSemaphore)
+{
+    vkEndCommandBuffer(commandBuffer);
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &commandBuffer;
+    if(waitUpdateFinishedSemaphore != VK_NULL_HANDLE)
+    {
+        submitInfo.waitSemaphoreCount = 1;
+        submitInfo.pWaitSemaphores = &waitUpdateFinishedSemaphore;
+        vkQueueSubmit(s_queue, 1, &submitInfo, nullptr);
+        vkQueueWaitIdle(s_queue);
+    }
+    else if (signalUpdateFinishedSemaphore != VK_NULL_HANDLE)
+    {
+        submitInfo.signalSemaphoreCount = 1;
+        submitInfo.pSignalSemaphores = &signalUpdateFinishedSemaphore;
+        vkQueueSubmit(s_queue, 1, &submitInfo, nullptr);
+    }
+    else
+    {
+        vkQueueSubmit(s_queue, 1, &submitInfo, nullptr);
+        vkQueueWaitIdle(s_queue);
+        vkFreeCommandBuffers(s_device, s_commandPool, 1, &commandBuffer);
+    }
+
+}
+
+void CubismRenderer_Vulkan::InitializeConstantSettings(
+    VkDevice device, VkPhysicalDevice physicalDevice,
+    VkCommandPool commandPool, VkQueue queue,
+    VkExtent2D extent, VkFormat imageFormat, VkFormat surfaceFormat, VkImage swapchainImage,
+    VkImageView swapchainImageView,
+    VkFormat dFormat)
+{
+    s_device = device;
+    s_physicalDevice = physicalDevice;
+    s_commandPool = commandPool;
+    s_queue = queue;
+    s_swapchainExtent = extent;
+    s_swapchainImageFormat = imageFormat;
+    s_imageFormat = surfaceFormat;
+    s_swapchainImage = swapchainImage;
+    s_swapchainImageView = swapchainImageView;
+    s_depthFormat = dFormat;
+}
+
+void CubismRenderer_Vulkan::EnableChangeRenderTarget()
+{
+    s_useRenderTarget = true;
+}
+
+void CubismRenderer_Vulkan::SetRenderTarget(VkImage image, VkImageView imageview)
+{
+    s_renderTargetImage = image;
+    s_renderTargetImageView = imageview;
+}
+
+void CubismRenderer_Vulkan::UpdateSwapchainVariable(VkExtent2D extent, VkImage image,
+                                                    VkImageView imageView)
+{
+    s_swapchainExtent = extent;
+    s_swapchainImage = image;
+    s_swapchainImageView = imageView;
+}
+
+void CubismRenderer_Vulkan::UpdateRendererSettings(VkImage image, VkImageView imageView)
+{
+    s_swapchainImage = image;
+    s_swapchainImageView = imageView;
+}
+
+void CubismRenderer_Vulkan::CreateCommandBuffer()
+{
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.commandPool = s_commandPool;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandBufferCount = 1;
+    if (vkAllocateCommandBuffers(s_device, &allocInfo, &updateCommandBuffer) != VK_SUCCESS || vkAllocateCommandBuffers(
+        s_device, &allocInfo, &drawCommandBuffer) != VK_SUCCESS)
+    {
+        CubismLogError("failed to allocate command buffers!");
+    }
+}
+
+void CubismRenderer_Vulkan::CreateVertexBuffer()
+{
+    const csmInt32 drawableCount = GetModel()->GetDrawableCount();
+    _vertexBuffers.Resize(drawableCount);
+
+    for (csmInt32 drawAssign = 0; drawAssign < drawableCount; drawAssign++)
+    {
+        const csmInt32 vcount = GetModel()->GetDrawableVertexCount(drawAssign);
+        if (vcount != 0)
+        {
+            //頂点データは初期化できない
+
+            VkDeviceSize bufferSize = sizeof(ModelVertex) * vcount; // 総長 構造体サイズ*個数
+            CubismBufferVulkan stagingBuffer;
+            stagingBuffer.CreateBuffer(s_device, s_physicalDevice, bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+            stagingBuffer.Map(s_device, bufferSize);
+            _stagingBuffers.PushBack(stagingBuffer);
+
+            CubismBufferVulkan vertexBuffer;
+            vertexBuffer.CreateBuffer(s_device, s_physicalDevice, bufferSize,
+                                      VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                                      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            _vertexBuffers[drawAssign] = vertexBuffer;
+        }
+    }
+}
+
+void CubismRenderer_Vulkan::CreateIndexBuffer()
+{
+    const csmInt32 drawableCount = GetModel()->GetDrawableCount();
+    _indexBuffers.Resize(drawableCount);
+
+    for (csmInt32 drawAssign = 0; drawAssign < drawableCount; drawAssign++)
+    {
+        const csmInt32 icount = GetModel()->GetDrawableVertexIndexCount(drawAssign);
+        if (icount != 0)
+        {
+            VkDeviceSize bufferSize = sizeof(uint16_t) * icount;
+            const csmUint16* indices = GetModel()->GetDrawableVertexIndices(drawAssign);
+
+            CubismBufferVulkan stagingBuffer;
+            stagingBuffer.CreateBuffer(s_device, s_physicalDevice, bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            stagingBuffer.Map(s_device, bufferSize);
+            stagingBuffer.MemCpy(indices, bufferSize);
+            stagingBuffer.UnMap(s_device);
+
+            CubismBufferVulkan indexBuffer;
+            indexBuffer.CreateBuffer(s_device, s_physicalDevice, bufferSize,
+                                     VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+                                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+            VkCommandBuffer commandBuffer = BeginSingleTimeCommands();
+
+            VkBufferCopy copyRegion{};
+            copyRegion.size = bufferSize;
+            vkCmdCopyBuffer(commandBuffer, stagingBuffer.GetBuffer(), indexBuffer.GetBuffer(), 1, &copyRegion);
+            SubmitCommand(commandBuffer);
+            _indexBuffers[drawAssign] = indexBuffer;
+            stagingBuffer.Destroy(s_device);
+        }
+    }
+}
+
+void CubismRenderer_Vulkan::CreateDescriptorSets()
+{
+    // ディスクリプタプールの作成
+    const csmInt32 drawableCount = GetModel()->GetDrawableCount();
+
+    VkDescriptorPoolSize poolSizes[2]{};
+    poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    poolSizes[0].descriptorCount = drawableCount;
+    poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    poolSizes[1].descriptorCount = drawableCount * 2; // drawableCount*マスクを用いるか*テクスチャの数
+
+    VkDescriptorPoolCreateInfo poolInfo{};
+    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    poolInfo.poolSizeCount = sizeof(poolSizes) / sizeof(poolSizes[0]);
+    poolInfo.pPoolSizes = poolSizes;
+    poolInfo.maxSets = drawableCount * 2;
+
+    if (vkCreateDescriptorPool(s_device, &poolInfo, nullptr, &_descriptorPool) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create descriptor pool!");
+    }
+
+    // ディスクリプタセットレイアウトの作成
+    VkDescriptorSetLayoutBinding bindings[3];
+    bindings[0].binding = 0;
+    bindings[0].descriptorCount = 1;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    bindings[0].pImmutableSamplers = nullptr;
+    bindings[0].stageFlags = VK_SHADER_STAGE_ALL;
+
+    bindings[1].binding = 1;
+    bindings[1].descriptorCount = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[1].pImmutableSamplers = nullptr;
+    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    bindings[2].binding = 2;
+    bindings[2].descriptorCount = 1;
+    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[2].pImmutableSamplers = nullptr;
+    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    VkDescriptorSetLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layoutInfo.bindingCount = sizeof(bindings) / sizeof(bindings[0]);
+    layoutInfo.pBindings = bindings;
+
+    if (vkCreateDescriptorSetLayout(s_device, &layoutInfo, nullptr, &_descriptorSetLayout) != VK_SUCCESS)
+    {
+        CubismLogError("failed to create descriptor set layout!");
+    }
+
+    _descriptorSets.Resize(drawableCount);
+
+    for (csmInt32 drawAssign = 0; drawAssign < drawableCount; drawAssign++)
+    {
+        _descriptorSets[drawAssign].uniformBuffer.CreateBuffer(s_device, s_physicalDevice, sizeof(ModelUBO),
+            VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        _descriptorSets[drawAssign].uniformBuffer.Map(s_device, VK_WHOLE_SIZE);
+    }
+
+    VkDescriptorSetAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    allocInfo.descriptorPool = _descriptorPool;
+    allocInfo.descriptorSetCount = drawableCount * 2;
+    csmVector<VkDescriptorSetLayout> layouts;
+    csmVector<VkDescriptorSet> descriptorSets;
+    descriptorSets.Resize(drawableCount * 2);
+    for (csmInt32 i = 0; i < drawableCount * 2; i++)
+    {
+        layouts.PushBack(_descriptorSetLayout);
+    }
+    allocInfo.pSetLayouts = layouts.GetPtr();
+    if (vkAllocateDescriptorSets(s_device, &allocInfo, descriptorSets.GetPtr()) != VK_SUCCESS)
+    {
+        CubismLogError("failed to allocate descriptor sets!");
+    }
+
+    for (csmInt32 drawAssign = 0; drawAssign < drawableCount; drawAssign++)
+    {
+        _descriptorSets[drawAssign].descriptorSet = descriptorSets[drawAssign * 2];
+        _descriptorSets[drawAssign].descriptorSetMasked = descriptorSets[drawAssign * 2 + 1];
+    }
+}
+
+void CubismRenderer_Vulkan::CreateDepthBuffer()
+{
+    _depthImage.CreateImage(s_device, s_physicalDevice, s_swapchainExtent.width, s_swapchainExtent.height,
+        1, s_depthFormat, VK_IMAGE_TILING_OPTIMAL,
+        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    _depthImage.CreateView(s_device, s_depthFormat,
+        VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 1);
+}
+
+void CubismRenderer_Vulkan::InitializeRenderer()
+{
+    vkCmdSetCullModeEXT = reinterpret_cast<PFN_vkCmdSetCullMode>(vkGetDeviceProcAddr(s_device, "vkCmdSetCullModeEXT"));
+
+    VkSemaphoreCreateInfo semaphoreInfo{};
+    semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    vkCreateSemaphore(s_device, &semaphoreInfo, nullptr, &_updateFinishedSemaphore);
+
+    CreateCommandBuffer();
+    CreateVertexBuffer();
+    CreateIndexBuffer();
+    CreateDescriptorSets();
+    CreateDepthBuffer();
+    CubismPipeline_Vulkan::GetInstance()->CreatePipelines(_descriptorSetLayout);
+}
+
+void CubismRenderer_Vulkan::Initialize(CubismModel* model)
+{
+    Initialize(model, 1);
+}
+
+void CubismRenderer_Vulkan::Initialize(CubismModel* model, csmInt32 maskBufferCount)
+{
+    if (s_device == nullptr)
+    {
+        CubismLogError("Device has not been set.");
+        CSM_ASSERT(0);
+        return;
+    }
+
+    if (model->IsUsingMasking())
+    {
+        //モデルがマスクを使用している時のみにする
+        _clippingManager = CSM_NEW CubismClippingManager_Vulkan();
+        _clippingManager->Initialize(
+            *model,
+            maskBufferCount
+        );
+    }
+
+    _sortedDrawableIndexList.Resize(model->GetDrawableCount(), 0);
+
+    CubismRenderer::Initialize(model, maskBufferCount); // 親クラスの処理を呼ぶ
+
+    // 1未満は1に補正する
+    if (maskBufferCount < 1)
+    {
+        maskBufferCount = 1;
+        CubismLogWarning(
+            "The number of render textures must be an integer greater than or equal to 1. Set the number of render textures to 1.");
+    }
+    if (model->IsUsingMasking())
+    {
+        const csmInt32 bufferWidth = static_cast<csmInt32>(_clippingManager->GetClippingMaskBufferSize().X);
+        const csmInt32 bufferHeight = static_cast<csmInt32>(_clippingManager->GetClippingMaskBufferSize().Y);
+
+        _offscreenFrameBuffers.Clear();
+        _offscreenFrameBuffers.Resize(maskBufferCount);
+        // バックバッファ分確保
+        for (csmInt32 i = 0; i < maskBufferCount; i++)
+        {
+            _offscreenFrameBuffers[i].CreateOffscreenSurface(s_device, s_physicalDevice, bufferWidth, bufferHeight,
+                s_imageFormat, s_depthFormat);
+        }
+    }
+
+    InitializeRenderer();
+}
+
+void CubismRenderer_Vulkan::CopyToBuffer(csmInt32 drawAssign, const csmInt32 vcount, const csmFloat32* varray,
+                                         const csmFloat32* uvarray, VkCommandBuffer commandBuffer)
+{
+    csmVector<ModelVertex> vertices;
+
+    for (csmInt32 ct = 0; ct < vcount * 2; ct += 2)
+    {
+        ModelVertex vertex;
+        // モデルデータからのコピー
+        vertex.pos.X = varray[ct + 0];
+        vertex.pos.Y = varray[ct + 1];
+        vertex.texCoord.X = uvarray[ct + 0];
+        vertex.texCoord.Y = uvarray[ct + 1];
+        vertices.PushBack(vertex);
+    }
+    csmUint32 bufferSize = sizeof(ModelVertex) * vertices.GetSize();
+    _stagingBuffers[drawAssign].MemCpy(vertices.GetPtr(), (size_t)bufferSize);
+
+    VkBufferCopy copyRegion{};
+    copyRegion.size = bufferSize;
+    vkCmdCopyBuffer(commandBuffer, _stagingBuffers[drawAssign].GetBuffer(), _vertexBuffers[drawAssign].GetBuffer(), 1,
+                    &copyRegion);
+}
+
+void CubismRenderer_Vulkan::UpdateMatrix(csmFloat32 vkMat16[16], CubismMatrix44 cubismMat)
+{
+    for (int i = 0; i < 16; i++)
+    {
+        vkMat16[i] = cubismMat.GetArray()[i];
+    }
+}
+
+void CubismRenderer_Vulkan::UpdateColor(csmFloat32 vkVec4[4], csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
+{
+    vkVec4[0] = r;
+    vkVec4[1] = g;
+    vkVec4[2] = b;
+    vkVec4[3] = a;
+}
+
+void CubismRenderer_Vulkan::UpdateDescriptorSet(Descriptor& descriptor, csmUint32 textureIndex, bool isMasked)
+{
+    VkBuffer uniformBuffer = descriptor.uniformBuffer.GetBuffer();
+    // descriptorが更新されていない最初の1回のみ行う
+    VkDescriptorSet descriptorSet;
+    if (isMasked && !descriptor.isDescriptorSetMaskedUpdated)
+    {
+        descriptorSet = descriptor.descriptorSetMasked;
+        descriptor.isDescriptorSetMaskedUpdated = true;
+    }
+    else if (!descriptor.isDescriptorSetUpdated)
+    {
+        descriptorSet = descriptor.descriptorSet;
+        descriptor.isDescriptorSetUpdated = true;
+    }
+    else
+    {
+        return;
+    }
+
+    csmVector<VkWriteDescriptorSet> descriptorWrites{};
+
+    VkDescriptorBufferInfo uniformBufferInfo{};
+    uniformBufferInfo.buffer = uniformBuffer;
+    uniformBufferInfo.offset = 0;
+    uniformBufferInfo.range = VK_WHOLE_SIZE;
+    VkWriteDescriptorSet ubo{};
+    ubo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    ubo.dstSet = descriptorSet;
+    ubo.dstBinding = 0;
+    ubo.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    ubo.descriptorCount = 1;
+    ubo.pBufferInfo = &uniformBufferInfo;
+    descriptorWrites.PushBack(ubo);
+
+    //テクスチャ1はキャラクターのテクスチャ、テクスチャ2はマスク用のオフスクリーンに使用するテクスチャ
+    VkDescriptorImageInfo imageInfo1{};
+    imageInfo1.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    imageInfo1.imageView = _textures[textureIndex].GetView();
+    imageInfo1.sampler = _textures[textureIndex].GetSampler();
+    VkWriteDescriptorSet image1{};
+    image1.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    image1.dstSet = descriptorSet;
+    image1.dstBinding = 1;
+    image1.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    image1.descriptorCount = 1;
+    image1.pImageInfo = &imageInfo1;
+    descriptorWrites.PushBack(image1);
+
+    if (isMasked)
+    {
+        VkDescriptorImageInfo imageInfo2{};
+        imageInfo2.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        imageInfo2.imageView = _offscreenFrameBuffers[GetClippingContextBufferForDraw()->
+            _bufferIndex].GetTextureView();
+        imageInfo2.sampler = _offscreenFrameBuffers[GetClippingContextBufferForDraw()->
+            _bufferIndex].GetTextureSampler();
+        VkWriteDescriptorSet image2{};
+        image2.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        image2.dstSet = descriptorSet;
+        image2.dstBinding = 2;
+        image2.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        image2.descriptorCount = 1;
+        image2.pImageInfo = &imageInfo2;
+        descriptorWrites.PushBack(image2);
+    }
+
+    vkUpdateDescriptorSets(s_device, descriptorWrites.GetSize(), descriptorWrites.GetPtr(), 0, NULL);
+}
+
+void CubismRenderer_Vulkan::ExecuteDrawForDraw(const CubismModel& model, const csmInt32 index, VkCommandBuffer& cmdBuffer)
+{
+    csmUint32 blendIndex = 0;
+    csmUint32 shaderIndex = 0;
+    const csmBool masked = GetClippingContextBufferForDraw() != NULL; // この描画オブジェクトはマスク対象か
+    const csmBool invertedMask = model.GetDrawableInvertedMask(index);
+    const csmInt32 offset = (masked ? (invertedMask ? 2 : 1) : 0) + (IsPremultipliedAlpha() ? 3 : 0);
+
+    switch (model.GetDrawableBlendMode(index))
+    {
+    default:
+        shaderIndex = ShaderNames_Normal + offset;
+        blendIndex = Blend_Normal;
+        break;
+
+    case CubismRenderer::CubismBlendMode_Additive:
+        shaderIndex = ShaderNames_Add + offset;
+        blendIndex = Blend_Add;
+        break;
+
+    case CubismRenderer::CubismBlendMode_Multiplicative:
+        shaderIndex = ShaderNames_Mult + offset;
+        blendIndex = Blend_Mult;
+        break;
+    }
+
+    Descriptor &descriptor = _descriptorSets[index];
+    if (masked)
+    {
+        CubismMatrix44 mvp = GetClippingContextBufferForDraw()->_matrixForDraw;
+        UpdateMatrix(_ubo.clipMatrix, mvp); // テクスチャ座標の変換に使用するのでy軸の向きは反転しない
+        const csmInt32 channelNo = GetClippingContextBufferForDraw()->_layoutChannelNo;
+        CubismTextureColor *colorChannel = GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        UpdateColor(_ubo.channelFlag, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
+    }
+
+    CubismMatrix44 mvp = GetMvpMatrix();
+    CubismTextureColor baseColor = GetModelColor();
+    baseColor.A *= model.GetDrawableOpacity(index);
+    if (IsPremultipliedAlpha())
+    {
+        baseColor.R *= baseColor.A;
+        baseColor.G *= baseColor.A;
+        baseColor.B *= baseColor.A;
+    }
+    CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+    CubismTextureColor screenColor = model.GetScreenColor(index);
+    UpdateMatrix(_ubo.projectionMatrix, mvp);
+    UpdateColor(_ubo.baseColor, baseColor.R, baseColor.G, baseColor.B, baseColor.A);
+    UpdateColor(_ubo.multiplyColor, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A);
+    UpdateColor(_ubo.screenColor, screenColor.R, screenColor.G, screenColor.B, screenColor.A);
+    descriptor.uniformBuffer.MemCpy(&_ubo, sizeof(ModelUBO));
+
+    vkCmdBindPipeline(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                      CubismPipeline_Vulkan::GetInstance()->GetPipeline(shaderIndex, blendIndex));
+
+    VkBuffer vertexBuffers[] = {_vertexBuffers[index].GetBuffer()};
+    VkDeviceSize offsets[] = {0};
+    vkCmdBindVertexBuffers(cmdBuffer, 0, 1, vertexBuffers, offsets);
+    vkCmdBindIndexBuffer(cmdBuffer, _indexBuffers[index].GetBuffer(), 0, VK_INDEX_TYPE_UINT16);
+
+    csmInt32 textureNo = model.GetDrawableTextureIndex(index);
+    if (masked)
+    {
+        UpdateDescriptorSet(descriptor, textureNo, true);
+        vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(shaderIndex, blendIndex), 0,
+                                1,
+                                &_descriptorSets[index].descriptorSetMasked, 0,
+                                nullptr);
+    }
+    else
+    {
+        UpdateDescriptorSet(descriptor, textureNo, false);
+        vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(shaderIndex, blendIndex), 0,
+                                1,
+                                &_descriptorSets[index].descriptorSet, 0,
+                                nullptr);
+    }
+
+    vkCmdDrawIndexed(cmdBuffer, model.GetDrawableVertexIndexCount(index), 1, 0, 0, 0);
+}
+
+void CubismRenderer_Vulkan::ExecuteDrawForMask(const CubismModel& model, const csmInt32 index, VkCommandBuffer& cmdBuffer)
+{
+    const csmInt32 channelNo = GetClippingContextBufferForMask()->_layoutChannelNo;
+    CubismTextureColor *colorChannel = GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    csmRectF *rect = GetClippingContextBufferForMask()->_layoutBounds;
+    UpdateMatrix(_ubo.clipMatrix, GetClippingContextBufferForMask()->_matrixForMask);
+    UpdateColor(_ubo.baseColor, rect->X * 2.0f - 1.0f, rect->Y * 2.0f - 1.0f, rect->GetRight() * 2.0f - 1.0f,
+                rect->GetBottom() * 2.0f - 1.0f);
+
+    CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
+    CubismTextureColor screenColor = model.GetScreenColor(index);
+    UpdateColor(_ubo.multiplyColor, multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A);
+    UpdateColor(_ubo.screenColor, screenColor.R, screenColor.G, screenColor.B, screenColor.A);
+    UpdateColor(_ubo.channelFlag, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
+    Descriptor &descriptor = _descriptorSets[index];
+    descriptor.uniformBuffer.MemCpy(&_ubo, sizeof(ModelUBO));
+    csmInt32 textureNo = model.GetDrawableTextureIndex(index);
+    UpdateDescriptorSet(descriptor, textureNo, false);
+
+    csmUint32 shaderIndex = ShaderNames_SetupMask;
+    csmUint32 blendIndex = Blend_Mask;
+    vkCmdBindPipeline(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                      CubismPipeline_Vulkan::GetInstance()->GetPipeline(shaderIndex, blendIndex));
+    VkBuffer vertexBuffers[] = {_vertexBuffers[index].GetBuffer()};
+    VkDeviceSize offsets[] = {0};
+    vkCmdBindVertexBuffers(cmdBuffer, 0, 1, vertexBuffers, offsets);
+    vkCmdBindIndexBuffer(cmdBuffer, _indexBuffers[index].GetBuffer(), 0, VK_INDEX_TYPE_UINT16);
+    vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(shaderIndex, blendIndex), 0, 1,
+                            &_descriptorSets[index].descriptorSet, 0, nullptr);
+    vkCmdDrawIndexed(cmdBuffer, model.GetDrawableVertexIndexCount(index), 1, 0, 0, 0);
+}
+
+void CubismRenderer_Vulkan::DrawMeshVulkan(const CubismModel& model, const csmInt32 index,
+                                           VkCommandBuffer commandBuffer, VkCommandBuffer updateCommandBuffer)
+{
+    if (s_device == VK_NULL_HANDLE)
+    {
+        // デバイス未設定
+        return;
+    }
+    if (model.GetDrawableVertexIndexCount(index) == 0)
+    {
+        // 描画物無し
+        return;
+    }
+    if (model.GetDrawableOpacity(index) <= 0.0f && GetClippingContextBufferForMask() == NULL)
+    {
+        // 描画不要なら描画処理をスキップする
+        return;
+    }
+
+    csmInt32 textureNo = model.GetDrawableTextureIndices(index);
+    if (_textures[textureNo].GetSampler() == VK_NULL_HANDLE || _textures[textureNo].GetView() == VK_NULL_HANDLE)
+    {
+        return;
+    }
+
+    // 裏面描画の有効・無効
+    if (IsCulling())
+    {
+        vkCmdSetCullModeEXT(commandBuffer, VK_CULL_MODE_BACK_BIT);
+    }
+    else
+    {
+        vkCmdSetCullModeEXT(commandBuffer, VK_CULL_MODE_NONE);
+    }
+
+    // 頂点バッファにコピー
+    CopyToBuffer(index, model.GetDrawableVertexCount(index),
+                 const_cast<csmFloat32*>(model.GetDrawableVertices(index)),
+                 reinterpret_cast<csmFloat32*>(const_cast<Core::csmVector2*>(model.GetDrawableVertexUvs(index))),
+                 updateCommandBuffer);
+
+    if (GetClippingContextBufferForMask() != NULL) // マスク生成時
+    {
+        ExecuteDrawForMask(model, index, commandBuffer);
+    }
+    else
+    {
+        ExecuteDrawForDraw(model, index, commandBuffer);
+    }
+
+    SetClippingContextBufferForDraw(NULL);
+    SetClippingContextBufferForMask(NULL);
+}
+
+void CubismRenderer_Vulkan::BeginRendering(VkCommandBuffer drawCommandBuffer, bool isResume)
+{
+    VkClearValue clearValue[2];
+    clearValue[0].color = _clearColor.color;
+    clearValue[1].depthStencil = {1.0, 0};
+
+    VkRenderingAttachmentInfoKHR colorAttachment{};
+    colorAttachment.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO_KHR;
+    if (s_useRenderTarget)
+    {
+        colorAttachment.imageView = s_renderTargetImageView;
+        if (isResume)
+        {
+            colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        }
+        else
+        {
+            colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        }
+    }
+    else
+    {
+        colorAttachment.imageView = s_swapchainImageView;
+        colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    }
+    colorAttachment.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    colorAttachment.clearValue = *clearValue;
+
+    VkRenderingAttachmentInfoKHR depthStencilAttachment{};
+    depthStencilAttachment.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO_KHR;
+    depthStencilAttachment.imageView = _depthImage.GetView();
+    depthStencilAttachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    depthStencilAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depthStencilAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthStencilAttachment.clearValue = {1.0f, 0};
+
+    VkRenderingInfo renderingInfo{};
+    renderingInfo.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
+    renderingInfo.renderArea = {{0, 0}, {s_swapchainExtent}};
+    renderingInfo.layerCount = 1;
+    renderingInfo.colorAttachmentCount = 1;
+    renderingInfo.pColorAttachments = &colorAttachment;
+    renderingInfo.pDepthAttachment = &depthStencilAttachment;
+
+    vkCmdBeginRendering(drawCommandBuffer, &renderingInfo);
+}
+
+void CubismRenderer_Vulkan::EndRendering(VkCommandBuffer drawCommandBuffer)
+{
+    vkCmdEndRendering(drawCommandBuffer);
+
+    // レイアウト変更
+    if (s_useRenderTarget)
+    {
+        VkImageMemoryBarrier memoryBarrier{};
+        memoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        memoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        memoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        memoryBarrier.image = s_renderTargetImage;
+        memoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+        vkCmdPipelineBarrier(drawCommandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &memoryBarrier);
+    }
+    else
+    {
+        VkImageMemoryBarrier memoryBarrier{};
+        memoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        memoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        memoryBarrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+        memoryBarrier.image = s_swapchainImage;
+        memoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+        vkCmdPipelineBarrier(drawCommandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &memoryBarrier);
+    }
+}
+
+void CubismRenderer_Vulkan::DoDrawModel()
+{
+    //------------ クリッピングマスク・バッファ前処理方式の場合 ------------
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    vkBeginCommandBuffer(updateCommandBuffer, &beginInfo);
+    vkBeginCommandBuffer(drawCommandBuffer, &beginInfo);
+
+    if (_clippingManager != NULL)
+    {
+        // サイズが違う場合はここで作成しなおし
+        for (csmInt32 i = 0; i < _clippingManager->GetRenderTextureCount(); ++i)
+        {
+            if (_offscreenFrameBuffers[i].GetBufferWidth() != static_cast<csmUint32>(
+                _clippingManager->
+                GetClippingMaskBufferSize().X) ||
+                _offscreenFrameBuffers[i].GetBufferHeight() != static_cast<csmUint32>(
+                    _clippingManager->
+                    GetClippingMaskBufferSize().Y))
+            {
+                _offscreenFrameBuffers[i].DestroyOffscreenSurface(s_device);
+                _offscreenFrameBuffers[i].CreateOffscreenSurface(
+                    s_device, s_physicalDevice,
+                    static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().X),
+                    static_cast<csmUint32>(_clippingManager->GetClippingMaskBufferSize().Y),
+                    s_imageFormat, s_depthFormat
+                );
+            }
+        }
+        if (IsUsingHighPrecisionMask())
+        {
+            _clippingManager->SetupMatrixForHighPrecision(*GetModel(), false);
+        }
+        else
+        {
+            _clippingManager->SetupClippingContext(*GetModel(), drawCommandBuffer, updateCommandBuffer, this);
+        }
+    }
+    SubmitCommand(updateCommandBuffer, _updateFinishedSemaphore);
+    SubmitCommand(drawCommandBuffer, VK_NULL_HANDLE, _updateFinishedSemaphore);
+
+    // スワップチェーンを再作成した際に深度バッファのサイズを更新する
+    if (_depthImage.GetWidth() != s_swapchainExtent.width || _depthImage.GetHeight() != s_swapchainExtent.height)
+    {
+        _depthImage.Destroy(s_device);
+        CreateDepthBuffer();
+    }
+
+    const csmInt32 drawableCount = GetModel()->GetDrawableCount();
+    const csmInt32* renderOrder = GetModel()->GetDrawableRenderOrders();
+    // インデックスを描画順でソート
+    for (csmInt32 i = 0; i < drawableCount; ++i)
+    {
+        const csmInt32 order = renderOrder[i];
+        _sortedDrawableIndexList[order] = i;
+    }
+
+    //描画
+    vkBeginCommandBuffer(updateCommandBuffer, &beginInfo);
+    vkBeginCommandBuffer(drawCommandBuffer, &beginInfo);
+    BeginRendering(drawCommandBuffer, false);
+
+    for (csmInt32 i = 0; i < drawableCount; ++i)
+    {
+        const csmInt32 drawableIndex = _sortedDrawableIndexList[i];
+        // Drawableが表示状態でなければ処理をパスする
+        if (!GetModel()->GetDrawableDynamicFlagIsVisible(drawableIndex))
+        {
+            continue;
+        }
+
+        // クリッピングマスクをセットする
+        CubismClippingContext_Vulkan* clipContext = (_clippingManager != NULL)
+                                                        ? (*_clippingManager->GetClippingContextListForDraw())[
+                                                            drawableIndex]
+                                                        : NULL;
+
+        if (clipContext != NULL && IsUsingHighPrecisionMask()) // マスクを書く必要がある
+        {
+            if (clipContext->_isUsing) // 書くことになっていた
+            {
+                // 一旦オフスクリーン描画に移る
+                EndRendering(drawCommandBuffer);
+
+                // 描画順を考慮して今までに積んだコマンドを実行する
+                SubmitCommand(updateCommandBuffer, _updateFinishedSemaphore);
+                SubmitCommand(drawCommandBuffer, VK_NULL_HANDLE, _updateFinishedSemaphore);
+                vkBeginCommandBuffer(updateCommandBuffer, &beginInfo);
+                vkBeginCommandBuffer(drawCommandBuffer, &beginInfo);
+
+                CubismOffscreenSurface_Vulkan* currentHighPrecisionMaskColorBuffer = &_offscreenFrameBuffers[clipContext->_bufferIndex];
+                currentHighPrecisionMaskColorBuffer->BeginDraw(drawCommandBuffer, 1.0f, 1.0f, 1.0f, 1.0f);
+
+                // 生成したFrameBufferと同じサイズでビューポートを設定
+                const VkViewport viewport = GetViewport(
+                    static_cast<csmFloat32>(_clippingManager->GetClippingMaskBufferSize().X),
+                    static_cast<csmFloat32>(_clippingManager->GetClippingMaskBufferSize().Y),
+                    0.0, 1.0
+                );
+                vkCmdSetViewport(drawCommandBuffer, 0, 1, &viewport);
+
+                const VkRect2D rect = GetScissor(
+                    0.0, 0.0,
+                    static_cast<csmFloat32>(_clippingManager->GetClippingMaskBufferSize().X),
+                    static_cast<csmFloat32>(_clippingManager->GetClippingMaskBufferSize().Y)
+                );
+                vkCmdSetScissor(drawCommandBuffer, 0, 1, &rect);
+
+                const csmInt32 clipDrawCount = clipContext->_clippingIdCount;
+                for (csmInt32 ctx = 0; ctx < clipDrawCount; ctx++)
+                {
+                    const csmInt32 clipDrawIndex = clipContext->_clippingIdList[ctx];
+
+                    // 頂点情報が更新されておらず、信頼性がない場合は描画をパスする
+                    if (!GetModel()->GetDrawableDynamicFlagVertexPositionsDidChange(clipDrawIndex))
+                    {
+                        continue;
+                    }
+
+                    IsCulling(GetModel()->GetDrawableCulling(clipDrawIndex) != 0);
+
+                    SetClippingContextBufferForMask(clipContext);
+                    DrawMeshVulkan(*GetModel(), clipDrawIndex, drawCommandBuffer, updateCommandBuffer);
+                }
+                // --- 後処理 ---
+                currentHighPrecisionMaskColorBuffer->EndDraw(drawCommandBuffer); // オフスクリーン描画終了
+                SetClippingContextBufferForMask(NULL);
+                SubmitCommand(updateCommandBuffer, _updateFinishedSemaphore);
+                SubmitCommand(drawCommandBuffer, VK_NULL_HANDLE, _updateFinishedSemaphore);
+                vkBeginCommandBuffer(updateCommandBuffer, &beginInfo);
+                vkBeginCommandBuffer(drawCommandBuffer, &beginInfo);
+
+                // 描画再開
+                BeginRendering(drawCommandBuffer, true);
+            }
+        }
+
+        // ビューポートを設定する
+        const VkViewport viewport = GetViewport(
+            static_cast<csmFloat32>(s_swapchainExtent.width),
+            static_cast<csmFloat32>(s_swapchainExtent.height),
+            0.0, 1.0
+        );
+        vkCmdSetViewport(drawCommandBuffer, 0, 1, &viewport);
+
+        const VkRect2D rect = GetScissor(
+            0.0, 0.0,
+            static_cast<csmFloat32>(s_swapchainExtent.width),
+            static_cast<csmFloat32>(s_swapchainExtent.height)
+        );
+        vkCmdSetScissor(drawCommandBuffer, 0, 1, &rect);
+
+        // クリッピングマスクをセットする
+        SetClippingContextBufferForDraw(clipContext);
+        IsCulling(GetModel()->GetDrawableCulling(drawableIndex) != 0);
+        DrawMeshVulkan(*GetModel(), drawableIndex, drawCommandBuffer, updateCommandBuffer);
+    }
+
+    EndRendering(drawCommandBuffer);
+    SubmitCommand(updateCommandBuffer, _updateFinishedSemaphore);
+    SubmitCommand(drawCommandBuffer, VK_NULL_HANDLE, _updateFinishedSemaphore);
+}
+
+void CubismRenderer_Vulkan::SetClippingContextBufferForMask(CubismClippingContext_Vulkan* clip)
+{
+    _clippingContextBufferForMask = clip;
+}
+
+CubismClippingContext_Vulkan* CubismRenderer_Vulkan::GetClippingContextBufferForMask() const
+{
+    return _clippingContextBufferForMask;
+}
+
+void CubismRenderer_Vulkan::SetClippingContextBufferForDraw(CubismClippingContext_Vulkan* clip)
+{
+    _clippingContextBufferForDraw = clip;
+}
+
+CubismClippingContext_Vulkan* CubismRenderer_Vulkan::GetClippingContextBufferForDraw() const
+{
+    return _clippingContextBufferForDraw;
+}
+
+void CubismRenderer_Vulkan::BindTexture(CubismImageVulkan& image)
+{
+    _textures.PushBack(image);
+}
+
+void CubismRenderer_Vulkan::SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height)
+{
+    // インスタンス破棄前にレンダーテクスチャの数を保存
+    const csmInt32 renderTextureCount = _clippingManager->GetRenderTextureCount();
+
+    //FrameBufferのサイズを変更するためにインスタンスを破棄・再作成する
+    CSM_DELETE_SELF(CubismClippingManager_Vulkan, _clippingManager);
+
+    _clippingManager = CSM_NEW CubismClippingManager_Vulkan();
+
+    _clippingManager->SetClippingMaskBufferSize(width, height);
+
+    _clippingManager->Initialize(
+        *GetModel(),
+        renderTextureCount
+    );
+}
+
+CubismVector2 CubismRenderer_Vulkan::GetClippingMaskBufferSize() const
+{
+    return _clippingManager->GetClippingMaskBufferSize();
+}
+
+CubismOffscreenSurface_Vulkan* CubismRenderer_Vulkan::GetMaskBuffer(csmInt32 index)
+{
+    return &_offscreenFrameBuffers[index];
+}
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/CubismRenderer_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismRenderer_Vulkan.hpp
@@ -1,0 +1,611 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+#include <string>
+#include "../CubismRenderer.hpp"
+#include "../CubismClippingManager.hpp"
+#include <vulkan/vulkan.h>
+#include "CubismFramework.hpp"
+#include "CubismOffscreenSurface_Vulkan.hpp"
+#include "CubismClass_Vulkan.hpp"
+#include "Type/csmVector.hpp"
+#include "Type/csmMap.hpp"
+#include "Math/CubismVector2.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/**
+ * @brief   viewportのサイズを設定する
+ *
+ * @param[in]  width    -> 横幅
+ * @param[in]  height   -> 縦幅
+ * @param[in]  minDepth -> 最小深度
+ * @param[in]  maxDepth -> 最大深度
+ */
+VkViewport GetViewport(csmFloat32 width, csmFloat32 height, csmFloat32 minDepth, csmFloat32 maxDepth);
+
+/**
+ * @brief   scissorのサイズを設定する
+ *
+ * @param[in]  offsetX  -> x方向のオフセット
+ * @param[in]  offsetY  -> y方向のオフセット
+ * @param[in]  width    -> 横幅
+ * @param[in]  height   -> 縦幅
+ */
+VkRect2D GetScissor(csmFloat32 offsetX, csmFloat32 offsetY, csmFloat32 width, csmFloat32 height);
+
+/*********************************************************************************************************************
+*                                      CubismRenderer_Vulkan
+********************************************************************************************************************/
+//  前方宣言
+class CubismRenderer_Vulkan;
+class CubismClippingContext_Vulkan;
+
+/**
+ * @brief  クリッピングマスクの処理を実行するクラス
+ */
+class CubismClippingManager_Vulkan : public CubismClippingManager<
+            CubismClippingContext_Vulkan, CubismOffscreenSurface_Vulkan>
+{
+public:
+    /**
+     * @brief   クリッピングコンテキストを作成する。モデル描画時に実行する。
+     *
+     * @param[in]   model          ->  モデルのインスタンス
+     * @param[in]   commandBuffer  ->  コマンドバッファ
+     * @param[in]   updateCommandBuffer  ->  更新用コマンドバッファ
+     * @param[in]   renderer       ->  レンダラのインスタンス
+     */
+    void SetupClippingContext(CubismModel& model, VkCommandBuffer commandBuffer, VkCommandBuffer updateCommandBuffer,
+                              CubismRenderer_Vulkan* renderer);
+};
+
+/**
+ * @brief   クリッピングマスクのコンテキスト
+ */
+class CubismClippingContext_Vulkan : public CubismClippingContext
+{
+    friend class CubismClippingManager_Vulkan;
+    friend class CubismRenderer_Vulkan;
+
+public:
+    /**
+     * @brief   引数付きコンストラクタ
+     *
+     */
+    CubismClippingContext_Vulkan(
+        CubismClippingManager<CubismClippingContext_Vulkan, CubismOffscreenSurface_Vulkan>* manager, CubismModel& model,
+        const csmInt32* clippingDrawableIndices, csmInt32 clipCount);
+
+    /**
+     * @brief   デストラクタ
+     */
+    virtual ~CubismClippingContext_Vulkan();
+
+    /**
+     * @brief   このマスクを管理するマネージャのインスタンスを取得する。
+     *
+     * @return  クリッピングマネージャのインスタンス
+     */
+    CubismClippingManager<CubismClippingContext_Vulkan, CubismOffscreenSurface_Vulkan>* GetClippingManager();
+
+    CubismClippingManager<CubismClippingContext_Vulkan, CubismOffscreenSurface_Vulkan>* _owner;
+    ///< このマスクを管理しているマネージャのインスタンス
+};
+
+enum ShaderNames
+{
+    // SetupMask
+    ShaderNames_SetupMask,
+
+    //Normal
+    ShaderNames_Normal,
+    ShaderNames_NormalMasked,
+    ShaderNames_NormalMaskedInverted,
+    ShaderNames_NormalPremultipliedAlpha,
+    ShaderNames_NormalMaskedPremultipliedAlpha,
+    ShaderNames_NormalMaskedInvertedPremultipliedAlpha,
+
+    //Add
+    ShaderNames_Add,
+    ShaderNames_AddMasked,
+    ShaderNames_AddMaskedInverted,
+    ShaderNames_AddPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlpha,
+    ShaderNames_AddMaskedPremultipliedAlphaInverted,
+
+    //Mult
+    ShaderNames_Mult,
+    ShaderNames_MultMasked,
+    ShaderNames_MultMaskedInverted,
+    ShaderNames_MultPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlpha,
+    ShaderNames_MultMaskedPremultipliedAlphaInverted,
+};
+
+enum Blend
+{
+    Blend_Normal,
+    Blend_Add,
+    Blend_Mult,
+    Blend_Mask
+};
+
+/**
+ * @brief   頂点情報を保持する構造体
+ *
+ */
+struct ModelVertex
+{
+    CubismVector2 pos; // Position
+    CubismVector2 texCoord; // UVs
+
+    static VkVertexInputBindingDescription GetBindingDescription()
+    {
+        VkVertexInputBindingDescription bindingDescription{};
+        bindingDescription.binding = 0;
+        bindingDescription.stride = sizeof(ModelVertex);
+        bindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+        return bindingDescription;
+    }
+
+    static void GetAttributeDescriptions(VkVertexInputAttributeDescription attributeDescriptions[2])
+    {
+        attributeDescriptions[0].binding = 0;
+        attributeDescriptions[0].location = 0;
+        attributeDescriptions[0].format = VK_FORMAT_R32G32_SFLOAT;
+        attributeDescriptions[0].offset = offsetof(ModelVertex, pos);
+
+        attributeDescriptions[1].binding = 0;
+        attributeDescriptions[1].location = 1;
+        attributeDescriptions[1].format = VK_FORMAT_R32G32_SFLOAT;
+        attributeDescriptions[1].offset = offsetof(ModelVertex, texCoord);
+    }
+};
+
+/**
+ * @brief  シェーダー関連のプログラムを生成・破棄するクラス<br>
+ *         シングルトンなクラスであり、CubismShader_Vulkan::GetInstance()からアクセスする。
+ */
+class CubismPipeline_Vulkan
+{
+public:
+    /**
+     * @brief   コンストラクタ
+     */
+    CubismPipeline_Vulkan();
+
+    /**
+     * @brief   デストラクタ
+     */
+    ~CubismPipeline_Vulkan();
+
+    struct PipelineResource
+    {
+        /**
+         * @brief   シェーダーモジュールを作成する
+         *
+         * @param[in]   device        ->  論理デバイス
+         * @param[in]   filename      ->  ファイル名
+         */
+        VkShaderModule CreateShaderModule(VkDevice device, std::string filename);
+
+        /**
+         * @brief   パイプラインを作成する
+         *
+         * @param[in]   vertFileName        ->  Vertexシェーダーのファイル
+         * @param[in]   fragFileName        ->  Fragmentシェーダーのファイル
+         * @param[in]   descriptorSetLayout ->  ディスクリプタセットレイアウト
+         */
+        void CreateGraphicsPipeline(std::string vertFileName, std::string fragFileName,
+                                    VkDescriptorSetLayout descriptorSetLayout);
+        void Release();
+        VkPipeline GetPipeline(csmInt32 index) { return _pipeline[index]; }
+        VkPipelineLayout GetPipelineLayout(csmInt32 index) { return _pipelineLayout[index]; }
+
+    private:
+        csmVector<VkPipeline> _pipeline; ///< normal, add, multi, maskそれぞれのパイプライン
+        csmVector<VkPipelineLayout> _pipelineLayout; ///< normal, add, multi, maskそれぞれのパイプラインレイアウト
+    };
+
+    /**
+     * @brief   シェーダーごとにPipelineResourceのインスタンスを作成する
+     *
+     * @param[in]   descriptorSetLayout ->  ディスクリプタセットレイアウト
+     */
+    void CreatePipelines(VkDescriptorSetLayout descriptorSetLayout);
+
+    /**
+     * @brief   指定したシェーダーのグラフィックスパイプラインを取得する
+     *
+     * @param[in]   shaderIndex         ->  シェーダインデックス
+     * @param[in]   blendIndex          ->  ブレンドモードのインデックス
+     *
+     * @return  指定したシェーダーのグラフィックスパイプライン
+     */
+    VkPipeline GetPipeline(csmInt32 shaderIndex, csmInt32 blendIndex)
+    {
+        return _pipelineResource[shaderIndex]->GetPipeline(blendIndex);
+    }
+
+    /**
+     * @brief   指定したブレンド方法のパイプラインレイアウトを取得する
+     *
+     * @param[in]   shaderIndex         ->  シェーダインデックス
+     * @param[in]   blendIndex          ->  ブレンドモードのインデックス
+     *
+     * @return  指定したブレンド方法のパイプラインレイアウト
+     */
+    VkPipelineLayout GetPipelineLayout(csmInt32 shaderIndex, csmInt32 blendIndex)
+    {
+        return _pipelineResource[shaderIndex]->GetPipelineLayout(blendIndex);
+    }
+
+    /**
+     * @brief   インスタンスを取得する（シングルトン）
+     *
+     * @return  インスタンスのポインタ
+     */
+    static CubismPipeline_Vulkan* GetInstance();
+
+    /**
+     * @brief   リソースを開放する
+     */
+    void ReleaseShaderProgram();
+
+private:
+    csmVector<PipelineResource*> _pipelineResource;
+};
+
+/**
+ * @brief   Vulkan用の描画命令を実装したクラス
+ *
+ */
+class CubismRenderer_Vulkan : public CubismRenderer
+{
+    friend class CubismClippingManager_Vulkan;
+    friend class CubismRenderer;
+
+    /**
+     * @brief   モデル用ユニフォームバッファオブジェクトの中身を保持する構造体
+     */
+    struct ModelUBO
+    {
+        csmFloat32 projectionMatrix[16]; ///< シェーダープログラムに渡すデータ(ProjectionMatrix)
+        csmFloat32 clipMatrix[16]; ///< シェーダープログラムに渡すデータ(ClipMatrix)
+        csmFloat32 baseColor[4]; ///< シェーダープログラムに渡すデータ(BaseColor)
+        csmFloat32 multiplyColor[4]; ///< シェーダープログラムに渡すデータ(MultiplyColor)
+        csmFloat32 screenColor[4]; ///< シェーダープログラムに渡すデータ(ScreenColor)
+        csmFloat32 channelFlag[4]; ///< シェーダープログラムに渡すデータ(ChannelFlag)
+    };
+
+    /**
+     * @brief   ディスクリプタセットとUBOを保持する構造体
+     */
+    struct Descriptor
+    {
+        CubismBufferVulkan uniformBuffer; ///< ユニフォームバッファ
+        VkDescriptorSet descriptorSet = VK_NULL_HANDLE; ///< ディスクリプタセット
+        bool isDescriptorSetUpdated = false; ///< ディスクリプタセットが更新されたか
+        VkDescriptorSet descriptorSetMasked = VK_NULL_HANDLE; ///< マスク用ディスクリプタセット
+        bool isDescriptorSetMaskedUpdated = false; ///< マスク用ディスクリプタセットが更新されたか
+    };
+
+protected:
+    /**
+     * @brief   コンストラクタ
+     */
+    CubismRenderer_Vulkan();
+
+    /**
+     * @brief   デストラクタ
+     */
+    ~CubismRenderer_Vulkan() override;
+
+    /**
+     * @brief   レンダラが保持する静的なリソースを解放する。
+     */
+    static void DoStaticRelease();
+
+public:
+
+    /**
+     * @brief   コマンドの記録を開始する。
+     *
+     * @return  記録を開始したコマンドバッファ
+     */
+    VkCommandBuffer BeginSingleTimeCommands();
+
+    /**
+     * @brief   コマンドを実行する。
+     *
+     * @param[in]   commandBuffer       -> コマンドバッファ
+     * @param[in]   signalUpdateFinishedSemaphore               -> フェンス
+     */
+    void SubmitCommand(VkCommandBuffer commandBuffer, VkSemaphore signalUpdateFinishedSemaphore = VK_NULL_HANDLE, VkSemaphore waitUpdateFinishedSemaphore = VK_NULL_HANDLE);
+
+    /**
+     * @brief    レンダラを作成するための各種設定
+     *
+     *           モデルを読み込む前に一度だけ呼び出す
+     *
+     * @param[in]   device              -> 論理デバイス
+     * @param[in]   physicalDevice      -> 物理デバイス
+     * @param[in]   commandPool         -> コマンドプール
+     * @param[in]   queue               -> キュー
+     * @param[in]   extent              -> 描画解像度
+     * @param[in]   depthFormat         -> 深度フォーマット
+     * @param[in]   surfaceFormat       -> フレームバッファのフォーマット
+     * @param[in]   swapchainImageView  -> スワップチェーンのイメージビュー
+     */
+    static void InitializeConstantSettings(VkDevice device, VkPhysicalDevice physicalDevice,
+                                           VkCommandPool commandPool, VkQueue queue,
+                                           VkExtent2D extent, VkFormat depthFormat, VkFormat surfaceFormat,
+                                           VkImage swapchainImage,
+                                           VkImageView swapchainImageView,
+                                           VkFormat dFormat);
+
+    /**
+     * @brief    レンダーターゲット変更を有効にする
+     */
+    static void EnableChangeRenderTarget();
+
+    /**
+     * @brief    レンダーターゲットを変更した際にレンダラを作成するための各種設定
+     *
+     * @param[in]   image          -> イメージ
+     * @param[in]   imageview      -> イメージビュー
+     */
+    static void SetRenderTarget(VkImage image, VkImageView imageview);
+
+    /**
+     * @brief   スワップチェーンを再作成したときに変更されるリソースを更新する
+     *
+     * @param[in]  extent 　　-> クリッピングマスクバッファのサイズ
+     * @param[in]  imageView -> イメージビュー
+     */
+    static void UpdateSwapchainVariable(VkExtent2D extent, VkImage image,
+                                        VkImageView imageView);
+
+    /**
+     * @brief   スワップチェーンイメージを更新する
+     *
+     * @param[in]   iamge     -> イメージ
+     * @param[in]   iamgeView     -> イメージビュー
+     */
+    static void UpdateRendererSettings(VkImage image, VkImageView imageView);
+
+    /**
+     * @brief   コマンドバッファを作成する。
+     */
+    void CreateCommandBuffer();
+
+
+    /**
+     * @brief   空の頂点バッファを作成する。
+     */
+    void CreateVertexBuffer();
+
+    /**
+     * @brief   インデックスバッファを作成する。
+     */
+    void CreateIndexBuffer();
+
+    /**
+     * @brief   ユニフォームバッファとディスクリプタセットを作成する。
+     *          ディスクリプタセットレイアウトはユニフォームバッファ1つとモデル用テクスチャ1つとマスク用テクスチャ1つを指定する。
+     */
+    void CreateDescriptorSets();
+
+    /**
+     * @brief  深度バッファを作成する。
+     */
+    void CreateDepthBuffer();
+
+    /**
+     * @brief   レンダラーを初期化する。
+     */
+    void InitializeRenderer();
+
+    /**
+     * @brief    レンダラの初期化処理を実行する<br>
+     *           引数に渡したモデルからレンダラの初期化処理に必要な情報を取り出すことができる
+     *
+     * @param[in]  model -> モデルのインスタンス
+     */
+    void Initialize(Framework::CubismModel* model) override;
+
+    /**
+     * @brief    レンダラの初期化処理を実行する<br>
+     *           引数に渡したモデルからレンダラの初期化処理に必要な情報を取り出すことができる
+     *
+     * @param[in]  model -> モデルのインスタンス
+     * @param[in]  maskBufferCount -> マスクバッファの数
+     */
+    void Initialize(Framework::CubismModel* model, csmInt32 maskBufferCount) override;
+
+    /**
+     * @brief   頂点バッファを更新する。
+     * @param[in]   drawAssign    -> 描画インデックス
+     * @param[in]   vcount        -> 頂点数
+     * @param[in]   varray        -> 頂点配列
+     * @param[in]   uvarray       -> uv配列
+     * @param[in]   commandBuffer -> コマンドバッファ
+     */
+    void CopyToBuffer(csmInt32 drawAssign, const csmInt32 vcount, const csmFloat32* varray, const csmFloat32* uvarray,
+                      VkCommandBuffer commandBuffer);
+
+    /**
+     * @brief   行列を更新する
+     *
+     * @param[in]   vkMat4     -> 更新する行列
+     * @param[in]   cubismMat  -> 新しい値
+     */
+    static void UpdateMatrix(csmFloat32 vkMat4[16], CubismMatrix44 cubismMat);
+
+    /**
+     * @brief   カラーベクトルを更新する
+     *
+     * @param[in]   vkVec4     -> 更新するカラーベクトル
+     * @param[in]   r, g, b, a -> 新しい値
+     */
+    void UpdateColor(csmFloat32 vkVec4[4], csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a);
+
+    /**
+     * @brief  ディスクリプタセットを更新する
+     * @param[in]   descriptor    -> 1つのシェーダーが使用するディスクリプタセットとUBO
+     * @param[in]   textureIndex  -> テクスチャインデックス
+     */
+    void UpdateDescriptorSet(Descriptor& descriptor, csmUint32 textureIndex, bool isMasked);
+
+    /**
+     * @brief   メッシュ描画を実行する
+     *
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index                 ->  描画オブジェクトのインデックス
+     * @param[in]   cmdBuffer             ->  フレームバッファ関連のコマンドバッファ
+     */
+    void ExecuteDrawForDraw(const CubismModel& model, const csmInt32 index, VkCommandBuffer& cmdBuffer);
+
+    /**
+     * @brief   マスク描画を実行する
+     *
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index                 ->  描画オブジェクトのインデックス
+     * @param[in]   cmdBuffer             ->  フレームバッファ関連のコマンドバッファ
+     */
+    void ExecuteDrawForMask(const CubismModel& model, const csmInt32 index, VkCommandBuffer& cmdBuffer);
+
+    /**
+     * @brief   [オーバーライド]<br>
+     *           描画オブジェクト（アートメッシュ）を描画する。<br>
+     * @param[in]   model                 ->  描画対象のモデル
+     * @param[in]   index           ->  描画メッシュのインデックス
+     * @param[in]   commandBuffer    ->  コマンドバッファ
+     * @param[in]   updateCommandBuffer ->  更新用コマンドバッファ
+     */
+    void DrawMeshVulkan(const CubismModel& model, const csmInt32 index,
+                        VkCommandBuffer commandBuffer, VkCommandBuffer updateCommandBuffer);
+
+    /**
+     * @brief   レンダリング開始
+     *
+     * @param[in]   drawCommandBuffer       ->  コマンドバッファ
+     * @param[in]   isResume                ->  レンダリング再開かのフラグ
+     */
+    void BeginRendering(VkCommandBuffer drawCommandBuffer, bool isResume);
+
+    /**
+     * @brief   レンダリング終了
+     *
+     * @param[in]   drawCommandBuffer       ->  コマンドバッファ
+     */
+    void EndRendering(VkCommandBuffer drawCommandBuffer);
+
+    /**
+     * @brief   モデルを描画する実際の処理
+     *
+     */
+    void DoDrawModel() override;
+
+    /**
+     * @brief   モデル描画直前のステートを保持する
+     */
+    void SaveProfile() override {}
+
+    /**
+     * @brief   モデル描画直前のステートを保持する
+     */
+    void RestoreProfile() override {}
+
+    /**
+     * @brief   マスクテクスチャに描画するクリッピングコンテキストをセットする。
+     */
+    void SetClippingContextBufferForMask(CubismClippingContext_Vulkan* clip);
+
+    /**
+     * @brief   マスクテクスチャに描画するクリッピングコンテキストを取得する。
+     *
+     * @return  マスクテクスチャに描画するクリッピングコンテキスト
+     */
+    CubismClippingContext_Vulkan* GetClippingContextBufferForMask() const;
+
+    /**
+     * @brief   画面上に描画するクリッピングコンテキストをセットする。
+     */
+    void SetClippingContextBufferForDraw(CubismClippingContext_Vulkan* clip);
+
+    /**
+     * @brief   画面上に描画するクリッピングコンテキストを取得する。
+     *
+     * @return  画面上に描画するクリッピングコンテキスト
+     */
+    CubismClippingContext_Vulkan* GetClippingContextBufferForDraw() const;
+
+    /**
+     * @brief   テクスチャマネージャーで作成したものをバインドする
+     *
+     * @param[in]   image         ->  テクスチャビューやサンプラーを保持しているインスタンス
+     */
+    void BindTexture(CubismImageVulkan& image);
+
+    /**
+     * @brief  クリッピングマスクバッファのサイズを設定する
+     *
+     * @param[in]  width  -> クリッピングマスクバッファの横幅
+     * @param[in]  height -> クリッピングマスクバッファの立幅
+     *
+     */
+    void SetClippingMaskBufferSize(csmFloat32 width, csmFloat32 height);
+
+    /**
+     * @brief  クリッピングマスクバッファのサイズを取得する
+    *
+     * @return クリッピングマスクバッファのサイズ
+     *
+     */
+    CubismVector2 GetClippingMaskBufferSize() const;
+
+    /**
+     * @brief  クリッピングマスクのバッファを取得する
+     *
+     * @return クリッピングマスクのバッファへのポインタ
+     *
+     */
+    CubismOffscreenSurface_Vulkan* GetMaskBuffer(csmInt32 index);
+
+private:
+    PFN_vkCmdSetCullModeEXT vkCmdSetCullModeEXT;
+
+    CubismRenderer_Vulkan(const CubismRenderer_Vulkan&);
+    CubismRenderer_Vulkan& operator=(const CubismRenderer_Vulkan&);
+
+    CubismClippingManager_Vulkan* _clippingManager; ///< クリッピングマスク管理オブジェクト
+    csmVector<csmInt32> _sortedDrawableIndexList; ///< 描画オブジェクトのインデックスを描画順に並べたリスト
+    CubismClippingContext_Vulkan* _clippingContextBufferForMask; ///< マスクテクスチャに描画するためのクリッピングコンテキスト
+    CubismClippingContext_Vulkan* _clippingContextBufferForDraw; ///< 画面上描画するためのクリッピングコンテキスト
+    csmVector<CubismOffscreenSurface_Vulkan> _offscreenFrameBuffers; ///< マスク描画用のフレームバッファ
+    csmVector<CubismBufferVulkan> _vertexBuffers; ///< 頂点バッファ
+    csmVector<CubismBufferVulkan> _stagingBuffers; ///< 頂点バッファを更新する際に使うステージングバッファ
+    csmVector<CubismBufferVulkan> _indexBuffers; ///< インデックスバッファ
+    ModelUBO _ubo; ///< ユニフォームバッファ
+    VkDescriptorPool _descriptorPool; ///< ディスクリプタプール
+    VkDescriptorSetLayout _descriptorSetLayout; ///< ディスクリプタセットのレイアウト
+    csmVector<Descriptor> _descriptorSets; ///< ディスクリプタ管理オブジェクト
+    csmVector<CubismImageVulkan> _textures; ///< モデルが使うテクスチャ
+    CubismImageVulkan _depthImage; ///< オフスクリーンの色情報を保持する深度画像
+    VkClearValue _clearColor; ///< クリアカラー
+    VkSemaphore _updateFinishedSemaphore; ///< セマフォ
+    VkCommandBuffer updateCommandBuffer; ///< 更新用コマンドバッファ
+    VkCommandBuffer drawCommandBuffer; ///< 描画用コマンドバッファ
+};
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/Shaders/CMakeLists.txt
+++ b/src/Rendering/Vulkan/Shaders/CMakeLists.txt
@@ -1,0 +1,30 @@
+file(GLOB shader_files src/*)
+
+# Shader compilation
+foreach(shader ${shader_files})
+    get_filename_component(file_name ${shader} NAME)
+    if(file_name MATCHES "common.glsl")
+        continue()
+    endif()
+    get_filename_component(full_path ${shader} ABSOLUTE)
+    set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/compiledShaders)
+    string(REGEX REPLACE \\.frag|\\.vert "" output_file ${file_name})
+    set(output_file ${output_dir}/${output_file}.spv)
+    set(compiled_shaders ${compiled_shaders} ${output_file})
+    set(compiled_shaders ${compiled_shaders} PARENT_SCOPE)
+    set_source_files_properties(${shader} PROPERTIES HEADER_FILE_ONLY TRUE)
+
+    add_custom_command(
+        OUTPUT ${output_file}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir}
+        COMMAND $ENV{VK_SDK_PATH}/Bin/glslc.exe ${full_path} -o ${output_file}
+        DEPENDS ${full_path}
+    )
+endforeach()
+
+source_group("shaders" FILES ${shader_files})
+add_custom_target(
+    FrameworkShaders ALL
+    DEPENDS ${compiled_shaders}
+    SOURCES ${shader_files}
+)

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrc.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrc.frag
@@ -1,0 +1,16 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec4 texColor = texture(s_texture0, v_texCoord);
+    texColor.rgb = texColor.rgb * ubo.u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + ubo.u_screenColor.rgb - (texColor.rgb * ubo.u_screenColor.rgb);
+    vec4 color = texColor *  ubo.u_baseColor;
+    outColor = vec4(color.rgb * color.a, color.a);
+}

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMask.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMask.frag
@@ -1,0 +1,21 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+layout(location = 1) in vec4 v_clipPos;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec4 texColor = texture(s_texture0, v_texCoord);
+    texColor.rgb = texColor.rgb * ubo.u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + ubo.u_screenColor.rgb - (texColor.rgb * ubo.u_screenColor.rgb);
+    vec4 col_formask = texColor * ubo.u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a;
+    vec4 clipMask = (1.0 - texture(s_texture1, v_clipPos.xy / v_clipPos.w)) * ubo.u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    outColor = col_formask;
+}

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMaskInverted.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMaskInverted.frag
@@ -1,0 +1,21 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+layout(location = 1) in vec4 v_clipPos;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec4 texColor = texture(s_texture0, v_texCoord);
+    texColor.rgb = texColor.rgb * ubo.u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + ubo.u_screenColor.rgb - (texColor.rgb * ubo.u_screenColor.rgb);
+    vec4 col_formask = texColor * ubo.u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture(s_texture1, v_clipPos.xy / v_clipPos.w)) * ubo.u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    outColor = col_formask;
+}

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMaskInvertedPremultipliedAlpha.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMaskInvertedPremultipliedAlpha.frag
@@ -1,0 +1,20 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+layout(location = 1) in vec4 v_clipPos;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec4 texColor = texture(s_texture0, v_texCoord);
+    texColor.rgb = texColor.rgb * ubo.u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + ubo.u_screenColor.rgb * texColor.a) - (texColor.rgb * ubo.u_screenColor.rgb);
+    vec4 col_formask = texColor * ubo.u_baseColor;
+    vec4 clipMask = (1.0 - texture(s_texture1, v_clipPos.xy / v_clipPos.w)) * ubo.u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    outColor = col_formask;
+}

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMaskPremultipliedAlpha.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrcMaskPremultipliedAlpha.frag
@@ -1,0 +1,20 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+layout(location = 1) in vec4 v_clipPos;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec4 texColor = texture(s_texture0, v_texCoord);
+    texColor.rgb = texColor.rgb * ubo.u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + ubo.u_screenColor.rgb * texColor.a) - (texColor.rgb * ubo.u_screenColor.rgb);
+    vec4 col_formask = texColor * ubo.u_baseColor;
+    vec4 clipMask = (1.0 - texture(s_texture1, v_clipPos.xy / v_clipPos.w)) * ubo.u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    outColor = col_formask;
+}

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrcPremultipliedAlpha.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrcPremultipliedAlpha.frag
@@ -1,0 +1,14 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec4 texColor = texture(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * ubo.u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + ubo.u_screenColor.rgb * texColor.a) - (texColor.rgb * ubo.u_screenColor.rgb);
+    outColor = texColor * ubo.u_baseColor;
+}

--- a/src/Rendering/Vulkan/Shaders/src/FragShaderSrcSetupMask.frag
+++ b/src/Rendering/Vulkan/Shaders/src/FragShaderSrcSetupMask.frag
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec2 v_texCoord;
+layout(location = 1) in vec4 v_myPos;
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    float isInside = step(ubo.u_baseColor.x, v_myPos.x/v_myPos.w)*
+    step(ubo.u_baseColor.y, v_myPos.y/v_myPos.w)*
+    step(v_myPos.x/v_myPos.w, ubo.u_baseColor.z)*
+    step(v_myPos.y/v_myPos.w, ubo.u_baseColor.w);
+
+    outColor = ubo.u_channelFlag * texture(s_texture0 , v_texCoord).a * isInside;
+}

--- a/src/Rendering/Vulkan/Shaders/src/VertShaderSrc.vert
+++ b/src/Rendering/Vulkan/Shaders/src/VertShaderSrc.vert
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec4 a_position;
+layout(location = 1) in vec2 a_texCoord;
+
+layout(location = 0) out vec2 v_texCoord;
+
+void main()
+{
+    vec4 pos = ubo.u_matrix * a_position;
+    pos.y = -pos.y;
+    gl_Position = pos;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/Vulkan/Shaders/src/VertShaderSrcMasked.vert
+++ b/src/Rendering/Vulkan/Shaders/src/VertShaderSrcMasked.vert
@@ -1,0 +1,20 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec4 a_position;
+layout(location = 1) in vec2 a_texCoord;
+
+layout(location = 0) out vec2 v_texCoord;
+layout(location = 1) out vec4 v_clipPos;
+
+void main()
+{
+    vec4 pos = ubo.u_matrix * a_position;
+    pos.y = -pos.y;
+    gl_Position = pos;
+    v_clipPos = ubo.u_clipMatrix * a_position;
+    v_clipPos.y = 1.0 - v_clipPos.y;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/Vulkan/Shaders/src/VertShaderSrcSetupMask.vert
+++ b/src/Rendering/Vulkan/Shaders/src/VertShaderSrcSetupMask.vert
@@ -1,0 +1,19 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#include "common.glsl"
+
+layout(location = 0) in vec4 a_position;
+layout(location = 1) in vec2 a_texCoord;
+
+layout(location = 0) out vec2 v_texCoord;
+layout(location = 1) out vec4 v_myPos;
+
+void main()
+{
+    vec4 pos = ubo.u_clipMatrix * a_position;
+    pos.y = -pos.y;
+    gl_Position = pos;
+    v_myPos = ubo.u_clipMatrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/Vulkan/Shaders/src/common.glsl
+++ b/src/Rendering/Vulkan/Shaders/src/common.glsl
@@ -1,0 +1,12 @@
+layout(binding = 0) uniform UBO
+{
+    mat4 u_matrix;
+    mat4 u_clipMatrix;
+    vec4 u_baseColor;
+    vec4 u_multiplyColor;
+    vec4 u_screenColor;
+    vec4 u_channelFlag;
+}ubo;
+
+layout(binding = 1) uniform sampler2D s_texture0;
+layout(binding = 2) uniform sampler2D s_texture1;


### PR DESCRIPTION
### Added

* Add the function to get the ID of a given parameter.(`CubismModel::GetParameterId`)
* Add the `CubismExpressionMotionManager` class.
* Add a Renderer for Vulkan API in Windows.

### Changed

* Unify Offscreen drawing-related terminology with `OffscreenSurface`.
* Change comment guidelines for headers in the `Framework` directory.

### Fixed

* Fix a bug that caused cocos2d-x culling to not be performed correctly.
* Fix the structure of the class in renderer.
* Separate the high precision mask process from the clipping mask setup process.
* Separate shader class from CubismRenderer files for Cocos2d-x, Metal, OpenGL.
* Fix Metal rendering results on macOS to be similar to OpenGL.
  * If you want to apply the previous Metal rendering results, change `mipFilter` in `MTLSamplerDescriptor` from `MTLSamplerMipFilterLinear` to `MTLSamplerMipFilterNotMipmapped`.
* Fix a bug that the value applied by multiply was not appropriate during expression transitions.

### Removed

* Remove several arguments of `DrawMesh` function.