### PR TITLE
Update to Cubism 5 SDK for Native R3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.3] - 2025-02-18
+
+### Added
+
+* Add new motion loop processing that seamlessly connects the start and end points of the loop.
+  * The `_isLoop` variable was moved from class `CubismMotion` to class `ACubismMotion`.
+  * Add the setter for `_isLoop`, `SetLoop(csmBool loop)`, to class `ACubismMotion`.
+  * Add the getter for `_isLoop`, `GetLoop()`, to class `ACubismMotion`.
+  * The `_isLoopFadeIn` variable was moved from class `CubismMotion` to class `ACubismMotion`.
+  * Add the setter for `_isLoopFadeIn`, `SetLoopFadeIn(csmBool loopFadeIn)`, to class `ACubismMotion`.
+  * Add the getter for `_isLoopFadeIn`, `GetLoopFadeIn()`, to class `ACubismMotion`.
+  * Add a variable `_motionBehavior` for version control to the `CubismMotion` class.
+
+### Deprecated
+
+* Deprecate the following elements due to the change in the variable declaration location.
+  * `CubismMotion::IsLoop(csmBool loop)`
+  * `CubismMotion::IsLoop()`
+  * `CubismMotion::IsLoopFadeIn(csmBool loopFadeIn)`
+  * `CubismMotion::IsLoopFadeIn()`
+
+
 ## [5-r.2] - 2024-12-19
 
 ### Added
@@ -425,6 +447,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[5-r.3]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1-beta.4...5-r.1
 [5-r.1-beta.4]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1-beta.3...5-r.1-beta.4

--- a/src/Motion/ACubismMotion.cpp
+++ b/src/Motion/ACubismMotion.cpp
@@ -22,7 +22,10 @@ ACubismMotion::ACubismMotion()
     : _fadeInSeconds(-1.0f)
     , _fadeOutSeconds(-1.0f)
     , _weight(1.0f)
-    , _offsetSeconds(0.0f) //再生の開始時刻
+    , _offsetSeconds(0.0f) // 再生の開始時刻
+    , _isLoop(false)       // trueから false へデフォルトを変更
+    , _isLoopFadeIn(true)  // ループ時にフェードインが有効かどうかのフラグ
+    , _previousLoopState(_isLoop)
     , _onBeganMotion(NULL)
     , _onBeganMotionCustomData(NULL)
     , _onFinishedMotion(NULL)
@@ -70,13 +73,11 @@ void ACubismMotion::SetupMotionQueueEntry(CubismMotionQueueEntry* motionQueueEnt
     motionQueueEntry->SetStartTime(userTimeSeconds - _offsetSeconds); //モーションの開始時刻を記録
     motionQueueEntry->SetFadeInStartTime(userTimeSeconds); //フェードインの開始時刻
 
-    const csmFloat32 duration = GetDuration();
 
     if (motionQueueEntry->GetEndTime() < 0)
     {
         //開始していないうちに終了設定している場合がある。
-        motionQueueEntry->SetEndTime((duration <= 0) ? -1 : motionQueueEntry->GetStartTime() + duration);
-        //duration == -1 の場合はループする
+        AdjustEndTime(motionQueueEntry);
     }
 
     if (this->_onBeganMotion != NULL)
@@ -160,6 +161,26 @@ void ACubismMotion::SetOffsetTime(csmFloat32 offsetSeconds)
     this->_offsetSeconds = offsetSeconds;
 }
 
