### PR TITLE
Update to Cubism 5 SDK for Native R4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,8 @@ trim_trailing_whitespace = true
 indent_size = 4
 charset = utf-8-bom
 
+[*.{frag,vert}]
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.4] - 2025-05-29
+
+### Added
+
+* Add parameter repeat processing that connects the right and left ends of the parameter to create a loop, allowing the motion to repeat.
+  * Add the variable `_isOverriddenParameterRepeat` to the `CubismModel` class for managing parameter repeat flags at the model level.
+  * Add the variable `_userParameterRepeatDataList` to the `CubismModel` class for managing parameter repeat flags for each parameter.
+* Add a flag to the arguments of the following methods to enable the function that verifies the consistency of `motion3.json`:
+  * `CubismUserModel.LoadMotion()`
+  * `CubismMotion.Create()`
+  * `CubismMotion.Parse()`
+* Add a `GetPartParentPartIndices()` function.
+
+### Changed
+
+* Change shader code to be used separately.
+
+### Removed
+
+* Remove the usage of `_DEBUG`.
+
+
 ## [5-r.3] - 2025-02-18
 
 ### Added
@@ -41,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+* Change an expression "overwrite" to "override" for multiply color, screen color, and culling to adapt the actual behavior.
 * Change to permit to overwrite motion fade by the value specified in .model3.json on `CubismUserModel::LoadMotion()`.
 * Change the threshold for enabling anisotropic filtering in all renderers.
 * Change `CubismJson` to not use character masking.
@@ -447,6 +470,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[5-r.4]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.3...5-r.4
 [5-r.3]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.1-beta.4...5-r.1

--- a/src/CubismFramework.cpp
+++ b/src/CubismFramework.cpp
@@ -213,6 +213,16 @@ CubismFramework::Option::LogLevel CubismFramework::GetLoggingLevel()
     return Option::LogLevel_Off;
 }
 
+csmLoadFileFunction CubismFramework::GetLoadFileFunction()
+{
+    return s_option->LoadFileFunction;
+}
+
+csmReleaseBytesFunction CubismFramework::GetReleaseBytesFunction()
+{
+    return s_option->ReleaseBytesFunction;
+}
+
 CubismIdManager* CubismFramework::GetIdManager()
 {
     return s_cubismIdManager;

--- a/src/CubismFramework.hpp
+++ b/src/CubismFramework.hpp
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #endif
 
+#include <string>
 
 //========================================================
 //  Configurations of Memory Allocator.
@@ -175,6 +176,10 @@ namespace Csm = Live2D::Cubism::Framework;
 //--------- LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework {
 
+/** Typedef for file loader */
+typedef csmByte* (*csmLoadFileFunction)(const std::string filePath, csmSizeInt* outSize);
+typedef void (*csmReleaseBytesFunction)(Csm::csmByte* byteData);
+
 /**
  * Constants.
  */
@@ -235,6 +240,12 @@ public:
 
         /** Logging level */
         LogLevel LoggingLevel;
+
+        /** File reading function */
+       csmLoadFileFunction LoadFileFunction;
+
+       /** Release bytes function */
+       csmReleaseBytesFunction ReleaseBytesFunction;
     };
 
     /**
@@ -303,6 +314,22 @@ public:
      * @return Logging level setting
      */
     static Option::LogLevel GetLoggingLevel();
+
+    /**
+     * Returns the loading file function.
+     *
+     * @return Function to read the file as csmByte*.
+     */
+    static csmLoadFileFunction GetLoadFileFunction();
+
+    /**
+     * Returns the memory release function.
+     *
+     * @return Function to free memory allocated by csmByte*.
+     *
+     * @note Memory allocated by GetLoadFileFunction() must be released with this function.
+     */
+    static csmReleaseBytesFunction GetReleaseBytesFunction();
 
     /**
      * Returns the instance of CubismIdManager.

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -33,17 +33,17 @@ public:
          * Constructor
          */
         DrawableColorData()
-            : IsOverwritten(false)
+            : IsOverridden(false)
             , Color() {};
 
         /**
          * Constructor
          *
-         * @param isOverwritten whether to be overwritten
+         * @param isOverridden whether to be overridden
          * @param color Texture color
          */
-        DrawableColorData(csmBool isOverwritten, Rendering::CubismRenderer::CubismTextureColor color)
-            : IsOverwritten(isOverwritten)
+        DrawableColorData(csmBool isOverridden, Rendering::CubismRenderer::CubismTextureColor color)
+            : IsOverridden(isOverridden)
             , Color(color) {};
 
         /**
@@ -51,7 +51,8 @@ public:
          */
         virtual ~DrawableColorData() {};
 
-        csmBool IsOverwritten;                                      ///< Whether to be overwritten
+        csmBool IsOverwritten;                                     ///< (deprecated) Whether to be overwritten
+        csmBool IsOverridden;                                      ///< Whether to be overridden
         Rendering::CubismRenderer::CubismTextureColor Color;        ///< Color
 
     };
@@ -65,17 +66,17 @@ public:
          * Constructor
          */
         DrawableCullingData()
-            : IsOverwritten(false)
+            : IsOverridden(false)
             , IsCulling(0) {};
 
         /**
          * Constructor
          *
-         * @param isOverwritten whether to be overwritten
+         * @param isOverridden whether to be overridden
          * @param isCulling Culling information
          */
-        DrawableCullingData(csmBool isOverwritten, csmInt32 isCulling)
-            : IsOverwritten(isOverwritten)
+        DrawableCullingData(csmBool isOverridden, csmInt32 isCulling)
+            : IsOverridden(isOverridden)
             , IsCulling(isCulling) {};
 
         /**
@@ -83,7 +84,8 @@ public:
          */
         virtual ~DrawableCullingData() {};
 
-        csmBool IsOverwritten;      ///< Whether to be overwritten
+        csmBool IsOverwritten;      ///< (deprecated) Whether to be overwritten
+        csmBool IsOverridden;      ///< Whether to be overridden
         csmInt32 IsCulling;         ///< Culling information
 
     };
@@ -97,17 +99,17 @@ public:
          * Constructor
          */
         PartColorData()
-            : IsOverwritten(false)
+            : IsOverridden(false)
             , Color() {};
 
         /**
          * Constructor
          *
-         * @param isOverwritten whether to be overwritten
+         * @param isOverridden whether to be overridden
          * @param color Texture color
          */
-        PartColorData(csmBool isOverwritten, Rendering::CubismRenderer::CubismTextureColor color)
-            : IsOverwritten(isOverwritten)
+        PartColorData(csmBool isOverridden, Rendering::CubismRenderer::CubismTextureColor color)
+            : IsOverridden(isOverridden)
             , Color(color) {};
 
         /**
@@ -115,8 +117,40 @@ public:
          */
         virtual ~PartColorData() {};
 
-        csmBool IsOverwritten;                                      ///< Whether to be overwritten
+        csmBool IsOverwritten;                                     ///< (deprecated) Whether to be overwritten
+        csmBool IsOverridden;                                      ///< Whether to be overridden
         Rendering::CubismRenderer::CubismTextureColor Color;        ///< Color
+    };
+
+    /**
+     * Structure for managing the override of parameter repetition settings
+     */
+    struct ParameterRepeatData
+    {
+        /**
+         * Constructor
+         */
+        ParameterRepeatData()
+            : IsOverridden(false)
+            , IsParameterRepeated(false) {}
+
+        /**
+         * Constructor
+         *
+         * @param isOverridden whether to be overriden
+         * @param isParameterRepeated override flag for settings
+         */
+        ParameterRepeatData(csmBool isOverridden, csmBool isParameterRepeated)
+            : IsOverridden(isOverridden)
+            , IsParameterRepeated(isParameterRepeated) {}
+
+        /**
+         * Destructor
+         */
+        virtual ~ParameterRepeatData() {}
+
+        csmBool IsOverridden;            ///< Whether to be overridden
+        csmBool IsParameterRepeated;     ///< Override flag for settings
     };
 
     /**
@@ -182,6 +216,13 @@ public:
      * @return Number of parts
      */
     csmInt32    GetPartCount() const;
+
+    /**
+     * Returns the index of the parent parts for the parts.
+     *
+     * @return Index of parent parts for the parts.
+     */
+    const csmInt32* GetPartParentPartIndices() const;
 
     /**
      * Sets the opacity of the part.
@@ -314,6 +355,44 @@ public:
      * @param weight Weight
      */
     void        SetParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
