### PR TITLE
reconstruct curve totals for corrupt/old models

### DIFF
--- a/src/Motion/CubismMotionJson.hpp
+++ b/src/Motion/CubismMotionJson.hpp
@@ -11,6 +11,8 @@
 #include "CubismJsonHolder.hpp"
 #include "Utils/CubismJson.hpp"
 #include "Id/CubismId.hpp"
+#include <memory>
+#include <tuple>
 
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -38,7 +40,7 @@ public:
      * @param[in]   buffer  motion3.jsonが読み込まれているバッファ
      * @param[in]   size    バッファのサイズ
      */
-    CubismMotionJson(const csmByte* buffer, csmSizeInt size);
+    CubismMotionJson(const csmByte* buffer, csmSizeInt size, bool trustUserBounds = false);
 
     /**
      * @brief デストラクタ
@@ -273,6 +275,17 @@ public:
     * @return  イベントの文字列
     */
     const csmChar* GetEventValue(csmInt32 userDataIndex) const;
+
+private:
+    csmInt32 GetRecoveredTotal(csmChar const key) const;
+    csmInt32 CountCurves() const;
+    csmInt32 CountSegments() const;
+    csmInt32 CountPoints() const;
+    // I would rather have std::optional or even an std::variant with std::monostate, but we're in c++14
+    std::unique_ptr<std::tuple<csmInt32,csmInt32,csmInt32>> recoveredTotals;
+    void RecoverTotals();
+
+    bool _trustUserBounds = false;
 };
 
 }}}


### PR DESCRIPTION
Reconstruct curve totals for models from, for example, [https://github.com/andatoshiki/toshiki-live2d/tree/master/为美好的世界献上祝福！Fantastic Days](https://github.com/andatoshiki/toshiki-live2d/tree/master/%E4%B8%BA%E7%BE%8E%E5%A5%BD%E7%9A%84%E4%B8%96%E7%95%8C%E7%8C%AE%E4%B8%8A%E7%A5%9D%E7%A6%8F%EF%BC%81Fantastic%20Days)
Resolves https://github.com/MizunagiKB/gd_cubism/issues/75 and https://github.com/MizunagiKB/gd_cubism/issues/52
Reconstruction algorithm based on https://gist.github.com/MizunagiKB/7fd109925e56db0ed88b77450cdea579, additional documentation from https://github.com/Live2D/CubismSpecs/blob/ab04558655dfd4d8c2d529286124e274648c772d/FileFormats/motion3.json.md