### PR TITLE
Finished cb with customdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### added
 
-* At [@MizunagiKB](https://github.com/MizunagiKB)'s suggestion, add a function to the ACubismMotion class that sets arbitrary data in the callback.
+* Add a function to the `ACubismMotion` class that sets arbitrary data in the callback. by [@MizunagiKB](https://github.com/MizunagiKB)
 
 
 ## [5-r.1-beta.1] - 2023-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [Unreleased]
+
+### added
+
+* At [@MizunagiKB](https://github.com/MizunagiKB)'s suggestion, add a function to the ACubismMotion class that sets arbitrary data in the callback.
+
+
 ## [5-r.1-beta.1] - 2023-08-17
 
 ### Added

--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -162,6 +162,12 @@ void* ACubismMotion::GetFinishedMotionCustomData()
     return this->_onFinishedMotionCustomData;
 }
 
+void ACubismMotion::SetFinishedMotionHandlerAndMotionCustomData(FinishedMotionCallback onFinishedMotionHandler, void* onFinishedMotionCustomData)
+{
+    this->_onFinishedMotion = onFinishedMotionHandler;
+    this->_onFinishedMotionCustomData = onFinishedMotionCustomData;
+}
+
 csmBool ACubismMotion::IsExistModelOpacity() const
 {
     return false;

--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -24,6 +24,7 @@ ACubismMotion::ACubismMotion()
     , _weight(1.0f)
     , _offsetSeconds(0.0f) //再生の開始時刻
     , _onFinishedMotion(NULL)
+    , _onFinishedMotionCustomData(NULL)
 { }
 
 ACubismMotion::~ACubismMotion()
@@ -149,6 +150,16 @@ void ACubismMotion::SetFinishedMotionHandler(FinishedMotionCallback onFinishedMo
 ACubismMotion::FinishedMotionCallback ACubismMotion::GetFinishedMotionHandler()
 {
     return this->_onFinishedMotion;
+}
+
+void ACubismMotion::SetFinishedMotionCustomData(void* onFinishedMotionCustomData)
+{
+    this->_onFinishedMotionCustomData = onFinishedMotionCustomData;
+}
+
+void* ACubismMotion::GetFinishedMotionCustomData()
+{
+    return this->_onFinishedMotionCustomData;
 }
 
 csmBool ACubismMotion::IsExistModelOpacity() const

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -180,6 +180,24 @@ public:
     FinishedMotionCallback GetFinishedMotionHandler();
 
     /**
+     * @brief モーション再生終了コールバックと共に渡されるデータの登録
+     *
+     * モーション再生終了コールバックと共に渡されるデータを登録する。
+     *
+     * @param[in]   onFinishedMotionCustomData  モーション再生終了コールバック関数に渡されるデータ
+     */
+    void SetFinishedMotionCustomData(void* onFinishedMotionCustomData);
+
+    /**
+     * @brief モーション再生終了コールバックと共に渡されるデータの取得
+     *
+     * モーション再生終了コールバックと元に渡されるデータを取得する。
+     *
+     * @return  登録されているモーション再生終了コールバック関数に渡されるデータ。NULLのとき、データは何も登録されていないかNULLが設定されている。
+     */
+    void* GetFinishedMotionCustomData();
+
+    /**
      * @brief        透明度のカーブが存在するかどうかを確認する
      *
      * @retval       true  -> キーが存在する
@@ -258,8 +276,8 @@ protected:
 
     csmVector<const csmString*>    _firedEventValues;
 
-    // モーション再生終了コールバック関数
-    FinishedMotionCallback _onFinishedMotion;
+    FinishedMotionCallback _onFinishedMotion;           ///< モーション再生終了コールバック関数ポインタ
+    void*                  _onFinishedMotionCustomData; ///< モーション再生終了コールバックに戻されるデータ
 };
 
 }}}

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -180,20 +180,20 @@ public:
     FinishedMotionCallback GetFinishedMotionHandler();
 
     /**
-     * @brief モーション再生終了コールバックと共に渡されるデータの登録
+     * @brief ユーザー任意データの登録
      *
-     * モーション再生終了コールバックと共に渡されるデータを登録する。
+     * ユーザー任意データを登録します。
      *
-     * @param[in]   onFinishedMotionCustomData  モーション再生終了コールバック関数に渡されるデータ
+     * @param[in]   onFinishedMotionCustomData  ユーザー任意データ
      */
     void SetFinishedMotionCustomData(void* onFinishedMotionCustomData);
 
     /**
-     * @brief モーション再生終了コールバックと共に渡されるデータの取得
+     * @brief ユーザー任意データの取得
      *
-     * モーション再生終了コールバックと元に渡されるデータを取得する。
+     * ユーザー任意データを取得します。
      *
-     * @return  登録されているモーション再生終了コールバック関数に渡されるデータ。NULLのとき、データは何も登録されていないかNULLが設定されている。
+     * @return  登録されているユーザー任意データ。
      */
     void* GetFinishedMotionCustomData();
 

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -198,6 +198,20 @@ public:
     void* GetFinishedMotionCustomData();
 
     /**
+     * @brief モーション再生終了コールバックとユーザー任意データの登録
+     *
+     * モーション再生終了コールバックを登録する。
+     * IsFinishedフラグを設定するタイミングで呼び出される。
+     * 以下の状態の際には呼び出されない:
+     *   1. 再生中のモーションが「ループ」として設定されているとき
+     *   2. コールバックにNULLが登録されているとき
+     *
+     * @param[in]   onFinishedMotionHandler     モーション再生終了コールバック関数
+     * @param[in]   onFinishedMotionCustomData  ユーザー任意データ
+     */
+    void SetFinishedMotionHandlerAndMotionCustomData(FinishedMotionCallback onFinishedMotionHandler, void* onFinishedMotionCustomData);
+
+    /**
      * @brief        透明度のカーブが存在するかどうかを確認する
      *
      * @retval       true  -> キーが存在する
@@ -276,8 +290,8 @@ protected:
 
     csmVector<const csmString*>    _firedEventValues;
 
-    FinishedMotionCallback _onFinishedMotion;           ///< モーション再生終了コールバック関数ポインタ
-    void*                  _onFinishedMotionCustomData; ///< モーション再生終了コールバックに戻されるデータ
+    FinishedMotionCallback _onFinishedMotion; ///< モーション再生終了コールバック関数ポインタ
+    void* _onFinishedMotionCustomData;        ///< モーション再生終了コールバックに戻されるデータ
 };
 
 }}}


### PR DESCRIPTION
Adds an area to the _ACubismMotion_ class where any data can be set.
The main use is to receive the data in the callback function at the end of motion playback.

If it is handled with the callback, it is better to set it when setting the handler.
However, that method requires more code changes.

Therefore, we decided to use a method that requires few changes, setting only when the user needs it.