+
+    /**
+     * Gets whether the parameter has the repeat setting.
+     *
+     * @param parameterIndex Parameter index
+     *
+     * @return true if it is set, otherwise returns false.
+     */
+    csmBool IsRepeat(csmInt32 parameterIndex) const;
+
+    /**
+     * Returns the calculated result ensuring the value falls within the parameter's range.
+     *
+     * @param parameterIndex Parameter index
+     * @param value Parameter value
+     *
+     * @return a value that falls within the parameter’s range. If the parameter does not exist, returns it as is.
+     */
+    csmFloat32 GetParameterRepeatValue(csmInt32 parameterIndex, csmFloat32 value) const;
+
+    /**
+     * Returns the result of clamping the value to ensure it falls within the parameter's range.
+     *
+     * @param parameterIndex Parameter index
+     * @param value Parameter value
+     *
+     * @return the clamped value. If the parameter does not exist, returns it as is.
+     */
+    csmFloat32 GetParameterClampValue(csmInt32 parameterIndex, csmFloat32 value) const;
+
+    /**
+     * Returns the repeat of the parameter.
+     *
+     * @param parameterIndex Parameter index
+     *
+     * @return the raw data parameter repeat from the Cubism Core.
+     */
+    csmBool GetParameterRepeats(csmUint32 parameterIndex) const;
 
     /**
      * Adds to the value of the parameter.
@@ -696,35 +775,120 @@ public:
     void SetPartScreenColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
 
     /**
+     * Checks whether parameter repetition is performed for the entire model.
+     *
+     * @return true if parameter repetition is performed for the entire model; otherwise returns false.
+     */
+    csmBool GetOverrideFlagForModelParameterRepeat() const;
+
+    /**
+     * Sets whether parameter repetition is performed for the entire model.
+     * Use true to perform parameter repetition for the entire model, or false to not perform it.
+     */
+    void SetOverrideFlagForModelParameterRepeat(csmBool isRepeat);
+
+    /**
+     * Returns the flag indicating whether to override the parameter repeat.
+     *
+     * @param parameterIndex Parameter index
+     *
+     * @return true if the parameter repeat is overridden, false otherwise.
+     */
+    csmBool GetOverrideFlagForParameterRepeat(csmInt32 parameterIndex) const;
+
+    /**
+     * Sets the flag indicating whether to override the parameter repeat.
+     *
+     * @param parameterIndex Parameter index
+     * @param value true if it is to be overridden; otherwise, false.
+     */
+    void SetOverrideFlagForParameterRepeat(csmInt32 parameterIndex, csmBool value);
+
+    /**
+     * Returns the repeat flag.
+     *
+     * @param parameterIndex Parameter index
+     *
+     * @return true if repeating, false otherwise.
+     */
+    csmBool GetRepeatFlagForParameterRepeat(csmInt32 parameterIndex) const;
+
+    /**
+     * Sets the repeat flag.
+     *
+     * @param parameterIndex Parameter index
+     * @param value true to enable repeating, false otherwise.
+     */
+    void SetRepeatFlagForParameterRepeat(csmInt32 parameterIndex, csmBool value);
+
+    /**
      * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForModelMultiplyColors instead.
      *
      * @return true if the color set at runtime is used; otherwise false.
      */
     csmBool GetOverwriteFlagForModelMultiplyColors() const;
 
     /**
+     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetOverrideFlagForModelMultiplyColors() const;
+
+    /**
      * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForModelScreenColors instead.
      *
      * @return true if the color set at runtime is used; otherwise false.
      */
     csmBool GetOverwriteFlagForModelScreenColors() const;
 
     /**
+     * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetOverrideFlagForModelScreenColors() const;
+
+    /**
      * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForModelMultiplyColors instead.
      *
      * @param value true if the color set at runtime is to be used; otherwise false.
      */
     void SetOverwriteFlagForModelMultiplyColors(csmBool value);
 
     /**
+     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetOverrideFlagForModelMultiplyColors(csmBool value);
+
+    /**
      * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForModelScreenColors instead.
      *
      * @param value true if the color set at runtime is to be used; otherwise false.
      */
     void SetOverwriteFlagForModelScreenColors(csmBool value);
 
     /**
+     * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetOverrideFlagForModelScreenColors(csmBool value);
+
+    /**
      * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForDrawableMultiplyColors instead.
      *
      * @param drawableIndex Drawable index
      *
@@ -733,7 +897,18 @@ public:
     csmBool GetOverwriteFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const;
 
     /**
+     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetOverrideFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const;
+
+    /**
      * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForDrawableScreenColors instead.
      *
      * @param drawableIndex Drawable index
      *
@@ -742,7 +917,18 @@ public:
     csmBool GetOverwriteFlagForDrawableScreenColors(csmInt32 drawableIndex) const;
 
     /**
+     * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetOverrideFlagForDrawableScreenColors(csmInt32 drawableIndex) const;
+
+    /**
      * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForDrawableMultiplyColors instead.
      *
      * @param drawableIndex Drawable index
      * @param value true if the color set at runtime is to be used; otherwise false.
@@ -750,7 +936,17 @@ public:
     void SetOverwriteFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value);
 
     /**
+     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetOverrideFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value);
+
+    /**
      * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForDrawableScreenColors instead.
      *
      * @param drawableIndex Drawable index
      * @param value true if the color set at runtime is to be used; otherwise false.
@@ -758,30 +954,72 @@ public:
     void SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
 
     /**
+     * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetOverrideFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
+
+    /**
      * Checks whether the part multiply color is overridden by the SDK.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideColorForPartMultiplyColors instead.
      *
      * @return true if the color information from the SDK is used; otherwise false.
      */
     csmBool GetOverwriteColorForPartMultiplyColors(csmInt32 partIndex) const;
 
     /**
+     * Checks whether the part multiply color is overridden by the SDK.
+     *
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    csmBool GetOverrideColorForPartMultiplyColors(csmInt32 partIndex) const;
+
+    /**
      * Checks whether the part screen color is overridden by the SDK.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideColorForPartScreenColors instead.
      *
      * @return true if the color information from the SDK is used; otherwise false.
      */
     csmBool GetOverwriteColorForPartScreenColors(csmInt32 partIndex) const;
 
     /**
+     * Checks whether the part screen color is overridden by the SDK.
+     *
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    csmBool GetOverrideColorForPartScreenColors(csmInt32 partIndex) const;
+
+    /**
+     * Sets whether the part multiply color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideColorForPartMultiplyColors instead.
+     */
+    void SetOverwriteColorForPartMultiplyColors(csmUint32 partIndex, csmBool value);
+
+    /**
      * Sets whether the part multiply color is overridden by the SDK.
      * Use true to use the color information from the SDK, or false to use the color information from the model.
      */
-    void SetOverwriteColorForPartMultiplyColors(csmUint32 partIndex, csmBool value);
+    void SetOverrideColorForPartMultiplyColors(csmUint32 partIndex, csmBool value);
+
+    /**
+     * Sets whether the part screen color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideColorForPartScreenColors instead.
+     */
+    void SetOverwriteColorForPartScreenColors(csmUint32 partIndex, csmBool value);
 
     /**
      * Sets whether the part screen color is overridden by the SDK.
      * Use true to use the color information from the SDK, or false to use the color information from the model.
      */
-    void SetOverwriteColorForPartScreenColors(csmUint32 partIndex, csmBool value);
+    void SetOverrideColorForPartScreenColors(csmUint32 partIndex, csmBool value);
 
     /**
      * Returns the culling information of the drawable.
@@ -800,28 +1038,62 @@ public:
     /**
      * Checks whether the culling settings for the entire model are overridden by the SDK.
      *
+     * @deprecated This function is deprecated due to a naming change, use GetOverwriteFlagForModelCullings instead.
+     *
      * @return true if the culling settings from the SDK are used; otherwise false.
      */
     csmBool GetOverwriteFlagForModelCullings() const;
 
     /**
+     * Checks whether the culling settings for the entire model are overridden by the SDK.
+     *
+     * @return true if the culling settings from the SDK are used; otherwise false.
+     */
+    csmBool GetOverrideFlagForModelCullings() const;
+
+    /**
      * Sets whether the culling settings for the entire model are overridden by the SDK.
      * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForModelCullings instead.
      */
     void SetOverwriteFlagForModelCullings(csmBool value);
 
     /**
+     * Sets whether the culling settings for the entire model are overridden by the SDK.
+     * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
+     */
+    void SetOverrideFlagForModelCullings(csmBool value);
+
+    /**
      * Checks whether the culling settings for the drawable are overridden by the SDK.
+     *
+     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForDrawableCullings instead.
      *
      * @return true if the culling settings from the SDK are used; otherwise false.
      */
     csmBool GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex) const;
 
     /**
+     * Checks whether the culling settings for the drawable are overridden by the SDK.
+     *
+     * @return true if the culling settings from the SDK are used; otherwise false.
+     */
+    csmBool GetOverrideFlagForDrawableCullings(csmInt32 drawableIndex) const;
+
+    /**
+     * Sets whether the culling settings for the drawable are overridden by the SDK.
+     * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
+     *
+     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForDrawableCullings instead.
+     */
+    void SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value);
+
+    /**
      * Sets whether the culling settings for the drawable are overridden by the SDK.
      * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
      */
