### PR TITLE
Update to Cubism 5 SDK for Native R1 beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.1-beta.4] - 2024-01-25
+
+### Fixed
+
+* Fix memory leak in DX11.
+* Fix an issue where models with a specific number of masks could not be drawn correctly.
+* Fix to check for null when reading json.
+* Fix an issue that caused some graphics drivers to not render correctly in Vulkan.
+* Fix errors related to semaphore waiting stages.
+* Fix errors that occurs when building with x86 in vulkan.
+
+
 ## [5-r.1-beta.3] - 2023-10-12
 
 ### Added
@@ -326,6 +338,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[5-r.1-beta.4]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1-beta.3...5-r.1-beta.4
 [5-r.1-beta.3]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1-beta.2...5-r.1-beta.3
 [5-r.1-beta.2]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1-beta.1...5-r.1-beta.2
 [5-r.1-beta.1]: https://github.com/Live2D/CubismNativeFramework/compare/4-r.7...5-r.1-beta.1

--- a/src/CubismFramework.cpp
+++ b/src/CubismFramework.cpp
@@ -83,9 +83,9 @@ csmBool CubismFramework::StartUp(ICubismAllocator* allocator, const Option* opti
         const csmUint32 major = static_cast<csmUint32>((version & 0xFF000000) >> 24);
         const csmUint32 minor = static_cast<csmUint32>((version & 0x00FF0000) >> 16);
         const csmUint32 patch = static_cast<csmUint32>((version & 0x0000FFFF));
-        const csmUint32 vesionNumber = version;
+        const csmUint32 versionNumber = version;
 
-        CubismLogInfo("Live2D Cubism Core version: %02d.%02d.%04d (%d)", major, minor, patch, vesionNumber);
+        CubismLogInfo("Live2D Cubism Core version: %02d.%02d.%04d (%d)", major, minor, patch, versionNumber);
     }
 
     CubismLogInfo("CubismFramework::StartUp() is complete.");

