### PR TITLE
Missing a default return value

### DIFF
--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -83,6 +83,7 @@ csmFloat32 ACubismMotion::UpdateFadeWeight(CubismMotionQueueEntry* motionQueueEn
     if (motionQueueEntry == NULL)
     {
         CubismLogError("motionQueueEntry is null.");
+        return 0;
     }
 
     csmFloat32 fadeWeight = _weight; //現在の値と掛け合わせる割合


### PR DESCRIPTION
It determines whether the motionQueueEntry is null, but does not return a default value
May cause npe to crash