-    void SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value);
+    void SetOverrideFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value);
 
     /**
      * Returns the opacity of the model.
@@ -855,7 +1127,7 @@ private:
         csmVector<PartColorData>& partColors,
         csmVector <DrawableColorData>& drawableColors);
 
-    void SetOverwriteColorForPartColors(
+    void SetOverrideColorForPartColors(
         csmUint32 partIndex,
         csmBool value,
         csmVector<CubismModel::PartColorData>& partColors,
@@ -882,15 +1154,17 @@ private:
     csmVector<CubismIdHandle> _parameterIds;
     csmVector<CubismIdHandle> _partIds;
     csmVector<CubismIdHandle> _drawableIds;
+    csmVector<ParameterRepeatData> _userParameterRepeatDataList;
     csmVector<DrawableColorData> _userScreenColors;
     csmVector<DrawableColorData> _userMultiplyColors;
     csmVector<DrawableCullingData> _userCullings;
     csmVector<PartColorData> _userPartScreenColors;
     csmVector<PartColorData> _userPartMultiplyColors;
     csmVector<csmVector<csmUint32> > _partChildDrawables;
-    csmBool _isOverwrittenModelMultiplyColors;
-    csmBool _isOverwrittenModelScreenColors;
-    csmBool _isOverwrittenCullings;
+    csmBool _isOverriddenParameterRepeat;
+    csmBool _isOverriddenModelMultiplyColors;
+    csmBool _isOverriddenModelScreenColors;
+    csmBool _isOverriddenCullings;
 };
 
 }}}

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -34,6 +34,7 @@ CubismUserModel::CubismUserModel()
     , _accelerationY(0.0f)
     , _accelerationZ(0.0f)
     , _mocConsistency(false)
+    , _motionConsistency(false)
     , _debugMode(false)
     , _renderer(NULL)
 {
@@ -190,7 +191,7 @@ csmBool CubismUserModel::IsHit(CubismIdHandle drawableId, csmFloat32 pointX, csm
 
 ACubismMotion* CubismUserModel::LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name,
                                             ACubismMotion::FinishedMotionCallback onFinishedMotionHandler, ACubismMotion::BeganMotionCallback onBeganMotionHandler,
-                                            ICubismModelSetting* modelSetting, const csmChar* group, const csmInt32 index)
+                                            ICubismModelSetting* modelSetting, const csmChar* group, const csmInt32 index, csmBool shouldCheckMotionConsistency)
 {
     if (!buffer)
     {
@@ -198,7 +199,7 @@ ACubismMotion* CubismUserModel::LoadMotion(const csmByte* buffer, csmSizeInt siz
         return NULL;
     }
 
-    ACubismMotion* motion = CubismMotion::Create(buffer, size, onFinishedMotionHandler, onBeganMotionHandler);
+    ACubismMotion* motion = CubismMotion::Create(buffer, size, onFinishedMotionHandler, onBeganMotionHandler, shouldCheckMotionConsistency);
 
     if (!motion)
     {

--- a/src/Model/CubismUserModel.hpp
+++ b/src/Model/CubismUserModel.hpp
@@ -129,7 +129,7 @@ public:
      */
     virtual ACubismMotion*  LoadMotion(const csmByte* buffer, csmSizeInt size, const csmChar* name,
                                        ACubismMotion::FinishedMotionCallback onFinishedMotionHandler = NULL, ACubismMotion::BeganMotionCallback onBeganMotionHandler = NULL,
-                                       ICubismModelSetting* modelSetting = NULL, const csmChar* group = NULL, const csmInt32 index = -1);
+                                       ICubismModelSetting* modelSetting = NULL, const csmChar* group = NULL, const csmInt32 index = -1, csmBool shouldCheckMotionConsistency = false);
 
     /**
      * Loads expression from an expression configuration file.
@@ -246,6 +246,7 @@ protected:
     csmFloat32  _accelerationY;
     csmFloat32  _accelerationZ;
     csmBool     _mocConsistency;
+    csmBool     _motionConsistency;
     csmBool     _debugMode;
 
 private:

--- a/src/Motion/CubismExpressionMotion.cpp
+++ b/src/Motion/CubismExpressionMotion.cpp
@@ -182,9 +182,7 @@ csmVector<CubismExpressionMotion::ExpressionParameter> CubismExpressionMotion::G
 
 csmFloat32 CubismExpressionMotion::GetFadeWeight()
 {
-#if _DEBUG
     CubismLogWarning("GetFadeWeight() is a deprecated function. Please use CubismExpressionMotionManager.GetFadeWeight(int index).");
-#endif // _DEBUG
 
     return _fadeWeight;
 }

--- a/src/Motion/CubismExpressionMotionManager.cpp
+++ b/src/Motion/CubismExpressionMotionManager.cpp
@@ -39,33 +39,25 @@ CubismExpressionMotionManager::~CubismExpressionMotionManager()
 
 csmInt32 CubismExpressionMotionManager::GetCurrentPriority() const
 {
-#if _DEBUG
     CubismLogWarning("CubismExpressionMotionManager::GetCurrentPriority() is deprecated because a priority value is not actually used during expression motion playback.");
-#endif
     return _currentPriority;
 }
 
 csmInt32 CubismExpressionMotionManager::GetReservePriority() const
 {
-#if _DEBUG
     CubismLogWarning("CubismExpressionMotionManager::GetReservePriority() is deprecated because a priority value is not actually used during expression motion playback.");
-#endif
     return _reservePriority;
 }
 
 void CubismExpressionMotionManager::SetReservePriority(csmInt32 priority)
 {
-#if _DEBUG
     CubismLogWarning("CubismExpressionMotionManager::SetReservePriority() is deprecated because a priority value is not actually used during expression motion playback.");
-#endif
     _reservePriority = priority;
 }
 
 CubismMotionQueueEntryHandle CubismExpressionMotionManager::StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority)
 {
-#if _DEBUG
     CubismLogWarning("CubismExpressionMotionManager::StartMotionPriority() is deprecated because a priority value is not actually used during expression motion playback.");
-#endif
 
     if (priority == _reservePriority)
     {

--- a/src/Motion/CubismMotion.hpp
+++ b/src/Motion/CubismMotion.hpp
@@ -39,10 +39,12 @@ public:
      * @param buf buffer containing the loaded motion file
      * @param size size of the buffer in bytes
      * @param onFinishedMotionHandler callback function for when motion playback ends
+     * @param onBeganMotionHandler callback function for when motion playback starts
+     * @param shouldCheckMotionConsistency flag to validate the consistency of motion3.json
      *
      * @return created instance
      */