+void ACubismMotion::SetLoop(csmBool loop)
+{
+    this->_isLoop = loop;
+}
+
+csmBool ACubismMotion::GetLoop() const
+{
+    return this->_isLoop;
+}
+
+void ACubismMotion::SetLoopFadeIn(csmBool loopFadeIn)
+{
+    this->_isLoopFadeIn = loopFadeIn;
+}
+
+csmBool ACubismMotion::GetLoopFadeIn() const
+{
+    return this->_isLoopFadeIn;
+}
+
 const csmVector<const csmString*>& ACubismMotion::GetFiredEvent(csmFloat32 beforeCheckTimeSeconds, csmFloat32 motionTimeSeconds)
 {
     return _firedEventValues;
@@ -236,6 +257,18 @@ CubismIdHandle ACubismMotion::GetModelOpacityId(csmInt32 index)
 csmFloat32 ACubismMotion::GetModelOpacityValue() const
 {
     return 1.0f;
+}
+
+void ACubismMotion::AdjustEndTime(CubismMotionQueueEntry* motionQueueEntry)
+{
+    const csmFloat32 duration = GetDuration();
+
+    // duration == -1 の場合はループする
+    const csmFloat32 endTime = (duration <= 0) ?
+        -1 :
+        motionQueueEntry->GetStartTime() + duration;
+
+    motionQueueEntry->SetEndTime(endTime);
 }
 
 }}}