--- a/src/Effect/CubismPose.cpp
+++ b/src/Effect/CubismPose.cpp
@@ -70,8 +70,12 @@ CubismPose::~CubismPose()
 
 CubismPose* CubismPose::Create(const csmByte* pose3json, csmSizeInt size)
 {
-    CubismPose*         ret = CSM_NEW CubismPose();
     Utils::CubismJson*  json = Utils::CubismJson::Create(pose3json, size);
+    if (!json)
+    {
+        return NULL;
+    }
+    CubismPose* ret = CSM_NEW CubismPose();
     Utils::Value&       root = json->GetRoot();
 
     // フェード時間の指定

--- a/src/Model/CubismModelUserData.cpp
+++ b/src/Model/CubismModelUserData.cpp
@@ -47,6 +47,12 @@ void CubismModelUserData::ParseUserData(const csmByte* buffer, const csmSizeInt 
 {
     CubismModelUserDataJson* json = CSM_NEW CubismModelUserDataJson(buffer, size);
 
+    if (!json->IsValid())
+    {
+        CSM_DELETE(json);
+        return;
+    }
+
     const ModelUserDataType typeOfArtMesh = CubismFramework::GetIdManager()->GetId(ArtMesh);
 
     const csmUint32 nodeCount = json->GetUserDataCount();

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -102,21 +102,41 @@ void CubismUserModel::LoadModel(const csmByte* buffer, csmSizeInt size, csmBool 
 
 ACubismMotion* CubismUserModel::LoadExpression(const csmByte* buffer, csmSizeInt size, const csmChar* name)
 {
+    if (!buffer)
+    {
+        CubismLogError("Failed to LoadExpression().");
+        return NULL;
+    }
+
     return CubismExpressionMotion::Create(buffer, size);
 }
 
 void CubismUserModel::LoadPose(const csmByte* buffer, csmSizeInt size)
 {
     _pose = CubismPose::Create(buffer, size);
+    if (!_pose)
+    {
+        CubismLogError("Failed to LoadPose().");
+    }
 }
 
 void CubismUserModel::LoadPhysics(const csmByte* buffer, csmSizeInt size)
 {
     _physics = CubismPhysics::Create(buffer, size);
+    if (!_physics)
+    {
+        CubismLogError("Failed to LoadPhysics().");
+    }
 }
 
 void CubismUserModel::LoadUserData(const csmByte* buffer, csmSizeInt size)
 {
+    if (!buffer)
+    {
+        CubismLogError("Failed to LoadUserData().");
+        return;
+    }
+
     _modelUserData = CubismModelUserData::Create(buffer, size);
 }
 csmBool CubismUserModel::IsHit(CubismIdHandle drawableId, csmFloat32 pointX, csmFloat32 pointY)
@@ -170,6 +190,11 @@ csmBool CubismUserModel::IsHit(CubismIdHandle drawableId, csmFloat32 pointX, csm
 
 ACubismMotion* CubismUserModel::LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name, ACubismMotion::FinishedMotionCallback onFinishedMotionHandler)
 {
+    if (!buffer)
+    {
+        CubismLogError("Failed to LoadMotion().");
+        return NULL;
+    }
     return CubismMotion::Create(buffer, size, onFinishedMotionHandler);
 }
 

--- a/src/Motion/CubismExpressionMotion.cpp
+++ b/src/Motion/CubismExpressionMotion.cpp
@@ -198,6 +198,11 @@ csmFloat32 CubismExpressionMotion::GetFadeWeight()
 void CubismExpressionMotion::Parse(const csmByte* buffer, csmSizeInt size)
 {
     Utils::CubismJson* json = Utils::CubismJson::Create(buffer, size);
+    if (!json)
+    {
+        return;
+    }
+
     Utils::Value& root = json->GetRoot();
 
     SetFadeInTime(root[ExpressionKeyFadeIn].ToFloat(DefaultFadeTime));   // フェードイン

--- a/src/Motion/CubismMotion.cpp
+++ b/src/Motion/CubismMotion.cpp
@@ -527,6 +527,12 @@ void CubismMotion::Parse(const csmByte* motionJson, const csmSizeInt size)
 
     CubismMotionJson* json = CSM_NEW CubismMotionJson(motionJson, size);
 
+    if (!json->IsValid())
+    {
+        CSM_DELETE(json);
+        return;
+    }
+
     _motionData->Duration = json->GetMotionDuration();
     _motionData->Loop = json->IsMotionLoop();
     _motionData->CurveCount = json->GetMotionCurveCount();

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.cpp
@@ -639,9 +639,9 @@ void CubismRenderer_Cocos2dx::RestoreProfile()
     _rendererProfile.Restore();
 }
 
-void CubismRenderer_Cocos2dx::BindTexture(csmUint32 modelTextureNo, cocos2d::Texture2D* texture)
+void CubismRenderer_Cocos2dx::BindTexture(csmUint32 modelTextureIndex, cocos2d::Texture2D* texture)
 {
-    _textures[modelTextureNo] = texture;
+    _textures[modelTextureIndex] = texture;
 }
 
 const csmMap<csmInt32, cocos2d::Texture2D*>& CubismRenderer_Cocos2dx::GetBindedTextures() const
@@ -712,9 +712,9 @@ const csmBool CubismRenderer_Cocos2dx::IsGeneratingMask() const
     return GetClippingContextBufferForMask() != NULL;
 }
 
-cocos2d::Texture2D* CubismRenderer_Cocos2dx::GetBindedTexture(csmInt32 textureNo)
+cocos2d::Texture2D* CubismRenderer_Cocos2dx::GetBindedTexture(csmInt32 textureIndex)
 {
-    return _textures[textureNo];
+    return _textures[textureIndex];
 }
 
 }}}}

--- a/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
+++ b/src/Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp
@@ -170,11 +170,11 @@ public:
      * @brief   OpenGLテクスチャのバインド処理<br>
      *           CubismRendererにテクスチャを設定し、CubismRenderer中でその画像を参照するためのIndex値を戻り値とする
      *
-     * @param[in]   modelTextureNo  ->  セットするモデルテクスチャの番号
+     * @param[in]   modelTextureIndex  ->  セットするモデルテクスチャの番号
      * @param[in]   texture     ->  バックエンドテクスチャ
      *
      */
-    void BindTexture(csmUint32 modelTextureNo, cocos2d::Texture2D* texture);
+    void BindTexture(csmUint32 modelTextureIndex, cocos2d::Texture2D* texture);
 
     /**
      * @brief   OpenGLにバインドされたテクスチャのリストを取得する
@@ -340,7 +340,7 @@ private:
      *
      * @return  バインドされたテクスチャ
      */
-    cocos2d::Texture2D* GetBindedTexture(csmInt32 textureNo);
+    cocos2d::Texture2D* GetBindedTexture(csmInt32 textureIndex);
 
 
     csmMap<csmInt32, cocos2d::Texture2D*> _textures;                      ///< モデルが参照するテクスチャとレンダラでバインドしているテクスチャとのマップ