-    static CubismMotion* Create(const csmByte* buffer, csmSizeInt size, FinishedMotionCallback onFinishedMotionHandler = NULL, BeganMotionCallback onBeganMotionHandler = NULL);
+    static CubismMotion* Create(const csmByte* buffer, csmSizeInt size, FinishedMotionCallback onFinishedMotionHandler = NULL, BeganMotionCallback onBeganMotionHandler = NULL, csmBool shouldCheckMotionConsistency = false);
 
     /**
      * Updates the model parameters.
@@ -215,7 +217,7 @@ private:
 
     void UpdateForNextLoop(CubismMotionQueueEntry* motionQueueEntry, const csmFloat32 userTimeSeconds, const csmFloat32 time);
 
-    void Parse(const csmByte* motionJson, const csmSizeInt size);
+    void Parse(const csmByte* motionJson, const csmSizeInt size, csmBool shouldCheckMotionConsistency);
 
     csmFloat32      _sourceFrameRate;
     csmFloat32      _loopDurationSeconds;

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -63,9 +63,7 @@ CubismMotionQueueEntryHandle CubismMotionQueueManager::StartMotion(ACubismMotion
 
 CubismMotionQueueEntryHandle CubismMotionQueueManager::StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds)
 {
-#if _DEBUG
     CubismLogWarning("StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds) is a deprecated function. Please use StartMotion(ACubismMotion* motion, csmBool autoDelete).");
-#endif
 
     if (motion == NULL)
     {

--- a/src/Rendering/D3D11/CubismShader_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismShader_D3D11.cpp
@@ -13,136 +13,11 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-static const csmChar* CubismShaderEffectSrc =
-    "cbuffer ConstantBuffer {"\
-        "float4x4 projectMatrix;"\
-        "float4x4 clipMatrix;"\
-        "float4 baseColor;"\
-        "float4 multiplyColor;"\
-        "float4 screenColor;"\
-        "float4 channelFlag;"\
-    "}"\
-    "Texture2D mainTexture : register(t0);"\
-    "SamplerState mainSampler : register(s0);"\
-    "Texture2D maskTexture : register(t1);"\
-    \
-    "struct VS_IN {"\
-        "float2 pos : POSITION;"\
-        "float2 uv : TEXCOORD0;"\
-    "};"\
-    "struct VS_OUT {"\
-        "float4 Position : SV_POSITION;"\
-        "float2 uv : TEXCOORD0;"\
-        "float4 clipPosition : TEXCOORD1;"\
-    "};"\
-    \
-"/* Setup mask shader */"\
-    "VS_OUT VertSetupMask(VS_IN In) {"\
-        "VS_OUT Out = (VS_OUT)0;"\
-        "Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.uv.x = In.uv.x;"\
-        "Out.uv.y = 1.0f - +In.uv.y;"\
-        "return Out;"\
-    "}"\
-    "float4 PixelSetupMask(VS_OUT In) : SV_Target{"\
-        "float isInside ="\
-        "step(baseColor.x, In.clipPosition.x / In.clipPosition.w)"\
-        "* step(baseColor.y, In.clipPosition.y / In.clipPosition.w)"\
-        "* step(In.clipPosition.x / In.clipPosition.w, baseColor.z)"\
-        "* step(In.clipPosition.y / In.clipPosition.w, baseColor.w);"\
-        "return channelFlag * mainTexture.Sample(mainSampler, In.uv).a * isInside;"\
-    "}"\
-    \
-"/* Vertex Shader */"\
-    "/* normal */"\
-    "VS_OUT VertNormal(VS_IN In) {"\
-        "VS_OUT Out = (VS_OUT)0;"\
-        "Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.uv.x = In.uv.x;"\
-        "Out.uv.y = 1.0f - +In.uv.y;"\
-        "return Out;"\
-    "}"\
-    "/* masked */"\
-    "VS_OUT VertMasked(VS_IN In) {"\
-        "VS_OUT Out = (VS_OUT)0;"\
-        "Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), clipMatrix);"\
-        "Out.uv.x = In.uv.x;"\
-        "Out.uv.y = 1.0f - In.uv.y;"\
-        "return Out;"\
-    "}"\
-    \
-"/* Pixel Shader */"\
-    "/* normal */"\
-    "float4 PixelNormal(VS_OUT In) : SV_Target{"\
-        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "color.xyz *= color.w;"\
-        "return color;"\
-    "}"\
-    \
-    "/* normal premult alpha */"\
-    "float4 PixelNormalPremult(VS_OUT In) : SV_Target{"\
-        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "return color;"\
-    "}"\
-    \
-    "/* masked */\n"\
-    "float4 PixelMasked(VS_OUT In) : SV_Target{\n"\
-        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "color.xyz *= color.w;\n"\
-        "float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
-        "color = color * maskVal;\n"\
-        "return color;\n"\
-    "}"\
-    "/* masked inverted*/\n"\
-    "float4 PixelMaskedInverted(VS_OUT In) : SV_Target{\n"\
-        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "color.xyz *= color.w;\n"\
-        "float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
-        "color = color * (1.0f - maskVal);\n"\
-        "return color;\n"\
-    "}"\
-    "/* masked premult alpha */\n"\
-    "float4 PixelMaskedPremult(VS_OUT In) : SV_Target{\n"\
-        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;\n"\
-        "float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
-        "color = color * maskVal;\n"\
-        "return color;\n"\
-    "}"\
-    "/* masked inverted premult alpha */\n"\
-    "float4 PixelMaskedInvertedPremult(VS_OUT In) : SV_Target{\n"\
-        "float4 texColor = mainTexture.Sample(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;\n"\
-        "float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;\n"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;\n"\
-        "color = color * (1.0f - maskVal);\n"\
-        "return color;\n"\
-    "}\n";
-
-
 void CubismShader_D3D11::ReleaseShaderProgram()
 {
+    // シェーダーソースコード開放
+    _shaderSrc.Clear();
+
     // 頂点レイアウト開放
     if (_vertexFormat)
     {
@@ -201,6 +76,36 @@ void CubismShader_D3D11::GenerateShaders(ID3D11Device* device)
     csmBool isSuccess = false;
     do
     {
+        // シェーダーソースコードが記述されているファイルを読み込み
+        const csmChar* frameworkShaderPath = "FrameworkShaders/CubismEffect.fx";
+        csmLoadFileFunction fileLoader = Csm::CubismFramework::GetLoadFileFunction();
+        csmReleaseBytesFunction bytesReleaser = Csm::CubismFramework::GetReleaseBytesFunction();
+
+        if (!fileLoader)
+        {
+            CubismLogError("File loader is not set.");
+            break;
+        }
+
+        if (!bytesReleaser)
+        {
+            CubismLogError("Byte releaser is not set.");
+            break;
+        }
+
+        csmSizeInt shaderSize;
+        csmByte* shaderSrc = fileLoader(frameworkShaderPath, &shaderSize);
+        csmString shaderString = csmString(reinterpret_cast<const csmChar*>(shaderSrc), shaderSize);
+
+        _shaderSrc.Clear();
+        for (csmInt32 i = 0; i < shaderString.GetLength(); i++)
+        {
+            _shaderSrc.PushBack(shaderString.GetRawString()[i]);
+        }
+
+        // ファイル読み込みで確保したバイト列を開放
+        bytesReleaser(shaderSrc);
+
         // マスク
         if(!LoadShaderProgram(device, false, ShaderNames_SetupMask, static_cast<const csmChar*>("VertSetupMask")))
         {
@@ -270,8 +175,8 @@ void CubismShader_D3D11::GenerateShaders(ID3D11Device* device)
     ID3DBlob* layoutError = NULL;
     ID3DBlob* layoutBlobr = NULL;
     HRESULT hr = D3DCompile(
-        CubismShaderEffectSrc,              // メモリー内のシェーダーへのポインターです。
-        strlen(CubismShaderEffectSrc),      // メモリー内のシェーダーのサイズです。
+        _shaderSrc.GetPtr(),                // メモリー内のシェーダーへのポインターです。
+        _shaderSrc.GetSize(),               // メモリー内のシェーダーのサイズです。
         NULL,                               // シェーダー コードが格納されているファイルの名前です。
         NULL,                               // マクロ定義の配列へのポインターです
         NULL,                               // インクルード ファイルを扱うインターフェイスへのポインターです
@@ -333,8 +238,8 @@ Csm::csmBool CubismShader_D3D11::LoadShaderProgram(ID3D11Device* device, bool is
 #endif
 
         hr = D3DCompile(
-            CubismShaderEffectSrc,              // メモリー内のシェーダーへのポインターです。
-            strlen(CubismShaderEffectSrc),      // メモリー内のシェーダーのサイズです。
+            _shaderSrc.GetPtr(),                // メモリー内のシェーダーへのポインターです。
+            _shaderSrc.GetSize(),               // メモリー内のシェーダーのサイズです。
             NULL,                               // シェーダー コードが格納されているファイルの名前です。
             NULL,                               // マクロ定義の配列へのポインターです
             NULL,                               // インクルード ファイルを扱うインターフェイスへのポインターです

--- a/src/Rendering/D3D11/CubismShader_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismShader_D3D11.hpp
@@ -130,6 +130,7 @@ private:
      */
     Csm::csmBool LoadShaderProgram(ID3D11Device* device, bool isPs, csmInt32 assign, const csmChar* entryPoint);
 
+    csmVector<csmChar> _shaderSrc; ///< シェーダーソースコード
     csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
 
     csmVector<ID3D11VertexShader*> _shaderSetsVS;     ///< ロードしたシェーダプログラムを保持する変数(VS)

--- a/src/Rendering/D3D11/Shaders/CubismEffect.fx
+++ b/src/Rendering/D3D11/Shaders/CubismEffect.fx
@@ -1,0 +1,135 @@
+cbuffer ConstantBuffer {
+    float4x4 projectMatrix;
+    float4x4 clipMatrix;
+    float4 baseColor;
+    float4 multiplyColor;
+    float4 screenColor;
+    float4 channelFlag;
+}
+
+Texture2D mainTexture : register(t0);
+SamplerState mainSampler : register(s0);
+Texture2D maskTexture : register(t1);
+
+// Vertex shader input
+struct VS_IN {
+    float2 pos : POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+// Vertex shader output
+struct VS_OUT {
+    float4 Position : SV_POSITION;
+    float2 uv : TEXCOORD0;
+    float4 clipPosition : TEXCOORD1;
+};
+
+
+// Mask shader
+VS_OUT VertSetupMask(VS_IN In) {
+    VS_OUT Out = (VS_OUT)0;
+    Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.uv.x = In.uv.x;
+    Out.uv.y = 1.0f - +In.uv.y;
+    return Out;
+}
+
+float4 PixelSetupMask(VS_OUT In) : SV_Target{
+    float isInside =
+    step(baseColor.x, In.clipPosition.x / In.clipPosition.w)
+    * step(baseColor.y, In.clipPosition.y / In.clipPosition.w)
+    * step(In.clipPosition.x / In.clipPosition.w, baseColor.z)
+    * step(In.clipPosition.y / In.clipPosition.w, baseColor.w);
+    return channelFlag * mainTexture.Sample(mainSampler, In.uv).a * isInside;
+}
+
+// Vertex shader
+// normal
+VS_OUT VertNormal(VS_IN In) {
+    VS_OUT Out = (VS_OUT)0;
+    Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.uv.x = In.uv.x;
+    Out.uv.y = 1.0f - +In.uv.y;
+    return Out;
+}
+
+// masked
+VS_OUT VertMasked(VS_IN In) {
+    VS_OUT Out = (VS_OUT)0;
+    Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), clipMatrix);
+    Out.uv.x = In.uv.x;
+    Out.uv.y = 1.0f - In.uv.y;
+    return Out;
+}
+
+// Pixel Shader
+// normal
+float4 PixelNormal(VS_OUT In) : SV_Target{
+    float4 texColor = mainTexture.Sample(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    color.xyz *= color.w;
+    return color;
+}
+
+// normal premult alpha
+float4 PixelNormalPremult(VS_OUT In) : SV_Target{
+    float4 texColor = mainTexture.Sample(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    return color;
+}
+
+// masked
+float4 PixelMasked(VS_OUT In) : SV_Target{
+    float4 texColor = mainTexture.Sample(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    color.xyz *= color.w;
+    float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * maskVal;
+    return color;
+}
+
+// masked inverted
+float4 PixelMaskedInverted(VS_OUT In) : SV_Target{
+    float4 texColor = mainTexture.Sample(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    color.xyz *= color.w;
+    float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * (1.0f - maskVal);
+    return color;
+}
+
+// masked premult alpha
+float4 PixelMaskedPremult(VS_OUT In) : SV_Target{
+    float4 texColor = mainTexture.Sample(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * maskVal;
+    return color;
+}
+
+// masked inverted premult alpha
+float4 PixelMaskedInvertedPremult(VS_OUT In) : SV_Target{
+    float4 texColor = mainTexture.Sample(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * (1.0f - maskVal);
+    return color;
+}

--- a/src/Rendering/D3D9/CubismShader_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismShader_D3D9.cpp
@@ -12,190 +12,10 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-static const csmChar* CubismShaderEffectSrc =
-    "float4x4 projectMatrix;"\
-    "float4x4 clipMatrix;"\
-    "float4 baseColor;"\
-    "float4 multiplyColor;"\
-    "float4 screenColor;"\
-    "float4 channelFlag;"\
-    "texture mainTexture;"\
-    "texture maskTexture;"\
-    \
-    "sampler mainSampler = sampler_state{"\
-        "texture = <mainTexture>;"\
-    "};"\
-    "sampler maskSampler = sampler_state{"\
-        "texture = <maskTexture>;"\
-    "};"\
-    \
-    "struct VS_IN {"\
-        "float2 pos : POSITION;"\
-        "float2 uv : TEXCOORD0;"\
-    "};"\
-    "struct VS_OUT {"\
-        "float4 Position : POSITION0;"\
-        "float2 uv : TEXCOORD0;"\
-        "float4 clipPosition : TEXCOORD1;"\
-    "};"\
-    \
-"/* Setup mask shader */"\
-    "VS_OUT VertSetupMask(VS_IN In) {"\
-        "VS_OUT Out = (VS_OUT)0;"\
-        "Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.uv.x = In.uv.x;"\
-        "Out.uv.y = 1.0f - +In.uv.y;"\
-        "return Out;"\
-    "}"\
-    "float4 PixelSetupMask(VS_OUT In) : COLOR0{"\
-        "float isInside ="\
-        "step(baseColor.x, In.clipPosition.x / In.clipPosition.w)"\
-        "* step(baseColor.y, In.clipPosition.y / In.clipPosition.w)"\
-        "* step(In.clipPosition.x / In.clipPosition.w, baseColor.z)"\
-        "* step(In.clipPosition.y / In.clipPosition.w, baseColor.w);"\
-        "return channelFlag * tex2D(mainSampler, In.uv).a * isInside;"\
-    "}"\
-    \
-"/* Vertex Shader */"\
-    "/* normal */"\
-    "VS_OUT VertNormal(VS_IN In) {"\
-        "VS_OUT Out = (VS_OUT)0;"\
-        "Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.uv.x = In.uv.x;"\
-        "Out.uv.y = 1.0f - +In.uv.y;"\
-        "return Out;"\
-    "}"\
-    "/* masked */"\
-    "VS_OUT VertMasked(VS_IN In) {"\
-        "VS_OUT Out = (VS_OUT)0;"\
-        "Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);"\
-        "Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), clipMatrix);"\
-        "Out.uv.x = In.uv.x;"\
-        "Out.uv.y = 1.0f - In.uv.y;"\
-        "return Out;"\
-    "}"\
-    \
-"/* Pixel Shader */"\
-    "/* normal */"\
-    "float4 PixelNormal(VS_OUT In) : COLOR0{"\
-        "float4 texColor = tex2D(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "color.xyz *= color.w;"\
-        "return color;"\
-    "}"\
-    \
-    "/* normal premult alpha */"\
-    "float4 PixelNormalPremult(VS_OUT In) : COLOR0{"\
-        "float4 texColor = tex2D(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "return color;"\
-    "}"\
-    \
-    "/* masked */"\
-    "float4 PixelMasked(VS_OUT In) : COLOR0{"\
-        "float4 texColor = tex2D(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "color.xyz *= color.w;"\
-        "float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
-        "color = color * maskVal;"\
-        "return color;"\
-    "}"\
-    "/* masked inverted */"
-    "float4 PixelMaskedInverted(VS_OUT In) : COLOR0{"\
-        "float4 texColor = tex2D(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "color.xyz *= color.w;"\
-        "float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
-        "color = color * (1.0f - maskVal);"\
-        "return color;"\
-    "}"\
-    "/* masked premult alpha */"\
-    "float4 PixelMaskedPremult(VS_OUT In) : COLOR0{"\
-        "float4 texColor = tex2D(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
-        "color = color * maskVal;"\
-        "return color;"\
-    "}"\
-    "/* masked inverted premult alpha */"\
-    "float4 PixelMaskedInvertedPremult(VS_OUT In) : COLOR0{"\
-        "float4 texColor = tex2D(mainSampler, In.uv);"\
-        "texColor.rgb = texColor.rgb * multiplyColor.rgb;"\
-        "texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);"\
-        "float4 color = texColor * baseColor;"\
-        "float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;"\
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"\
-        "color = color * (1.0f - maskVal);"\
-        "return color;"\
-    "}"\
-    \
-"/* Technique */"\
-    "technique ShaderNames_SetupMask {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertSetupMask();"\
-            "PixelShader = compile ps_2_0 PixelSetupMask();"\
-        "}"\
-    "}"\
-    \
-    "technique ShaderNames_Normal {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertNormal();"\
-            "PixelShader = compile ps_2_0 PixelNormal();"\
-        "}"\
-    "}"\
-    \
-    "technique ShaderNames_NormalMasked {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertMasked();"\
-            "PixelShader = compile ps_2_0 PixelMasked();"\
-        "}"\
-    "}"\
-    \
-    "technique ShaderNames_NormalMaskedInverted {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertMasked();"\
-            "PixelShader = compile ps_2_0 PixelMaskedInverted();"\
-        "}"\
-    "}"\
-    \
-    "technique ShaderNames_NormalPremultipliedAlpha {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertNormal();"\
-            "PixelShader = compile ps_2_0 PixelNormalPremult();"\
-        "}"\
-    "}"\
-    \
-    "technique ShaderNames_NormalMaskedPremultipliedAlpha {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertMasked();"\
-            "PixelShader = compile ps_2_0 PixelMaskedPremult();"\
-        "}"\
-    "}"\
-    \
-    "technique ShaderNames_NormalMaskedInvertedPremultipliedAlpha {"\
-        "pass p0{"\
-            "VertexShader = compile vs_2_0 VertMasked();"\
-            "PixelShader = compile ps_2_0 PixelMaskedInvertedPremult();"\
-        "}"\
-    "}";
-
-
 void CubismShader_D3D9::ReleaseShaderProgram()
 {
+    _shaderSrc.Clear();
+
     if(_vertexFormat)
     {
         _vertexFormat->Release();
@@ -231,6 +51,36 @@ void CubismShader_D3D9::GenerateShaders(LPDIRECT3DDEVICE9 device)
         return;
     }
 
+    // シェーダーソースコードが記述されているファイルを読み込み
+    const csmChar* frameworkShaderPath = "FrameworkShaders/CubismEffect.fx";
+    csmLoadFileFunction fileLoader = Csm::CubismFramework::GetLoadFileFunction();
+    csmReleaseBytesFunction bytesReleaser = Csm::CubismFramework::GetReleaseBytesFunction();
+
+    if (!fileLoader)
+    {
+        CubismLogError("File loader is not set.");
+        return;
+    }
+
+    if (!bytesReleaser)
+    {
+        CubismLogError("Byte releaser is not set.");
+        return;
+    }
+
+    csmSizeInt shaderSize;
+    csmByte* shaderSrc = fileLoader(frameworkShaderPath, &shaderSize);
+    csmString shaderString = csmString(reinterpret_cast<const csmChar*>(shaderSrc), shaderSize);
+
+    _shaderSrc.Clear();
+    for (csmInt32 i = 0; i < shaderString.GetLength(); i++)
+    {
+        _shaderSrc.PushBack(shaderString.GetRawString()[i]);
+    }
+
+    // ファイル読み込みで確保したバイト列を開放
+    bytesReleaser(shaderSrc);
+
     //
     if(!LoadShaderProgram(device))
     {
@@ -257,7 +107,7 @@ Csm::csmBool CubismShader_D3D9::LoadShaderProgram(LPDIRECT3DDEVICE9 device)
     if (!device) return false;
 
     ID3DXBuffer* error = NULL;
-    if (FAILED(D3DXCreateEffect(device, CubismShaderEffectSrc, static_cast<UINT>(strlen(CubismShaderEffectSrc)), 0, 0, 0, 0, &_shaderEffect, &error)))
+    if (FAILED(D3DXCreateEffect(device, _shaderSrc.GetPtr(), _shaderSrc.GetSize(), 0, 0, 0, 0, &_shaderEffect, &error)))
     {
         return false;
     }

--- a/src/Rendering/D3D9/CubismShader_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismShader_D3D9.hpp
@@ -89,6 +89,7 @@ private:
     Csm::csmBool LoadShaderProgram(LPDIRECT3DDEVICE9 pD3dDevice);
 
 
+    csmVector<csmChar> _shaderSrc; ///< シェーダーソースコード
     ID3DXEffect*                    _shaderEffect; ///< CubismD3dでは一つのシェーダで内部テクニックの変更をする
     IDirect3DVertexDeclaration9*    _vertexFormat; ///< 描画で使用する型宣言
 };

--- a/src/Rendering/D3D9/Shaders/CubismEffect.fx
+++ b/src/Rendering/D3D9/Shaders/CubismEffect.fx
@@ -1,0 +1,185 @@
+float4x4 projectMatrix;
+float4x4 clipMatrix;
+float4 baseColor;
+float4 multiplyColor;
+float4 screenColor;
+float4 channelFlag;
+texture mainTexture;
+texture maskTexture;
+
+sampler mainSampler = sampler_state {
+    texture = <mainTexture>;
+};
+sampler maskSampler = sampler_state {
+    texture = <maskTexture>;
+};
+
+struct VS_IN {
+    float2 pos : POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+struct VS_OUT {
+    float4 Position : POSITION0;
+    float2 uv : TEXCOORD0;
+    float4 clipPosition : TEXCOORD1;
+};
+
+// Setup mask shader
+VS_OUT VertSetupMask(VS_IN In) {
+    VS_OUT Out = (VS_OUT)0;
+    Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.uv.x = In.uv.x;
+    Out.uv.y = 1.0f - +In.uv.y;
+    return Out;
+}
+
+float4 PixelSetupMask(VS_OUT In) : COLOR0 {
+    float isInside =
+    step(baseColor.x, In.clipPosition.x / In.clipPosition.w)
+    * step(baseColor.y, In.clipPosition.y / In.clipPosition.w)
+    * step(In.clipPosition.x / In.clipPosition.w, baseColor.z)
+    * step(In.clipPosition.y / In.clipPosition.w, baseColor.w);
+    return channelFlag * tex2D(mainSampler, In.uv).a * isInside;
+}
+
+// Vertex Shader
+// normal
+VS_OUT VertNormal(VS_IN In) {
+    VS_OUT Out = (VS_OUT)0;
+    Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.uv.x = In.uv.x;
+    Out.uv.y = 1.0f - +In.uv.y;
+    return Out;
+}
+
+// masked
+VS_OUT VertMasked(VS_IN In) {
+    VS_OUT Out = (VS_OUT)0;
+    Out.Position = mul(float4(In.pos, 0.0f, 1.0f), projectMatrix);
+    Out.clipPosition = mul(float4(In.pos, 0.0f, 1.0f), clipMatrix);
+    Out.uv.x = In.uv.x;
+    Out.uv.y = 1.0f - In.uv.y;
+    return Out;
+}
+
+// Pixel Shader
+// normal
+float4 PixelNormal(VS_OUT In) : COLOR0 {
+    float4 texColor = tex2D(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    color.xyz *= color.w;
+    return color;
+}
+
+// normal premult alpha
+float4 PixelNormalPremult(VS_OUT In) : COLOR0 {
+    float4 texColor = tex2D(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    return color;
+}
+
+// masked
+float4 PixelMasked(VS_OUT In) : COLOR0{
+    float4 texColor = tex2D(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    color.xyz *= color.w;
+    float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * maskVal;
+    return color;
+}
+
+// masked inverted
+float4 PixelMaskedInverted(VS_OUT In) : COLOR0 {
+    float4 texColor = tex2D(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    color.xyz *= color.w;
+    float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * (1.0f - maskVal);
+    return color;
+}
+
+// masked premult alpha
+float4 PixelMaskedPremult(VS_OUT In) : COLOR0 {
+    float4 texColor = tex2D(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * maskVal;
+    return color;
+}
+
+// masked inverted premult alpha
+float4 PixelMaskedInvertedPremult(VS_OUT In) : COLOR0 {
+    float4 texColor = tex2D(mainSampler, In.uv);
+    texColor.rgb = texColor.rgb * multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
+    float4 color = texColor * baseColor;
+    float4 clipMask = (1.0f - tex2D(maskSampler, In.clipPosition.xy / In.clipPosition.w)) * channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    color = color * (1.0f - maskVal);
+    return color;
+}
+
+// Technique
+technique ShaderNames_SetupMask {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertSetupMask();
+        PixelShader = compile ps_2_0 PixelSetupMask();
+    }
+}
+
+technique ShaderNames_Normal {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertNormal();
+        PixelShader = compile ps_2_0 PixelNormal();
+    }
+}
+
+technique ShaderNames_NormalMasked {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertMasked();
+        PixelShader = compile ps_2_0 PixelMasked();
+    }
+}
+
+technique ShaderNames_NormalMaskedInverted {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertMasked();
+        PixelShader = compile ps_2_0 PixelMaskedInverted();
+    }
+}
+
+technique ShaderNames_NormalPremultipliedAlpha {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertNormal();
+        PixelShader = compile ps_2_0 PixelNormalPremult();
+    }
+}
+
+technique ShaderNames_NormalMaskedPremultipliedAlpha {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertMasked();
+        PixelShader = compile ps_2_0 PixelMaskedPremult();
+    }
+}
+
+technique ShaderNames_NormalMaskedInvertedPremultipliedAlpha {
+    pass p0 {
+        VertexShader = compile vs_2_0 VertMasked();
+        PixelShader = compile ps_2_0 PixelMaskedInvertedPremult();
+    }
+}

--- a/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
@@ -60,406 +60,6 @@ enum ShaderNames
     ShaderNames_MultMaskedPremultipliedAlphaInverted,
 };
 
-// SetupMask
-static const csmChar* VertShaderSrcSetupMask =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-#else
-        "#version 120\n"
-#endif
-        "attribute vec4 a_position;"
-        "attribute vec2 a_texCoord;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
-        "uniform mat4 u_clipMatrix;"
-        "void main()"
-        "{"
-        "gl_Position = u_clipMatrix * a_position;"
-        "v_myPos = u_clipMatrix * a_position;"
-        "v_texCoord = a_texCoord;"
-        "v_texCoord.y = 1.0 - v_texCoord.y;"
-        "}";
-static const csmChar* FragShaderSrcSetupMask =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "void main()"
-        "{"
-        "float isInside = "
-        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcSetupMaskTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_myPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "void main()"
-        "{"
-        "float isInside = "
-        "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-        "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-        "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-        "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-        "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-        "}";
-#endif
-
-//----- バーテックスシェーダプログラム -----
-// Normal & Add & Mult 共通
-static const csmChar* VertShaderSrc =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-#else
-        "#version 120\n"
-#endif
-        "attribute vec4 a_position;" //v.vertex
-        "attribute vec2 a_texCoord;" //v.texcoord
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform mat4 u_matrix;"
-        "void main()"
-        "{"
-        "gl_Position = u_matrix * a_position;"
-        "v_texCoord = a_texCoord;"
-        "v_texCoord.y = 1.0 - v_texCoord.y;"
-        "}";
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* VertShaderSrcMasked =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-#else
-        "#version 120\n"
-#endif
-        "attribute vec4 a_position;"
-        "attribute vec2 a_texCoord;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform mat4 u_matrix;"
-        "uniform mat4 u_clipMatrix;"
-        "void main()"
-        "{"
-        "gl_Position = u_matrix * a_position;"
-        "v_clipPos = u_clipMatrix * a_position;"
-        "v_texCoord = a_texCoord;"
-        "v_texCoord.y = 1.0 - v_texCoord.y;"
-        "}";
-
-//----- フラグメントシェーダプログラム -----
-// Normal & Add & Mult 共通
-static const csmChar* FragShaderSrc =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 color = texColor * u_baseColor;"
-        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 color = texColor * u_baseColor;"
-        "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通 （PremultipliedAlpha）
-static const csmChar* FragShaderSrcPremultipliedAlpha =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "gl_FragColor = texColor * u_baseColor;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;" //v2f.texcoord
-        "uniform sampler2D s_texture0;" //_MainTex
-        "uniform vec4 u_baseColor;" //v2f.color
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "gl_FragColor = texColor * u_baseColor;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* FragShaderSrcMask =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
-static const csmChar* FragShaderSrcMaskInverted =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskInvertedTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * maskVal;"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
-// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
-#if defined(CSM_TARGET_IPHONE_ES2) || defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_HARMONYOS_ES3)
-        "#version 100\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-#else
-        "#version 120\n"
-#endif
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#if defined(CSM_TARGET_ANDROID_ES2)
-static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
-        "#version 100\n"
-        "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-        "precision " CSM_FRAGMENT_SHADER_FP_PRECISION " float;"
-        "varying vec2 v_texCoord;"
-        "varying vec4 v_clipPos;"
-        "uniform sampler2D s_texture0;"
-        "uniform sampler2D s_texture1;"
-        "uniform vec4 u_channelFlag;"
-        "uniform vec4 u_baseColor;"
-        "uniform vec4 u_multiplyColor;"
-        "uniform vec4 u_screenColor;"
-        "void main()"
-        "{"
-        "vec4 texColor = texture2D(s_texture0 , v_texCoord);"
-        "texColor.rgb = texColor.rgb * u_multiplyColor.rgb;"
-        "texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);"
-        "vec4 col_formask = texColor * u_baseColor;"
-        "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-        "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-        "col_formask = col_formask * (1.0 - maskVal);"
-        "gl_FragColor = col_formask;"
-        "}";
-#endif
-
 void CubismShader_OpenGLES2::ReleaseShaderProgram()
 {
     for (csmUint32 i = 0; i < _shaderSets.GetSize(); i++)
@@ -528,25 +128,25 @@ void CubismShader_OpenGLES2::GenerateShaders()
 #ifdef CSM_TARGET_ANDROID_ES2
     if (s_extMode)
     {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMaskTegra);
+        _shaderSets[0]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcSetupMask.vert", "FragShaderSrcSetupMaskTegra.frag");
 
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcTegra);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskTegra);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedTegra);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlphaTegra);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlphaTegra);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlphaTegra);
+        _shaderSets[1]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrc.vert", "FragShaderSrcTegra.frag");
+        _shaderSets[2]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskTegra.frag");
+        _shaderSets[3]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskInvertedTegra.frag");
+        _shaderSets[4]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrc.vert", "FragShaderSrcPremultipliedAlphaTegra.frag");
+        _shaderSets[5]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskPremultipliedAlphaTegra.frag");
+        _shaderSets[6]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskInvertedPremultipliedAlphaTegra.frag");
     }
     else
     {
-        _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
+        _shaderSets[0]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcSetupMask.vert", "FragShaderSrcSetupMask.frag");
 
-        _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
-        _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
-        _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
-        _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
-        _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
-        _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+        _shaderSets[1]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrc.vert", "FragShaderSrc.frag");
+        _shaderSets[2]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMask.frag");
+        _shaderSets[3]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskInverted.frag");
+        _shaderSets[4]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrc.vert", "FragShaderSrcPremultipliedAlpha.frag");
+        _shaderSets[5]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskPremultipliedAlpha.frag");
+        _shaderSets[6]->ShaderProgram = LoadShaderProgramFromFile("VertShaderSrcMasked.vert", "FragShaderSrcMaskInvertedPremultipliedAlpha.frag");
     }
 
     // 加算も通常と同じシェーダーを利用する