--- a/src/Motion/ACubismMotion.hpp
+++ b/src/Motion/ACubismMotion.hpp
@@ -127,6 +127,34 @@ public:
     void SetOffsetTime(csmFloat32 offsetSeconds);
 
     /**
+     * Sets whether the motion should loop.
+     *
+     * @param loop true to set the motion to loop
+     */
+    void SetLoop(csmBool loop);
+
+    /**
+     * Checks whether the motion is set to loop.
+     *
+     * @return true if the motion is set to loop; otherwise false.
+     */
+    csmBool GetLoop() const;
+
+    /**
+     * Sets whether to perform fade-in for looping motion.
+     *
+     * @param loopFadeIn true to perform fade-in for looping motion
+     */
+    void SetLoopFadeIn(csmBool loopFadeIn);
+
+    /**
+     * Checks the setting for fade-in of looping motion.
+     *
+     * @return true if fade-in for looping motion is set; otherwise false.
+     */
+    csmBool GetLoopFadeIn() const;
+
+    /**
      * Returns the triggered user data events.
      *
      * @param beforeCheckTimeSeconds previous playback time in seconds
@@ -272,10 +300,15 @@ protected:
 
     virtual void DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 weight, CubismMotionQueueEntry* motionQueueEntry) = 0;
 
+    void AdjustEndTime(CubismMotionQueueEntry* motionQueueEntry);
+
     csmFloat32    _fadeInSeconds;
     csmFloat32    _fadeOutSeconds;
     csmFloat32    _weight;
     csmFloat32    _offsetSeconds;
+    csmBool       _isLoop;
+    csmBool       _isLoopFadeIn;
+    csmBool       _previousLoopState;
 
     csmVector<const csmString*>    _firedEventValues;
 

--- a/src/Motion/CubismMotion.cpp
+++ b/src/Motion/CubismMotion.cpp
@@ -187,7 +187,34 @@ csmFloat32 InverseSteppedEvaluate(const CubismMotionPoint* points, const csmFloa
     return points[1].Value;
 }
 
-csmFloat32 EvaluateCurve(const CubismMotionData* motionData, const csmInt32 index, csmFloat32 time)
+csmFloat32 CorrectEndPoint(
+    const CubismMotionData* motionData,
+    const csmInt32 segmentIndex,
+    const csmInt32 beginIndex,
+    const csmInt32 endIndex,
+    const csmFloat32 time,
+    const csmFloat32 endTime
+    )
+{
+    CubismMotionPoint motionPoint[2];
+    motionPoint[0] = motionData->Points[endIndex];
+    motionPoint[1] = motionData->Points[beginIndex];
+    motionPoint[1].Time = endTime;
+
+    switch (motionData->Segments[segmentIndex].SegmentType)
+    {
+    case CubismMotionSegmentType_Linear:
+    case CubismMotionSegmentType_Bezier:
+    default:
+        return LinearEvaluate(motionPoint, time);
+    case CubismMotionSegmentType_Stepped:
+        return SteppedEvaluate(motionPoint, time);
+    case CubismMotionSegmentType_InverseStepped:
+        return InverseSteppedEvaluate(motionPoint, time);
+    }
+}
+
+csmFloat32 EvaluateCurve(const CubismMotionData* motionData, const csmInt32 index, csmFloat32 time, const csmBool isCorrection, const csmFloat32 endTime)
 {
     // Find segment to evaluate.
     const CubismMotionCurve& curve = motionData->Curves[index];
@@ -215,6 +242,19 @@ csmFloat32 EvaluateCurve(const CubismMotionData* motionData, const csmInt32 inde
 
     if (target == -1)
     {
+        if (isCorrection && time < endTime)
+        {
+            // 終点から始点への補正処理
+            return CorrectEndPoint(
+                motionData,
+                totalSegmentCount - 1,
+                motionData->Segments[curve.BaseSegmentIndex].BasePointIndex,
+                pointPosition,
+                time,
+                endTime
+                );
+        }
+
         return motionData->Points[pointPosition].Value;
     }
 
@@ -229,8 +269,7 @@ csmFloat32 EvaluateCurve(const CubismMotionData* motionData, const csmInt32 inde
 CubismMotion::CubismMotion()
     : _sourceFrameRate(30.0f)
     , _loopDurationSeconds(-1.0f)
-    , _isLoop(false)                // trueから false へデフォルトを変更
-    , _isLoopFadeIn(true)           // ループ時にフェードインが有効かどうかのフラグ
+    , _motionBehavior(MotionBehavior_V2)
     , _lastWeight(0.0f)
     , _motionData(NULL)
     , _modelCurveIdEyeBlink(NULL)
@@ -282,6 +321,16 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
         _modelCurveIdOpacity = CubismFramework::GetIdManager()->GetId(IdNameOpacity);
     }
 
+    if (_motionBehavior == MotionBehavior_V2)
+    {
+        if (_previousLoopState != _isLoop)
+        {
+            // 終了時間を再計算する
+            AdjustEndTime(motionQueueEntry);
+            _previousLoopState = _isLoop;
+        }
+    }
+
     csmFloat32 timeOffsetSeconds = userTimeSeconds - motionQueueEntry->GetStartTime();
 
     if (timeOffsetSeconds < 0.0f)
@@ -320,12 +369,18 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
 
     // 'Repeat' time as necessary.
     csmFloat32 time = timeOffsetSeconds;
+    csmFloat32 duration = _motionData->Duration;
+    csmBool isCorrection = _motionBehavior == MotionBehavior_V2 && _isLoop;
 
     if (_isLoop)
     {
-        while (time > _motionData->Duration)
+        if (_motionBehavior == MotionBehavior_V2)
         {
-            time -= _motionData->Duration;
+            duration += 1.0f / _motionData->Fps;
+        }
+        while (time > duration)
+        {
+            time -= duration;
         }
     }
 
@@ -335,7 +390,7 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
     for (c = 0; c < _motionData->CurveCount && curves[c].Type == CubismMotionCurveTarget_Model; ++c)
     {
         // Evaluate curve and call handler.
-        value = EvaluateCurve(_motionData, c, time);
+        value = EvaluateCurve(_motionData, c, time, isCorrection, duration);
 
         if (curves[c].Id == _modelCurveIdEyeBlink)
         {
@@ -372,7 +427,7 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
         const csmFloat32 sourceValue = model->GetParameterValue(parameterIndex);
 
         // Evaluate curve and apply value.
-        value = EvaluateCurve(_motionData, c, time);
+        value = EvaluateCurve(_motionData, c, time, isCorrection, duration);
 
         if (eyeBlinkValue != FLT_MAX)
         {
@@ -492,21 +547,16 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
         }
 
         // Evaluate curve and apply value.
-        value = EvaluateCurve(_motionData, c, time);
+        value = EvaluateCurve(_motionData, c, time, isCorrection, duration);
 
         model->SetParameterValue(parameterIndex, value);
     }
 
-    if (timeOffsetSeconds >= _motionData->Duration)
+    if (timeOffsetSeconds >= duration)
     {
         if (_isLoop)
         {
-            motionQueueEntry->SetStartTime(userTimeSeconds); //最初の状態へ
-            if (_isLoopFadeIn)
-            {
-                //ループ中でループ用フェードインが有効のときは、フェードイン設定し直し
-                motionQueueEntry->SetFadeInStartTime(userTimeSeconds);
-            }
+            UpdateForNextLoop(motionQueueEntry, userTimeSeconds, time);
         }
         else
         {
@@ -520,6 +570,37 @@ void CubismMotion::DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSec
     }
 
     _lastWeight = fadeWeight;
+}
+
+void CubismMotion::UpdateForNextLoop(CubismMotionQueueEntry* motionQueueEntry, const csmFloat32 userTimeSeconds, const csmFloat32 time)
+{
+    switch (_motionBehavior)
+    {
+    case MotionBehavior_V2:
+    default:
+        motionQueueEntry->SetStartTime(userTimeSeconds - time); //最初の状態へ
+        if (_isLoopFadeIn)
+        {
+            //ループ中でループ用フェードインが有効のときは、フェードイン設定し直し
+            motionQueueEntry->SetFadeInStartTime(userTimeSeconds - time);
+        }
+
+        if (this->_onFinishedMotion != NULL)
+        {
+            this->_onFinishedMotion(this);
+        }
+        break;
+    case MotionBehavior_V1:
+        // 旧ループ処理
+
+        motionQueueEntry->SetStartTime(userTimeSeconds); //最初の状態へ
+        if (_isLoopFadeIn)
+        {
+            //ループ中でループ用フェードインが有効のときは、フェードイン設定し直し
+            motionQueueEntry->SetFadeInStartTime(userTimeSeconds);
+        }
+        break;
+    }
 }
 
 void CubismMotion::Parse(const csmByte* motionJson, const csmSizeInt size)
@@ -772,22 +853,40 @@ csmFloat32 CubismMotion::GetParameterFadeOutTime(CubismIdHandle parameterId) con
 
 void CubismMotion::IsLoop(csmBool loop)
 {
+    CubismLogWarning("IsLoop(csmBool loop) is a deprecated function. Please use SetLoop(csmBool loop).");
+
     this->_isLoop = loop;
 }
 
 csmBool CubismMotion::IsLoop() const
 {
+    CubismLogWarning("IsLoop() is a deprecated function. Please use GetLoop().");
+
     return this->_isLoop;
 }
 
 void CubismMotion::IsLoopFadeIn(csmBool loopFadeIn)
 {
+    CubismLogWarning("IsLoopFadeIn(csmBool loopFadeIn) is a deprecated function. Please use SetLoopFadeIn(csmBool loopFadeIn).");
+
     this->_isLoopFadeIn = loopFadeIn;
 }
 
 csmBool CubismMotion::IsLoopFadeIn() const
 {
+    CubismLogWarning("IsLoopFadeIn() is a deprecated function. Please use GetLoopFadeIn().");
+
     return this->_isLoopFadeIn;
+}
+
+void CubismMotion::SetMotionBehavior(MotionBehavior motionBehavior)
+{
+    _motionBehavior = motionBehavior;
+}
+
+CubismMotion::MotionBehavior CubismMotion::GetMotionBehavior() const
+{
+    return _motionBehavior;
 }
 
 csmFloat32 CubismMotion::GetLoopDuration()

--- a/src/Motion/CubismMotion.hpp
+++ b/src/Motion/CubismMotion.hpp
@@ -24,6 +24,16 @@ class CubismMotion : public ACubismMotion
 {
 public:
     /**
+     * Enumerator for version control of Motion Behavior
+        For details, see the SDK Manual.
+     */
+    enum MotionBehavior
+    {
+        MotionBehavior_V1,
+        MotionBehavior_V2,
+    };
+
+    /**
      * Makes an instance.
      *
      * @param buf buffer containing the loaded motion file
@@ -45,6 +55,9 @@ public:
     virtual void        DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 fadeWeight, CubismMotionQueueEntry* motionQueueEntry);
 
     /**
+     * @deprecated Not recommended due to the relocation of _isLoop to the base class.
+     *             Use ACubismMotion.SetLoop(csmBool loop) instead.
+     *
      * Sets whether the motion should loop.
      *
      * @param loop true to set the motion to loop
@@ -52,6 +65,9 @@ public:
     void                IsLoop(csmBool loop);
 
     /**
+     * @deprecated Not recommended due to the relocation of _isLoop to the base class.
+     *             Use ACubismMotion.GetLoop() instead.
+     *
      * Checks whether the motion is set to loop.
      *
      * @return true if the motion is set to loop; otherwise false.
@@ -59,6 +75,9 @@ public:
     csmBool             IsLoop() const;
 
     /**
+     * @deprecated Not recommended due to the relocation of _isLoopFadeIn to the base class.
+     *             Use ACubismMotion.SetLoopFadeIn(csmBool loopFadeIn) instead.
+     *
      * Sets whether to perform fade-in for looping motion.
      *
      * @param loopFadeIn true to perform fade-in for looping motion
@@ -66,11 +85,28 @@ public:
     void                IsLoopFadeIn(csmBool loopFadeIn);
 
     /**
+     * @deprecated Not recommended due to the relocation of _isLoopFadeIn to the base class.
+     *             Use ACubismMotion.GetLoopFadeIn() instead.
+     *
      * Checks the setting for fade-in of looping motion.
      *
      * @return true if fade-in for looping motion is set; otherwise false.
      */
     csmBool             IsLoopFadeIn() const;