--- a/src/Rendering/Cocos2d/CubismShader_Cocos2dx.cpp
+++ b/src/Rendering/Cocos2d/CubismShader_Cocos2dx.cpp
@@ -784,8 +784,8 @@ void CubismShader_Cocos2dx::SetupShaderProgramForMask(CubismCommandBuffer_Cocos2
 
 
     //テクスチャ設定
-    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
-    cocos2d::Texture2D* texture = renderer->GetBindedTexture(textureNo);
+    const csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
+    cocos2d::Texture2D* texture = renderer->GetBindedTexture(textureIndex);
     programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
 
     // 頂点配列の設定
@@ -794,8 +794,8 @@ void CubismShader_Cocos2dx::SetupShaderProgramForMask(CubismCommandBuffer_Cocos2
     programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, cocos2d::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
 
     // チャンネル
-    const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
-    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    const csmInt32 channelIndex = renderer->GetClippingContextBufferForMask()->_layoutChannelIndex;
+    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
     csmFloat32 colorFlag[4] = { colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
     programState->setUniform(shaderSet->UnifromChannelFlagLocation, colorFlag, sizeof(float) * 4);
 
@@ -901,15 +901,15 @@ void CubismShader_Cocos2dx::SetupShaderProgramForDraw(CubismCommandBuffer_Cocos2
                                  sizeof(float) * 16);
 
         // 使用するカラーチャンネルを設定
-        const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
-        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        const csmInt32 channelIndex = renderer->GetClippingContextBufferForDraw()->_layoutChannelIndex;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
         csmFloat32 colorFlag[4] = { colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
         programState->setUniform(shaderSet->UnifromChannelFlagLocation, colorFlag, sizeof(float) * 4);
     }
 
     //テクスチャ設定
-    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
-    cocos2d::Texture2D* texture = renderer->GetBindedTexture(textureNo);
+    const csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
+    cocos2d::Texture2D* texture = renderer->GetBindedTexture(textureIndex);
     programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
 
     //座標変換

--- a/src/Rendering/CubismClippingManager.hpp
+++ b/src/Rendering/CubismClippingManager.hpp
@@ -121,9 +121,9 @@ public:
     /**
      * @brief   カラーチャンネル(RGBA)のフラグを取得する
      *
-     * @param[in]   channelNo   ->   カラーチャンネル(RGBA)の番号(0:R , 1:G , 2:B, 3:A)
+     * @param[in]   channelIndex   ->   カラーチャンネル(RGBA)の番号(0:R , 1:G , 2:B, 3:A)
      */
-    CubismRenderer::CubismTextureColor* GetChannelFlagAsColor(csmInt32 channelNo);
+    CubismRenderer::CubismTextureColor* GetChannelFlagAsColor(csmInt32 channelIndex);
 
     /**
      *@brief  クリッピングマスクバッファのサイズを設定する

--- a/src/Rendering/CubismRenderer.cpp
+++ b/src/Rendering/CubismRenderer.cpp
@@ -164,7 +164,7 @@ CubismClippingContext::CubismClippingContext(const csmInt32* clippingDrawableInd
     // マスクの数
     _clippingIdCount = clipCount;
 
-    _layoutChannelNo = 0;
+    _layoutChannelIndex = 0;
 
     _allClippedDrawRect = CSM_NEW csmRectF();
     _layoutBounds = CSM_NEW csmRectF();

--- a/src/Rendering/CubismRenderer.hpp
+++ b/src/Rendering/CubismRenderer.hpp
@@ -296,7 +296,7 @@ public:
     csmBool _isUsing;                                ///< 現在の描画状態でマスクの準備が必要ならtrue
     const csmInt32* _clippingIdList;                 ///< クリッピングマスクのIDリスト
     csmInt32 _clippingIdCount;                       ///< クリッピングマスクの数
-    csmInt32 _layoutChannelNo;                       ///< RGBAのいずれのチャンネルにこのクリップを配置するか(0:R , 1:G , 2:B , 3:A)
+    csmInt32 _layoutChannelIndex;                       ///< RGBAのいずれのチャンネルにこのクリップを配置するか(0:R , 1:G , 2:B , 3:A)
     csmRectF* _layoutBounds;                         ///< マスク用チャンネルのどの領域にマスクを入れるか(View座標-1..1, UVは0..1に直す)
     csmRectF* _allClippedDrawRect;                   ///< このクリッピングで、クリッピングされる全ての描画オブジェクトの囲み矩形（毎回更新）
     CubismMatrix44 _matrixForMask;                   ///< マスクの位置計算結果を保持する行列

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
@@ -192,40 +192,10 @@ CubismClippingContext_D3D11::CubismClippingContext_D3D11(CubismClippingManager<C
     _isUsing = false;
 
     _owner = manager;
-
-    // クリップしている（＝マスク用の）Drawableのインデックスリスト
-    _clippingIdList = clippingDrawableIndices;
-
-    // マスクの数
-    _clippingIdCount = clipCount;
-
-    _layoutChannelNo = 0;
-
-    _allClippedDrawRect = CSM_NEW csmRectF();
-    _layoutBounds = CSM_NEW csmRectF();
-
-    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
 }
 
 CubismClippingContext_D3D11::~CubismClippingContext_D3D11()
 {
-    if (_layoutBounds != NULL)
-    {
-        CSM_DELETE(_layoutBounds);
-        _layoutBounds = NULL;
-    }
-
-    if (_allClippedDrawRect != NULL)
-    {
-        CSM_DELETE(_allClippedDrawRect);
-        _allClippedDrawRect = NULL;
-    }
-
-    if (_clippedDrawableIndexList != NULL)
-    {
-        CSM_DELETE(_clippedDrawableIndexList);
-        _clippedDrawableIndexList = NULL;
-    }
 }
 
 CubismClippingManager<CubismClippingContext_D3D11, CubismOffscreenSurface_D3D11>* CubismClippingContext_D3D11::GetClippingManager()
@@ -728,8 +698,8 @@ void CubismRenderer_D3D11::ExecuteDrawForMask(const CubismModel& model, const cs
 
         DirectX::XMMATRIX proj = ConvertToD3DX(GetClippingContextBufferForMask()->_matrixForMask);
         csmRectF* rect = GetClippingContextBufferForMask()->_layoutBounds;
-        const csmInt32 channelNo = GetClippingContextBufferForMask()->_layoutChannelNo;
-        CubismTextureColor* colorChannel = GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        const csmInt32 channelIndex = GetClippingContextBufferForMask()->_layoutChannelIndex;
+        CubismTextureColor* colorChannel = GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
         const CubismTextureColor& multiplyColor = model.GetMultiplyColor(index);
         const CubismTextureColor& screenColor = model.GetScreenColor(index);
 
@@ -815,8 +785,8 @@ void CubismRenderer_D3D11::ExecuteDrawForDraw(const CubismModel& model, const cs
                 XMStoreFloat4x4(&cb.clipMatrix, DirectX::XMMatrixTranspose(clip));
 
                 // 使用するカラーチャンネルを設定
-                const csmInt32 channelNo = GetClippingContextBufferForDraw()->_layoutChannelNo;
-                CubismRenderer::CubismTextureColor* colorChannel = GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+                const csmInt32 channelIndex = GetClippingContextBufferForDraw()->_layoutChannelIndex;
+                CubismRenderer::CubismTextureColor* colorChannel = GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
                 XMStoreFloat4(&cb.channelFlag, DirectX::XMVectorSet(colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A));
             }
 
@@ -1067,10 +1037,10 @@ void CubismRenderer_D3D11::CopyToBuffer(ID3D11DeviceContext* renderContext, csmI
 ID3D11ShaderResourceView* CubismRenderer_D3D11::GetTextureViewWithIndex(const CubismModel& model, const csmInt32 index)
 {
     ID3D11ShaderResourceView* result = NULL;
-    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
-    if (textureNo >= 0)
+    const csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
+    if (textureIndex >= 0)
     {
-        result = _textures[textureNo];
+        result = _textures[textureIndex];
     }
     return result;
 }

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
@@ -641,8 +641,8 @@ void CubismRenderer_D3D9::ExecuteDrawForDraw(const CubismModel& model, const csm
             shaderEffect->SetMatrix("clipMatrix", &clipM);
 
             // 使用するカラーチャンネルを設定
-            const csmInt32 channelNo = GetClippingContextBufferForDraw()->_layoutChannelNo;
-            CubismRenderer::CubismTextureColor* colorChannel = GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+            const csmInt32 channelIndex = GetClippingContextBufferForDraw()->_layoutChannelIndex;
+            CubismRenderer::CubismTextureColor* colorChannel = GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
             D3DXVECTOR4 channel(colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
             shaderEffect->SetVector("channelFlag", &channel);
         }
@@ -727,9 +727,9 @@ void CubismRenderer_D3D9::ExecuteDrawForMask(const CubismModel& model, const csm
         shaderEffect->SetVector("screenColor", &shaderScreenColor);
 
         // チャンネル
-        const csmInt32 channelNo = GetClippingContextBufferForMask()->_layoutChannelNo;
+        const csmInt32 channelIndex = GetClippingContextBufferForMask()->_layoutChannelIndex;
         // チャンネルをRGBAに変換
-        CubismTextureColor* colorChannel = GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        CubismTextureColor* colorChannel = GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
         D3DXVECTOR4 channel(colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
         shaderEffect->SetVector("channelFlag", &channel);
 
@@ -976,10 +976,10 @@ void CubismRenderer_D3D9::CopyToBuffer(csmInt32 drawAssign, const csmInt32 vcoun
 LPDIRECT3DTEXTURE9 CubismRenderer_D3D9::GetTextureWithIndex(const CubismModel& model, const csmInt32 index)
 {
     LPDIRECT3DTEXTURE9 result = NULL;
-    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
-    if (textureNo >= 0)
+    const csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
+    if (textureIndex >= 0)
     {
-        result = _textures[textureNo];
+        result = _textures[textureIndex];
     }
 
     return result;

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -135,11 +135,11 @@ public:
      * @brief   テクスチャのバインド処理<br>
      *           CubismRendererにテクスチャを設定し、CubismRenderer中でその画像を参照するためのIndex値を戻り値とする
      *
-     * @param[in]   modelTextureNo  ->  セットするモデルテクスチャの番号
+     * @param[in]   modelTextureIndex  ->  セットするモデルテクスチャの番号
      * @param[in]   texture     ->  バックエンドテクスチャ
      *
      */
-    void BindTexture(csmUint32 modelTextureNo, id <MTLTexture> texture);
+    void BindTexture(csmUint32 modelTextureIndex, id <MTLTexture> texture);
 
     /**
      * @brief   バインドされたテクスチャのリストを取得する
@@ -214,7 +214,7 @@ protected:
      * @brief    描画オブジェクト（アートメッシュ）を描画する。<br>
      *           ポリゴンメッシュとテクスチャ番号をセットで渡す。
      *
-     * @param[in]   textureNo         ->  描画するテクスチャ番号
+     * @param[in]   textureIndex         ->  描画するテクスチャ番号
      * @param[in]   renderEncoder     ->  MTLRenderCommandEncoder
      * @param[in]   model             ->  描画対象モデル
      * @param[in]   index             ->  描画オブジェクトのインデックス

--- a/src/Rendering/Metal/CubismRenderer_Metal.mm
+++ b/src/Rendering/Metal/CubismRenderer_Metal.mm
@@ -591,9 +591,9 @@ void CubismRenderer_Metal::RestoreProfile()
 {
 }
 
-void CubismRenderer_Metal::BindTexture(csmUint32 modelTextureNo, id <MTLTexture> texture)
+void CubismRenderer_Metal::BindTexture(csmUint32 modelTextureIndex, id <MTLTexture> texture)
 {
-    _textures[modelTextureNo] = texture;
+    _textures[modelTextureIndex] = texture;
 }
 
 const csmMap< csmInt32, id <MTLTexture> >& CubismRenderer_Metal::GetBindedTextures() const

--- a/src/Rendering/Metal/CubismShader_Metal.mm
+++ b/src/Rendering/Metal/CubismShader_Metal.mm
@@ -272,8 +272,8 @@ void CubismShader_Metal::SetupShaderProgramForDraw(CubismCommandBuffer_Metal::Dr
         [renderEncoder setFragmentTexture:tex atIndex:1];
 
         // 使用するカラーチャンネルを設定
-        const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
-        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        const csmInt32 channelIndex = renderer->GetClippingContextBufferForDraw()->_layoutChannelIndex;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
 
         fragMaskedShaderUniforms.channelFlag = (vector_float4){ colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
         {
@@ -366,8 +366,8 @@ void CubismShader_Metal::SetupShaderProgramForMask(CubismCommandBuffer_Metal::Dr
     [renderEncoder setVertexBuffer:(drawCommandBuffer->GetUvBuffer()) offset:0 atIndex:MetalVertexInputUVs];
 
     CubismSetupMaskedShaderUniforms maskedShaderUniforms;
-    const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
-    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    const csmInt32 channelIndex = renderer->GetClippingContextBufferForMask()->_layoutChannelIndex;
+    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
     maskedShaderUniforms.channelFlag = (vector_float4){ colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A };
 
     csmFloat32* srcArray = renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray();

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -704,9 +704,9 @@ void CubismRenderer_OpenGLES2::RestoreProfile()
     _rendererProfile.Restore();
 }
 
-void CubismRenderer_OpenGLES2::BindTexture(csmUint32 modelTextureNo, GLuint glTextureNo)
+void CubismRenderer_OpenGLES2::BindTexture(csmUint32 modelTextureIndex, GLuint glTextureIndex)
 {
-    _textures[modelTextureNo] = glTextureNo;
+    _textures[modelTextureIndex] = glTextureIndex;
 }
 
 const csmMap<csmInt32, GLuint>& CubismRenderer_OpenGLES2::GetBindedTextures() const

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp
@@ -188,11 +188,11 @@ public:
      * @brief   OpenGLテクスチャのバインド処理<br>
      *           CubismRendererにテクスチャを設定し、CubismRenderer中でその画像を参照するためのIndex値を戻り値とする
      *
-     * @param[in]   modelTextureNo  ->  セットするモデルテクスチャの番号
-     * @param[in]   glTextureNo     ->  OpenGLテクスチャの番号
+     * @param[in]   modelTextureIndex  ->  セットするモデルテクスチャの番号
+     * @param[in]   glTextureIndex     ->  OpenGLテクスチャの番号
      *
      */
-    void BindTexture(csmUint32 modelTextureNo, GLuint glTextureNo);
+    void BindTexture(csmUint32 modelTextureIndex, GLuint glTextureIndex);
 
     /**
      * @brief   OpenGLにバインドされたテクスチャのリストを取得する

--- a/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
@@ -867,14 +867,14 @@ void CubismShader_OpenGLES2::SetupShaderProgramForDraw(CubismRenderer_OpenGLES2*
         glUniformMatrix4fv(shaderSet->UniformClipMatrixLocation, 1, 0, renderer->GetClippingContextBufferForDraw()->_matrixForDraw.GetArray());
 
         // 使用するカラーチャンネルを設定
-        const csmInt32 channelNo = renderer->GetClippingContextBufferForDraw()->_layoutChannelNo;
-        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+        const csmInt32 channelIndex = renderer->GetClippingContextBufferForDraw()->_layoutChannelIndex;
+        CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForDraw()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
         glUniform4f(shaderSet->UnifromChannelFlagLocation, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
     }
 
     //テクスチャ設定
-    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
-    const GLuint textureId = renderer->GetBindedTextureId(textureNo);
+    const csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
+    const GLuint textureId = renderer->GetBindedTextureId(textureIndex);
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, textureId);
     glUniform1i(shaderSet->SamplerTexture0Location, 0);
@@ -912,8 +912,8 @@ void CubismShader_OpenGLES2::SetupShaderProgramForMask(CubismRenderer_OpenGLES2*
     glUseProgram(shaderSet->ShaderProgram);
 
     //テクスチャ設定
-    const csmInt32 textureNo = model.GetDrawableTextureIndex(index);
-    const GLuint textureId = renderer->GetBindedTextureId(textureNo);
+    const csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
+    const GLuint textureId = renderer->GetBindedTextureId(textureIndex);
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, textureId);
     glUniform1i(shaderSet->SamplerTexture0Location, 0);
@@ -929,8 +929,8 @@ void CubismShader_OpenGLES2::SetupShaderProgramForMask(CubismRenderer_OpenGLES2*
     glVertexAttribPointer(shaderSet->AttributeTexCoordLocation, 2, GL_FLOAT, GL_FALSE, sizeof(csmFloat32) * 2, uvArray);
 
     // チャンネル
-    const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
-    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelNo);
+    const csmInt32 channelIndex = renderer->GetClippingContextBufferForMask()->_layoutChannelIndex;
+    CubismRenderer::CubismTextureColor* colorChannel = renderer->GetClippingContextBufferForMask()->GetClippingManager()->GetChannelFlagAsColor(channelIndex);
     glUniform4f(shaderSet->UnifromChannelFlagLocation, colorChannel->R, colorChannel->G, colorChannel->B, colorChannel->A);
 
     glUniformMatrix4fv(shaderSet->UniformClipMatrixLocation, 1, GL_FALSE, renderer->GetClippingContextBufferForMask()->_matrixForMask.GetArray());

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
@@ -203,14 +203,14 @@ void CubismImageVulkan::CreateSampler(VkDevice device, float maxAnistropy,
     }
 }
 
-void CubismImageVulkan::SetImageLayout(VkCommandBuffer commandBuffer, VkImageLayout newLayout, csmUint32 mipLevels)
+void CubismImageVulkan::SetImageLayout(VkCommandBuffer commandBuffer, VkImageLayout newLayout, csmUint32 mipLevels, VkImageAspectFlags aspectMask)
 {
     VkImageMemoryBarrier barrier{};
     barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     barrier.oldLayout = currentLayout;
     barrier.newLayout = newLayout;
     barrier.image = image;
-    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.aspectMask = aspectMask;
     barrier.subresourceRange.baseMipLevel = 0;
     barrier.subresourceRange.levelCount = mipLevels;
     barrier.subresourceRange.baseArrayLayer = 0;
@@ -285,6 +285,11 @@ void CubismImageVulkan::SetImageLayout(VkCommandBuffer commandBuffer, VkImageLay
         &barrier
     );
 
+    currentLayout = newLayout;
+}
+
+void CubismImageVulkan::SetCurrentLayout(VkImageLayout newLayout)
+{
     currentLayout = newLayout;
 }
 

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.hpp
@@ -149,7 +149,14 @@ public:
      * @param[in]  newLayout      -> 新しいレイアウト
      * @param[in]  mipLevels      -> ミップマップのレベル
      */
-    void SetImageLayout(VkCommandBuffer commandBuffer, VkImageLayout newLayout, csmUint32 mipLevels);
+    void SetImageLayout(VkCommandBuffer commandBuffer, VkImageLayout newLayout, csmUint32 mipLevels, VkImageAspectFlags aspectMask);
+
+    /**
+     * @brief   vkCmdEndRendering後のパイプラインバリアで変わってしまうイメージレイアウトを保存する
+     *
+     * @param[in]  newLayout  -> 新しいレイアウト
+     */
+    void SetCurrentLayout(VkImageLayout newLayout);
 
     /**
      * @brief   リソースを破棄する

--- a/src/Rendering/Vulkan/CubismRenderer_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismRenderer_Vulkan.hpp
@@ -288,14 +288,18 @@ class CubismRenderer_Vulkan : public CubismRenderer
 
     /**
      * @brief   ディスクリプタセットとUBOを保持する構造体
+     *          コマンドバッファでまとめて描画する場合、ディスクリプタセットをバインド後に
+     *          更新してはならない。<br>
+     *          マスクされる描画対象のみ、フレームバッファをディスクリプタセットに設定する必要があるが、
+     *          その際バインド済みのディスクリプタセットを更新しないよう、別でマスクされる用のディスクリプタセットを用意する。
      */
     struct Descriptor
     {
         CubismBufferVulkan uniformBuffer; ///< ユニフォームバッファ
         VkDescriptorSet descriptorSet = VK_NULL_HANDLE; ///< ディスクリプタセット
         bool isDescriptorSetUpdated = false; ///< ディスクリプタセットが更新されたか
-        VkDescriptorSet descriptorSetMasked = VK_NULL_HANDLE; ///< マスク用ディスクリプタセット
-        bool isDescriptorSetMaskedUpdated = false; ///< マスク用ディスクリプタセットが更新されたか
+        VkDescriptorSet descriptorSetMasked = VK_NULL_HANDLE; ///< マスクされる描画対象用のディスクリプタセット
+        bool isDescriptorSetMaskedUpdated = false; ///< マスクされる描画対象用のディスクリプタセットが更新されたか
     };
 
 protected:

--- a/src/Utils/CubismJson.cpp
+++ b/src/Utils/CubismJson.cpp
@@ -131,7 +131,17 @@ csmBool CubismJson::ParseBytes(const csmByte* buffer, csmInt32 size)
 
 csmString CubismJson::ParseString(const csmChar* string, csmInt32 length, csmInt32 begin, csmInt32* outEndPos)
 {
-    if (_error) return NULL;
+    if (_error)
+    {
+        return NULL;
+    }
+
+    if (!string)
+    {
+        _error = "string is null";
+        return NULL;
+    }
+
     csmInt32 i = begin;
     csmChar c, c2;
     csmString ret;
@@ -151,7 +161,10 @@ csmString CubismJson::ParseString(const csmChar* string, csmInt32 length, csmInt
         case '\\': {//エスケープの場合
             i++; //２文字をセットで扱う
 
-            if (i - 1 > buf_start) ret.Append(static_cast<const csmChar*>(string + buf_start), (i - buf_start - 1)); //前の文字までを登録する
+            if (i - 1 > buf_start)
+            {
+                ret.Append(static_cast<const csmChar*>(string + buf_start), (i - buf_start - 1)); //前の文字までを登録する
+            }
             buf_start = i + 1; //エスケープ（２文字）の次の文字から
 
             if (i < length)
@@ -200,7 +213,17 @@ csmString CubismJson::ParseString(const csmChar* string, csmInt32 length, csmInt
 
 Value* CubismJson::ParseObject(const csmChar* buffer, csmInt32 length, csmInt32 begin, csmInt32* outEndPos)
 {
-    if (_error) return NULL;
+    if (_error)
+    {
+        return NULL;
+    }
+
+    if (!buffer)
+    {
+        _error = "buffer is null";
+        return NULL;
+    }
+
     Map* ret = CSM_NEW Map();
 
     //key : value ,
@@ -273,7 +296,10 @@ Value* CubismJson::ParseObject(const csmChar* buffer, csmInt32 length, csmInt32 
 
         // 値をチェック
         Value* value = ParseValue(buffer, length, i, local_ret_endpos2);
-        if (_error) return NULL;
+        if (_error)
+        {
+            return NULL;
+        }
         i = local_ret_endpos2[0];
         // ret.put( key , value ) ;
         ret->Put(key, value);
@@ -305,7 +331,17 @@ Value* CubismJson::ParseObject(const csmChar* buffer, csmInt32 length, csmInt32 
 
 Value* CubismJson::ParseArray(const csmChar* buffer, csmInt32 length, csmInt32 begin, csmInt32* outEndPos)
 {
-    if (_error) return NULL;
+    if (_error)
+    {
+        return NULL;
+    }
+
+    if (!buffer)
+    {
+        _error = "buffer is null";
+        return NULL;
+    }
+
     Array* ret = CSM_NEW Array();
 
     //key : value ,
@@ -318,7 +354,10 @@ Value* CubismJson::ParseArray(const csmChar* buffer, csmInt32 length, csmInt32 b
     {
         // : をチェック
         Value* value = ParseValue(buffer, length, i, local_ret_endpos2);
-        if (_error) return NULL;
+        if (_error)
+        {
+            return NULL;
+        }
         i = local_ret_endpos2[0];
         if (value)
         {
@@ -357,7 +396,16 @@ Value* CubismJson::ParseArray(const csmChar* buffer, csmInt32 length, csmInt32 b
 
 Value* CubismJson::ParseValue(const csmChar* buffer, csmInt32 length, csmInt32 begin, csmInt32* outEndPos)
 {
-    if (_error) return NULL;
+    if (_error)
+    {
+        return NULL;
+    }
+
+    if (!buffer)
+    {
+        _error = "buffer is null";
+        return NULL;
+    }
 
     Value* o = NULL;
     csmInt32 i = begin;
@@ -372,12 +420,13 @@ Value* CubismJson::ParseValue(const csmChar* buffer, csmInt32 length, csmInt32 b
         {
         case '-': case '.':
         case '0': case '1': case '2': case '3': case '4':
-        case '5': case '6': case '7': case '8': case '9': {
-            char* ret_ptr;
-            f = strtof(const_cast<csmChar*>(buffer + i), &ret_ptr);
-            *outEndPos = static_cast<csmInt32>(ret_ptr - buffer);
-            return CSM_NEW Float(f);
-        }
+        case '5': case '6': case '7': case '8': case '9':
+            {
+                char* ret_ptr;
+                f = strtof(const_cast<csmChar*>(buffer + i), &ret_ptr);
+                *outEndPos = static_cast<csmInt32>(ret_ptr - buffer);
+                return CSM_NEW Float(f);
+            }
         case '\"':
             return CSM_NEW String(ParseString(buffer, length, i + 1, outEndPos)); //\"の次の文字から
         case '[':
@@ -434,11 +483,17 @@ Map::~Map()
     while (ite != _map.End())
     {
         Value* v = (*ite).Second;
-        if (v && !v->IsStatic()) CSM_DELETE(v);
+        if (v && !v->IsStatic())
+        {
+            CSM_DELETE(v);
+        }
         ++ite;
     }
 
-    if (_keys) CSM_DELETE(_keys);
+    if (_keys)
+    {
+        CSM_DELETE(_keys);
+    }
 }
 
 
@@ -448,7 +503,10 @@ Array::~Array()
     for (; ite != _array.End(); ++ite)
     {
         Value* v = (*ite);
-        if (v && !v->IsStatic()) CSM_DELETE(v);
+        if (v && !v->IsStatic())
+        {
+            CSM_DELETE(v);
+        }
     }
 }
 }}}}


### PR DESCRIPTION
### Fixed

* Fix memory leak in DX11.
* Fix an issue where models with a specific number of masks could not be drawn correctly.
* Fix to check for null when reading json.
* Fix an issue that caused some graphics drivers to not render correctly in Vulkan.
* Fix errors related to semaphore waiting stages.
* Fix errors that occurs when building with x86 in vulkan.