@@ -567,14 +167,13 @@ void CubismShader_OpenGLES2::GenerateShaders()
 
 #else
 
-    _shaderSets[0]->ShaderProgram = LoadShaderProgram(VertShaderSrcSetupMask, FragShaderSrcSetupMask);
-
-    _shaderSets[1]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrc);
-    _shaderSets[2]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMask);
-    _shaderSets[3]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInverted);
-    _shaderSets[4]->ShaderProgram = LoadShaderProgram(VertShaderSrc, FragShaderSrcPremultipliedAlpha);
-    _shaderSets[5]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskPremultipliedAlpha);
-    _shaderSets[6]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha);
+    _shaderSets[0]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrcSetupMask.vert", "FrameworkShaders/FragShaderSrcSetupMask.frag");
+    _shaderSets[1]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrc.vert", "FrameworkShaders/FragShaderSrc.frag");
+    _shaderSets[2]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrcMasked.vert", "FrameworkShaders/FragShaderSrcMask.frag");
+    _shaderSets[3]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrcMasked.vert", "FrameworkShaders/FragShaderSrcMaskInverted.frag");
+    _shaderSets[4]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrc.vert", "FrameworkShaders/FragShaderSrcPremultipliedAlpha.frag");
+    _shaderSets[5]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrcMasked.vert", "FrameworkShaders/FragShaderSrcMaskPremultipliedAlpha.frag");
+    _shaderSets[6]->ShaderProgram = LoadShaderProgramFromFile("FrameworkShaders/VertShaderSrcMasked.vert", "FrameworkShaders/FragShaderSrcMaskInvertedPremultipliedAlpha.frag");
 
     // 加算も通常と同じシェーダーを利用する
     _shaderSets[7]->ShaderProgram = _shaderSets[1]->ShaderProgram;