+
+    /**
+     * Sets the version of the Motion Behavior.
+     *
+     * @param Specifies the version of the Motion Behavior.
+     */
+    void SetMotionBehavior(MotionBehavior motionBehavior);
+
+    /**
+     * Gets the version of the Motion Behavior.
+     *
+     * @return Returns the version of the Motion Behavior.
+     */
+    MotionBehavior GetMotionBehavior() const;
 
     /**
      * Returns the length of the motion.
@@ -177,12 +213,13 @@ private:
     CubismMotion(const CubismMotion&);
     CubismMotion& operator=(const CubismMotion&);
 
+    void UpdateForNextLoop(CubismMotionQueueEntry* motionQueueEntry, const csmFloat32 userTimeSeconds, const csmFloat32 time);
+
     void Parse(const csmByte* motionJson, const csmSizeInt size);
 
     csmFloat32      _sourceFrameRate;
     csmFloat32      _loopDurationSeconds;
-    csmBool         _isLoop;
-    csmBool         _isLoopFadeIn;
+    MotionBehavior  _motionBehavior;
     csmFloat32      _lastWeight;
 
     CubismMotionData*    _motionData;


### PR DESCRIPTION
### Added

* Add new motion loop processing that seamlessly connects the start and end points of the loop.
  * The `_isLoop` variable was moved from class `CubismMotion` to class `ACubismMotion`.
  * Add the setter for `_isLoop`, `SetLoop(csmBool loop)`, to class `ACubismMotion`.
  * Add the getter for `_isLoop`, `GetLoop()`, to class `ACubismMotion`.
  * The `_isLoopFadeIn` variable was moved from class `CubismMotion` to class `ACubismMotion`.
  * Add the setter for `_isLoopFadeIn`, `SetLoopFadeIn(csmBool loopFadeIn)`, to class `ACubismMotion`.
  * Add the getter for `_isLoopFadeIn`, `GetLoopFadeIn()`, to class `ACubismMotion`.
  * Add a variable `_motionBehavior` for version control to the `CubismMotion` class.

### Deprecated

* Deprecate the following elements due to the change in the variable declaration location.
  * `CubismMotion::IsLoop(csmBool loop)`
  * `CubismMotion::IsLoop()`
  * `CubismMotion::IsLoopFadeIn(csmBool loopFadeIn)`
  * `CubismMotion::IsLoopFadeIn()`