### PR TITLE
Refactors and fix potential memory leak

### DIFF
--- a/src/Effect/CubismPose.cpp
+++ b/src/Effect/CubismPose.cpp
@@ -32,9 +32,8 @@ CubismPose::PartData::~PartData()
 CubismPose::PartData::PartData(const PartData& v)
                                             : ParameterIndex(0)
                                             , PartIndex(0)
+                                            , PartId(v.PartId)
 {
-    PartId = v.PartId;
-
     for (csmVector<PartData>::const_iterator ite = v.Link.Begin(); ite != v.Link.End(); ++ite)
     {
         Link.PushBack(*ite);

--- a/src/Id/CubismId.cpp
+++ b/src/Id/CubismId.cpp
@@ -18,9 +18,8 @@ CubismId::CubismId(const CubismId& c)
 { }
 
 CubismId::CubismId(const csmChar* id)
-{
-    _id = id;
-}
+                        : _id(id)
+{ }
 
 CubismId::~CubismId()
 { }

--- a/src/Math/CubismModelMatrix.cpp
+++ b/src/Math/CubismModelMatrix.cpp
@@ -16,10 +16,9 @@ CubismModelMatrix::CubismModelMatrix()
 { }
 
 CubismModelMatrix::CubismModelMatrix(csmFloat32 w, csmFloat32 h)
+                                : _width(w)
+                                , _height(h)
 {
-    _width = w;
-    _height = h;
-
     SetHeight(2.0f);
 }
 

--- a/src/Motion/CubismExpressionMotionManager.cpp
+++ b/src/Motion/CubismExpressionMotionManager.cpp
@@ -153,9 +153,6 @@ csmBool CubismExpressionMotionManager::UpdateMotion(CubismModel* model, csmFloat
     // ----- 最新のExpressionのフェードが完了していればそれ以前を削除する ------
     if (motions->GetSize() > 1)
     {
-        CubismExpressionMotion* expressionMotion =
-            (CubismExpressionMotion*)(motions->At(motions->GetSize() - 1))->GetCubismMotion();
-
         csmFloat32 latestFadeWeight = _fadeWeights[_fadeWeights.GetSize() - 1];
         if (latestFadeWeight >= 1.0f)
         {

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -229,7 +229,7 @@ csmBool CubismMotionQueueManager::IsFinished(CubismMotionQueueEntryHandle motion
 {
     // 既にモーションがあれば終了フラグを立てる
 
-    for (csmVector<CubismMotionQueueEntry*>::iterator ite = _motions.Begin(); ite != _motions.End(); ite++)
+    for (csmVector<CubismMotionQueueEntry*>::iterator ite = _motions.Begin(); ite != _motions.End(); ++ite)
     {
         CubismMotionQueueEntry* motionQueueEntry = *ite;
 

--- a/src/Physics/CubismPhysics.cpp
+++ b/src/Physics/CubismPhysics.cpp
@@ -442,13 +442,13 @@ void UpdateOutputParameterValue(csmFloat32* parameterValue, csmFloat32 parameter
 
 CubismPhysics::CubismPhysics()
     : _physicsRig(NULL)
+    , _currentRemainTime(0.0f)
 {
     // set default options.
     _options.Gravity.Y = -1.0f;
     _options.Gravity.X = 0;
     _options.Wind.X = 0;
     _options.Wind.Y = 0;
-    _currentRemainTime = 0.0f;
 }
 
 CubismPhysics::~CubismPhysics()

--- a/src/Rendering/CubismRenderer.cpp
+++ b/src/Rendering/CubismRenderer.cpp
@@ -157,20 +157,13 @@ csmBool CubismRenderer::IsUsingHighPrecisionMask()
 *                                      CubismClippingContext
 ********************************************************************************************************************/
 CubismClippingContext::CubismClippingContext(const csmInt32* clippingDrawableIndices, csmInt32 clipCount)
-{
-    // クリップしている（＝マスク用の）Drawableのインデックスリスト
-    _clippingIdList = clippingDrawableIndices;
-
-    // マスクの数
-    _clippingIdCount = clipCount;
-
-    _layoutChannelIndex = 0;
-
-    _allClippedDrawRect = CSM_NEW csmRectF();
-    _layoutBounds = CSM_NEW csmRectF();
-
-    _clippedDrawableIndexList = CSM_NEW csmVector<csmInt32>();
-}
+                                : _clippingIdList(clippingDrawableIndices)
+                                , _clippingIdCount(clipCount)
+                                , _layoutChannelIndex(0)
+                                , _allClippedDrawRect(CSM_NEW csmRectF())
+                                , _layoutBounds(CSM_NEW csmRectF())
+                                , _clippedDrawableIndexList(CSM_NEW csmVector<csmInt32>())
+{ }
 
 CubismClippingContext::~CubismClippingContext()
 {

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
@@ -305,10 +305,9 @@ CubismRenderer_D3D11::CubismRenderer_D3D11()
     , _clippingManager(NULL)
     , _clippingContextBufferForMask(NULL)
     , _clippingContextBufferForDraw(NULL)
+    , _commandBufferNum(0)
+    , _commandBufferCurrent(0)
 {
-    _commandBufferNum = 0;
-    _commandBufferCurrent = 0;
-
     // テクスチャ対応マップの容量を確保しておく.
     _textures.PrepareCapacity(32, true);
 }

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
@@ -294,10 +294,9 @@ CubismRenderer_D3D9::CubismRenderer_D3D9()
     , _clippingManager(NULL)
     , _clippingContextBufferForMask(NULL)
     , _clippingContextBufferForDraw(NULL)
+    , _commandBufferNum(0)
+    , _commandBufferCurrent(0)
 {
-    _commandBufferNum = 0;
-    _commandBufferCurrent = 0;
-
     // テクスチャ対応マップの容量を確保しておく.
     _textures.PrepareCapacity(32, true);
 }

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
@@ -264,7 +264,6 @@ void CubismImageVulkan::SetImageLayout(VkCommandBuffer commandBuffer, VkImageLay
 
     case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
         barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
         destinationStage = VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
         break;
 

--- a/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.cpp
@@ -80,7 +80,8 @@ void CubismOffscreenSurface_Vulkan::CreateOffscreenSurface(
     csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
     VkFormat surfaceFormat, VkFormat depthFormat)
 {
-    if (_colorImage != nullptr) {
+    if (_colorImage != nullptr)
+    {
         vkFreeMemory(device, _colorImage, nullptr);
     }
 

--- a/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismOffscreenSurface_Vulkan.cpp
@@ -80,6 +80,10 @@ void CubismOffscreenSurface_Vulkan::CreateOffscreenSurface(
     csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
     VkFormat surfaceFormat, VkFormat depthFormat)
 {
+    if (_colorImage != nullptr) {
+        vkFreeMemory(device, _colorImage, nullptr);
+    }
+
     _colorImage = new CubismImageVulkan;
     _colorImage->CreateImage(device, physicalDevice, displayBufferWidth, displayBufferHeight,
                              1, surfaceFormat, VK_IMAGE_TILING_OPTIMAL,

--- a/src/Rendering/Vulkan/CubismRenderer_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismRenderer_Vulkan.cpp
@@ -271,7 +271,7 @@ VkShaderModule CubismPipeline_Vulkan::PipelineResource::CreateShaderModule(VkDev
     return shaderModule;
 }
 
-void CubismPipeline_Vulkan::PipelineResource::CreateGraphicsPipeline(std::string vertFileName, std::string fragFileName,
+void CubismPipeline_Vulkan::PipelineResource::CreateGraphicsPipeline(const std::string vertFileName, const std::string fragFileName,
                                                                    VkDescriptorSetLayout descriptorSetLayout)
 {
     VkShaderModule vertShaderModule = CreateShaderModule(s_device, vertFileName);


### PR DESCRIPTION
Items in this PR address potential performance gains by: 
* Moving constructor assignments into initialization lists
* Favor pre-increment over post-increment on iterators
* Safety for certain function arguments that are not modified
* Preventing a potential memory leak by freeing pointer reference before assignment
* Remove unnecessary lines for variables no longer referenced later in the cycle