@@ -999,6 +598,40 @@ csmBool CubismShader_OpenGLES2::ValidateProgram(GLuint shaderProgram)
     }
 
     return true;
+}
+
+GLuint CubismShader_OpenGLES2::LoadShaderProgramFromFile(const csmChar* vertShaderPath, const csmChar* fragShaderPath)
+{
+    csmLoadFileFunction fileLoader = Csm::CubismFramework::GetLoadFileFunction();
+    csmReleaseBytesFunction bytesReleaser = Csm::CubismFramework::GetReleaseBytesFunction();
+
+    if (!fileLoader)
+    {
+        CubismLogError("File loader is not set.");
+        return 0;
+    }
+
+    if (!bytesReleaser)
+    {
+        CubismLogError("Byte releaser is not set.");
+        return 0;
+    }
+
+    // ファイルからシェーダーのソースコードを読み込み
+    csmSizeInt vertSrcSize, fragSrcSize;
+    csmByte* vertSrc = fileLoader(vertShaderPath, &vertSrcSize);
+    csmByte* fragSrc = fileLoader(fragShaderPath, &fragSrcSize);
+
+    // 読み込んだソースコードを文字列として扱うために、終端文字列を付加
+    csmString vertString = csmString(reinterpret_cast<const csmChar*>(vertSrc), vertSrcSize);
+    csmString fragString = csmString(reinterpret_cast<const csmChar*>(fragSrc), fragSrcSize);
+
+    // ファイル読み込みで確保したバイト列を開放
+    bytesReleaser(vertSrc);
+    bytesReleaser(fragSrc);
+
+    // シェーダーオブジェクトを作成
+    return LoadShaderProgram(vertString.GetRawString(), fragString.GetRawString());
 }
 
 GLuint CubismShader_OpenGLES2::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)

--- a/src/Rendering/OpenGL/CubismShader_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismShader_OpenGLES2.hpp
@@ -130,6 +130,16 @@ private:
     void GenerateShaders();
 
     /**
+     * @brief   ファイルからシェーダプログラムをロードし、シェーダーオブジェクトの番号を返す。
+     *
+     * @param[in]   vertShaderSrc   ->  頂点シェーダのファイルパス
+     * @param[in]   fragShaderSrc   ->  フラグメントシェーダのファイルパス
+     *
+     * @return  シェーダーオブジェクトの番号
+     */
+    GLuint LoadShaderProgramFromFile(const csmChar* vertShaderPath, const csmChar* fragShaderPath);
+
+    /**
      * @brief   シェーダプログラムをロードしてアドレス返す。
      *
      * @param[in]   vertShaderSrc   ->  頂点シェーダのソース

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrc.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrc.frag
@@ -1,0 +1,16 @@
+#version 120
+
+varying vec2 v_texCoord; //v2f.texcoord
+uniform sampler2D s_texture0; //_MainTex
+uniform vec4 u_baseColor; //v2f.color
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 color = texColor * u_baseColor;
+    gl_FragColor = vec4(color.rgb * color.a,  color.a);
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMask.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMask.frag
@@ -1,0 +1,23 @@
+#version 120
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMaskInverted.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMaskInverted.frag
@@ -1,0 +1,23 @@
+#version 120
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMaskInvertedPremultipliedAlpha.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMaskInvertedPremultipliedAlpha.frag
@@ -1,0 +1,22 @@
+#version 120
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMaskPremultipliedAlpha.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcMaskPremultipliedAlpha.frag
@@ -1,0 +1,22 @@
+#version 120
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcPremultipliedAlpha.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcPremultipliedAlpha.frag
@@ -1,0 +1,15 @@
+#version 120
+
+varying vec2 v_texCoord; //v2f.texcoord
+uniform sampler2D s_texture0; //_MainTex
+uniform vec4 u_baseColor; //v2f.color
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    gl_FragColor = texColor * u_baseColor;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcSetupMask.frag
+++ b/src/Rendering/OpenGL/Shaders/Standard/FragShaderSrcSetupMask.frag
@@ -1,0 +1,18 @@
+#version 120
+
+varying vec2 v_texCoord;
+varying vec4 v_myPos;
+uniform sampler2D s_texture0;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+
+void main()
+{
+    float isInside =
+        step(u_baseColor.x, v_myPos.x/v_myPos.w)
+        * step(u_baseColor.y, v_myPos.y/v_myPos.w)
+        * step(v_myPos.x/v_myPos.w, u_baseColor.z)
+        * step(v_myPos.y/v_myPos.w, u_baseColor.w);
+
+    gl_FragColor = u_channelFlag * texture2D(s_texture0, v_texCoord).a * isInside;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/VertShaderSrc.vert
+++ b/src/Rendering/OpenGL/Shaders/Standard/VertShaderSrc.vert
@@ -1,0 +1,13 @@
+#version 120
+
+attribute vec4 a_position; //v.vertex
+attribute vec2 a_texCoord; //v.texcoord
+varying vec2 v_texCoord; //v2f.texcoord
+uniform mat4 u_matrix;
+
+void main()
+{
+    gl_Position = u_matrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/VertShaderSrcMasked.vert
+++ b/src/Rendering/OpenGL/Shaders/Standard/VertShaderSrcMasked.vert
@@ -1,0 +1,16 @@
+#version 120
+
+attribute vec4 a_position;
+attribute vec2 a_texCoord;
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform mat4 u_matrix;
+uniform mat4 u_clipMatrix;
+
+void main()
+{
+    gl_Position = u_matrix * a_position;
+    v_clipPos = u_clipMatrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/OpenGL/Shaders/Standard/VertShaderSrcSetupMask.vert
+++ b/src/Rendering/OpenGL/Shaders/Standard/VertShaderSrcSetupMask.vert
@@ -1,0 +1,15 @@
+#version 120
+
+attribute vec4 a_position;
+attribute vec2 a_texCoord;
+varying vec2 v_texCoord;
+varying vec4 v_myPos;
+uniform mat4 u_clipMatrix;
+
+void main()
+{
+    gl_Position = u_clipMatrix * a_position;
+    v_myPos = u_clipMatrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrc.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrc.frag
@@ -1,0 +1,18 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord; //v2f.texcoord
+uniform sampler2D s_texture0; //_MainTex
+uniform vec4 u_baseColor; //v2f.color
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 color = texColor * u_baseColor;
+    gl_FragColor = vec4(color.rgb * color.a,  color.a);
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMask.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMask.frag
@@ -1,0 +1,25 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInverted.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInverted.frag
@@ -1,0 +1,25 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInvertedPremultipliedAlpha.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInvertedPremultipliedAlpha.frag
@@ -1,0 +1,24 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInvertedPremultipliedAlphaTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInvertedPremultipliedAlphaTegra.frag
@@ -1,0 +1,25 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInvertedTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskInvertedTegra.frag
@@ -1,0 +1,26 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskPremultipliedAlpha.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskPremultipliedAlpha.frag
@@ -1,0 +1,24 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskPremultipliedAlphaTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskPremultipliedAlphaTegra.frag
@@ -1,0 +1,25 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcMaskTegra.frag
@@ -1,0 +1,26 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform sampler2D s_texture0;
+uniform sampler2D s_texture1;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 col_formask = texColor * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    gl_FragColor = col_formask;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcPremultipliedAlpha.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcPremultipliedAlpha.frag
@@ -1,0 +1,17 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord; //v2f.texcoord
+uniform sampler2D s_texture0; //_MainTex
+uniform vec4 u_baseColor; //v2f.color
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    gl_FragColor = texColor * u_baseColor;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcPremultipliedAlphaTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcPremultipliedAlphaTegra.frag
@@ -1,0 +1,18 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord; //v2f.texcoord
+uniform sampler2D s_texture0; //_MainTex
+uniform vec4 u_baseColor; //v2f.color
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);
+    gl_FragColor = texColor * u_baseColor;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcSetupMask.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcSetupMask.frag
@@ -1,0 +1,20 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_myPos;
+uniform sampler2D s_texture0;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+
+void main()
+{
+    float isInside =
+        step(u_baseColor.x, v_myPos.x/v_myPos.w)
+        * step(u_baseColor.y, v_myPos.y/v_myPos.w)
+        * step(v_myPos.x/v_myPos.w, u_baseColor.z)
+        * step(v_myPos.y/v_myPos.w, u_baseColor.w);
+
+    gl_FragColor = u_channelFlag * texture2D(s_texture0, v_texCoord).a * isInside;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcSetupMaskTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcSetupMaskTegra.frag
@@ -1,0 +1,21 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord;
+varying vec4 v_myPos;
+uniform sampler2D s_texture0;
+uniform vec4 u_channelFlag;
+uniform vec4 u_baseColor;
+
+void main()
+{
+    float isInside =
+        step(u_baseColor.x, v_myPos.x/v_myPos.w)
+        * step(u_baseColor.y, v_myPos.y/v_myPos.w)
+        * step(v_myPos.x/v_myPos.w, u_baseColor.z)
+        * step(v_myPos.y/v_myPos.w, u_baseColor.w);
+
+    gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcTegra.frag
+++ b/src/Rendering/OpenGL/Shaders/StandardES/FragShaderSrcTegra.frag
@@ -1,0 +1,19 @@
+#version 100
+#extension GL_NV_shader_framebuffer_fetch : enable
+
+precision highp float;
+
+varying vec2 v_texCoord; //v2f.texcoord
+uniform sampler2D s_texture0; //_MainTex
+uniform vec4 u_baseColor; //v2f.color
+uniform vec4 u_multiplyColor;
+uniform vec4 u_screenColor;
+
+void main()
+{
+    vec4 texColor = texture2D(s_texture0 , v_texCoord);
+    texColor.rgb = texColor.rgb * u_multiplyColor.rgb;
+    texColor.rgb = texColor.rgb + u_screenColor.rgb - (texColor.rgb * u_screenColor.rgb);
+    vec4 color = texColor * u_baseColor;
+    gl_FragColor = vec4(color.rgb * color.a,  color.a);
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/VertShaderSrc.vert
+++ b/src/Rendering/OpenGL/Shaders/StandardES/VertShaderSrc.vert
@@ -1,0 +1,13 @@
+#version 100
+
+attribute vec4 a_position; //v.vertex
+attribute vec2 a_texCoord; //v.texcoord
+varying vec2 v_texCoord; //v2f.texcoord
+uniform mat4 u_matrix;
+
+void main()
+{
+    gl_Position = u_matrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/VertShaderSrcMasked.vert
+++ b/src/Rendering/OpenGL/Shaders/StandardES/VertShaderSrcMasked.vert
@@ -1,0 +1,16 @@
+#version 100
+
+attribute vec4 a_position;
+attribute vec2 a_texCoord;
+varying vec2 v_texCoord;
+varying vec4 v_clipPos;
+uniform mat4 u_matrix;
+uniform mat4 u_clipMatrix;
+
+void main()
+{
+    gl_Position = u_matrix * a_position;
+    v_clipPos = u_clipMatrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Rendering/OpenGL/Shaders/StandardES/VertShaderSrcSetupMask.vert
+++ b/src/Rendering/OpenGL/Shaders/StandardES/VertShaderSrcSetupMask.vert
@@ -1,0 +1,15 @@
+#version 100
+
+attribute vec4 a_position;
+attribute vec2 a_texCoord;
+varying vec2 v_texCoord;
+varying vec4 v_myPos;
+uniform mat4 u_clipMatrix;
+
+void main()
+{
+    gl_Position = u_clipMatrix * a_position;
+    v_myPos = u_clipMatrix * a_position;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/src/Type/csmMap.hpp
+++ b/src/Type/csmMap.hpp
@@ -205,7 +205,7 @@ public:
      * @retval  true    ->  引数で渡したKeyを持つ要素が存在する
      * @retval  false   ->  引数で渡したKeyを持つ要素が存在しない
      */
-    csmBool IsExist(_KeyT key)
+    csmBool IsExist(_KeyT key) const
     {
         for (csmInt32 i = 0; i < _size; i++)
         {


### PR DESCRIPTION
### Added

* Add parameter repeat processing that connects the right and left ends of the parameter to create a loop, allowing the motion to repeat.
  * Add the variable `_isOverriddenParameterRepeat` to the `CubismModel` class for managing parameter repeat flags at the model level.
  * Add the variable `_userParameterRepeatDataList` to the `CubismModel` class for managing parameter repeat flags for each parameter.
* Add a flag to the arguments of the following methods to enable the function that verifies the consistency of `motion3.json`:
  * `CubismUserModel.LoadMotion()`
  * `CubismMotion.Create()`
  * `CubismMotion.Parse()`
* Add a `GetPartParentPartIndices()` function.

### Changed

* Change shader code to be used separately.

### Removed

* Remove the usage of `_DEBUG`.