### PR TITLE
Update to Cubism 5 SDK for Native R5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.5] - 2026-04-02
+
+### Added
+
+* Add the `SetRenderViewport` method to `CubismRenderer_Metal` to set the viewport when drawing the model.
+* Add functionality to change motion calculation order.
+* Add `cubismlook` class that implements the target tracking feature.
+  * The target tracking feature can now specify parameter IDs through the `Framework`.
+
+### Changed
+
+* Change Vulkan renderer to use `CubismDeviceInfo_Vulkan` instead of singletons for pipeline and offscreen manager.
+  * Rename `InitializeConstantSettings` to `SetConstantSettings` in Vulkan renderer.
+* Change the access level of the private members in the `CubismMoc` and `CubismModel` classes to protected.
+* Change multiply and screen color functions to separate class with renamed methods.
+* Change shader generation from draw loop to Initialize() in OpenGL, D3D9, D3D11 and Metal.
+* Change to unify sampler settings across all graphics APIs, except for OpenGL ES on Android and iOS.
+
+### Fixed
+
+* Fix a validation error on Vulkan.
+* Fix unnecessary multiply color and screen color settings in mask drawing.
+* Fix a memory leak in `CubismRenderer_D3D11::ReleaseCommandBuffer()` where `_indexBuffers` and `_vertexBuffers` were not freed due to a copy-paste bug.
+* Fix a memory leak in `CubismRenderer_Vulkan::CreatePipelines()` where `PipelineResource` objects allocated for Add/Mult blend modes were overwritten and leaked.
+* Fix missing null checks after loading shader source files in OpenGL, D3D9 and D3D11 renderers.
+* Fix a resource leak in `CubismShader_D3D11::GenerateShaders()` where Copy and SetupMask shaders were loaded twice, causing the first set of COM objects to leak.
+* Fix redundant matrix transpose in D3D11 renderer.
+* Improve the viewport save and restore process on OpenGL.
+
+### Removed
+
+* Remove unnecessary shader processing in D3D11 and D3D9.
+* Remove deprecated functions from CubismModel:
+ * `GetDrawableTextureIndices(csmInt32 drawableIndex)` (use `GetDrawableTextureIndex(csmInt32 drawableIndex)` instead)
+ * `GetDrawableBlendMode(csmInt32 drawableIndex)` (use `GetDrawableBlendModeType(csmInt32 drawableIndex)` instead)
+ * `SetOverwriteFlagForModelCullings(csmBool value)` (use `SetOverrideFlagForModelCullings(csmBool value)` instead)
+ * `GetOverwriteFlagForModelCullings()` (use `GetOverwriteFlagForModelCullings()` instead)
+ * `SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value)` (use `SetOverrideFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value)` instead)
+ * `GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex)` (use `GetOverrideFlagForDrawableCullings(csmInt32 drawableIndex)` instead)
+* Remove deprecated functions from CubismExpressionMotion:
+ * `GetFadeWeight()` (use `CubismExpressionMotionManager.GetFadeWeight(csmInt32 index)` instead)
+* Remove deprecated fields from CubismExpressionMotion:
+ * `_fadeWeight` (priority is not used in expression motion playback)
+* Remove deprecated functions from CubismExpressionMotionManager:
+ * `GetCurrentPriority()` (priority is not used in expression motion playback)
+ * `SetReservePriority(csmInt32 priority)` (priority is not used in expression motion playback)
+ * `GetReservePriority()` (priority is not used in expression motion playback)
+ * `StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority)` (use `CubismMotionQueueManager::StartMotion(ACubismMotion* motion, csmBool autoDelete)` instead)
+* Remove deprecated fields from CubismExpressionMotionManager:
+ * `_currentPriority` (priority is not used in expression motion playback)
+ * `_reservePriority` (priority is not used in expression motion playback)
+* Remove deprecated functions from CubismMotion:
+ * `IsLoop(csmBool loop)` (use `ACubismMotion.SetLoop(csmBool loop)` instead)
+ * `IsLoop()` (use `ACubismMotion.GetLoop()` instead)
+ * `IsLoopFadeIn(csmBool loopFadeIn)` (use `ACubismMotion.SetLoopFadeIn(csmBool loopFadeIn)` instead)
+ * `IsLoopFadeIn()` (use `ACubismMotion.GetLoopFadeIn()` instead)
+* Remove deprecated functions from CubismMotionQueueManager:
+ * `StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds)` (use `StartMotion(ACubismMotion* motion, csmBool autoDelete)` instead)
+
+
 ## [5-r.5-beta.3.1] - 2026-02-19
 
 ### Added
@@ -546,6 +606,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix invalid expressions of `CubismCdiJson`.
 
 
+[5-r.5]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.5-beta.3.1...5-r.5
 [5-r.5-beta.3.1]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.5-beta.3...5-r.5-beta.3.1
 [5-r.5-beta.3]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.5-beta.2...5-r.5-beta.3
 [5-r.5-beta.2]: https://github.com/Live2D/CubismNativeFramework/compare/5-r.5-beta.1...5-r.5-beta.2

--- a/src/Effect/CMakeLists.txt
+++ b/src/Effect/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismBreath.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismEyeBlink.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismEyeBlink.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismLook.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismLook.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismPose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismPose.hpp
 )

--- a/src/Effect/CubismLook.cpp
+++ b/src/Effect/CubismLook.cpp
@@ -1,0 +1,44 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismLook.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismLook* CubismLook::Create()
+{
+    return CSM_NEW CubismLook();
+}
+
+void CubismLook::Delete(CubismLook* instance)
+{
+    CSM_DELETE_SELF(CubismLook, instance);
+}
+
+void CubismLook::SetParameters(const csmVector<LookParameterData>& lookParameters)
+{
+    _lookParameters = lookParameters;
+}
+
+const csmVector<CubismLook::LookParameterData>& CubismLook::GetParameters() const
+{
+    return _lookParameters;
+}
+
+void CubismLook::UpdateParameters(CubismModel* model, const csmFloat32 dragX, const csmFloat32 dragY) const
+{
+    const csmFloat32 dragXY = dragX * dragY;
+
+    for (csmUint32 i = 0; i < _lookParameters.GetSize(); ++i)
+    {
+        const LookParameterData& data = _lookParameters[i];
+
+        model->AddParameterValue(data.ParameterId, data.FactorX * dragX + data.FactorY * dragY + data.FactorXY * dragXY);
+    }
+}
+
+}}}

--- a/src/Effect/CubismLook.hpp
+++ b/src/Effect/CubismLook.hpp
@@ -1,0 +1,108 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <climits>
+#include "CubismFramework.hpp"
+#include "Model/CubismModel.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Parameter Following Feature by Target.<br>
+ * Provides parameter following functionality for drag input.
+ */
+class CubismLook
+{
+public:
+    /**
+     * Data attached to the parameters of look.
+     */
+    struct LookParameterData
+    {
+        /**
+         * Constructor
+         */
+        LookParameterData()
+            : ParameterId(nullptr)
+            , FactorX(0.0f)
+            , FactorY(0.0f)
+            , FactorXY(0.0f)
+        {
+        }
+
+        /**
+         * Constructor<br>
+         * Sets the data.
+         *
+         * @param parameterId ID of the breath parameter to attach.
+         * @param factorX Coefficient for drag input along the X-axis.
+         * @param factorY Coefficient for drag input along the Y-axis.
+         * @param factorXY Coefficient for the combined X-Y (cross) drag input.
+         */
+        LookParameterData(CubismIdHandle parameterId, const csmFloat32 factorX = 0.0f, const csmFloat32 factorY = 0.0f, const csmFloat32 factorXY = 0.0f)
+            : ParameterId(parameterId)
+            , FactorX(factorX)
+            , FactorY(factorY)
+            , FactorXY(factorXY)
+        {
+        }
+
+        CubismIdHandle ParameterId;
+        csmFloat32 FactorX;
+        csmFloat32 FactorY;
+        csmFloat32 FactorXY;
+    };
+
+    /**
+     * Makes an instance of CubismLook.
+     *
+     * @return Maked instance of CubismLook
+     */
+    static CubismLook* Create();
+
+    /**
+     * Destroys an instance of CubismLook.
+     *
+     * @param instance Instance of CubismLook to destroy
+     */
+    static void Delete(CubismLook* instance);
+
+    /**
+     * Attaches the parameters of look.
+     *
+     * @param lookParameters Collection of look parameters to attach
+     */
+    void SetParameters(const csmVector<LookParameterData>& lookParameters);
+
+    /**
+     * Returns parameters attached to look.
+     *
+     * @return Attached collection of look parameters
+     */
+    const csmVector<LookParameterData>& GetParameters() const;
+
+    /**
+     * Updates the parameters of the model.
+     *
+     * @param model Model to update
+     * @param dragX X coordinate of the target
+     * @param dragY Y coordinate of the target
+     *
+     * @note Execute after making an instance with #Create() and binding parameters with #setParameters().
+     */
+    void UpdateParameters(CubismModel* model, const csmFloat32 dragX, const csmFloat32 dragY) const;
+
+private:
+    CubismLook() = default;
+    ~CubismLook() = default;
+
+    csmVector<LookParameterData> _lookParameters;
+};
+
+}}}

--- a/src/Model/CMakeLists.txt
+++ b/src/Model/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMoc.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModel.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelMultiplyAndScreenColor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelMultiplyAndScreenColor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserData.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserData.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismModelUserDataJson.cpp

--- a/src/Model/CubismMoc.hpp
+++ b/src/Model/CubismMoc.hpp
@@ -95,7 +95,17 @@ public:
      */
     static csmBool HasMocConsistencyFromUnrevivedMoc(const csmByte* mocBytes, csmSizeInt size);
 
-private:
+    /**
+     * Delete copy constructor.
+     */
+    CubismMoc(const CubismMoc&) = delete;
+
+    /**
+     * Delete copy assignment operator.
+     */
+    CubismMoc& operator=(const CubismMoc&) = delete;
+
+protected:
     CubismMoc(Core::csmMoc* moc);
 
     virtual ~CubismMoc();

--- a/src/Model/CubismModel.cpp
+++ b/src/Model/CubismModel.cpp
@@ -24,12 +24,11 @@ CubismModel::CubismModel(Core::csmModel* model)
     , _parameterMaximumValues(NULL)
     , _parameterMinimumValues(NULL)
     , _partOpacities(NULL)
+    , _modelOpacity(1.0f)
+    , _overrideMultiplyAndScreenColors(this, &_partsHierarchy)
     , _isOverriddenParameterRepeat(true)
-    , _isOverriddenModelMultiplyColors(false)
-    , _isOverriddenModelScreenColors(false)
     , _isOverriddenCullings(false)
     , _isBlendModeEnabled(false)
-    , _modelOpacity(1.0f)
 { }
 
 CubismModel::~CubismModel()
@@ -498,6 +497,10 @@ void CubismModel::Initialize()
     }
 
     const csmInt32  partCount = Core::csmGetPartCount(_model);
+    const csmInt32  drawableCount = Core::csmGetDrawableCount(_model);
+    const csmInt32 offscreenCount = Core::csmGetOffscreenCount(_model);
+
+    // Part
     {
         const csmChar** partIds = Core::csmGetPartIds(_model);
 
@@ -506,19 +509,13 @@ void CubismModel::Initialize()
         {
             _partIds.PushBack(CubismFramework::GetIdManager()->GetId(partIds[i]));
         }
-
-        _userPartMultiplyColors.PrepareCapacity(partCount);
-        _userPartScreenColors.PrepareCapacity(partCount);
-        _partChildDrawables.Resize(partCount);
     }
 
+    // Drawable
     {
         const csmChar** drawableIds = Core::csmGetDrawableIds(_model);
-        const csmInt32  drawableCount = Core::csmGetDrawableCount(_model);
 
         _drawableIds.PrepareCapacity(drawableCount);
-        _userDrawableMultiplyColors.PrepareCapacity(drawableCount);
-        _userDrawableScreenColors.PrepareCapacity(drawableCount);
         _userDrawableCullings.PrepareCapacity(drawableCount);
 
         // カリング設定
@@ -526,77 +523,30 @@ void CubismModel::Initialize()
         userCulling.IsOverridden = false;
         userCulling.IsCulling = 0;
 
-        // 乗算色
-        Rendering::CubismRenderer::CubismTextureColor multiplyColor;
-        multiplyColor.R = 1.0f;
-        multiplyColor.G = 1.0f;
-        multiplyColor.B = 1.0f;
-        multiplyColor.A = 1.0f;
-
-        // スクリーン色
-        Rendering::CubismRenderer::CubismTextureColor screenColor;
-        screenColor.R = 0.0f;
-        screenColor.G = 0.0f;
-        screenColor.B = 0.0f;
-        screenColor.A = 1.0f;
-
-        // Parts
+        for (csmInt32 i = 0; i < drawableCount; ++i)
         {
-            // 乗算色
-            ColorData userMultiplyColor;
-            userMultiplyColor.IsOverridden = false;
-            userMultiplyColor.Color = multiplyColor;
-
-            // スクリーン色
-            ColorData userScreenColor;
-            userScreenColor.IsOverridden = false;
-            userScreenColor.Color = screenColor;
-
-            for (csmInt32 i = 0; i < partCount; ++i)
-            {
-                _userPartMultiplyColors.PushBack(userMultiplyColor);
-                _userPartScreenColors.PushBack(userScreenColor);
-            }
-        }
-
-        // Drawables
-        {
-            // 乗算色
-            ColorData userMultiplyColor;
-            userMultiplyColor.IsOverridden = false;
-            userMultiplyColor.Color = multiplyColor;
-
-            // スクリーン色
-            ColorData userScreenColor;
-            userScreenColor.IsOverridden = false;
-            userScreenColor.Color = screenColor;
-
-            for (csmInt32 i = 0; i < drawableCount; ++i)
-            {
-                _drawableIds.PushBack(CubismFramework::GetIdManager()->GetId(drawableIds[i]));
-                _userDrawableMultiplyColors.PushBack(userMultiplyColor);
-                _userDrawableScreenColors.PushBack(userScreenColor);
-                _userDrawableCullings.PushBack(userCulling);
-
-                csmInt32 parentIndex = Core::csmGetDrawableParentPartIndices(_model)[i];
-                if (parentIndex >= 0)
-                {
-                    _partChildDrawables[parentIndex].PushBack(i);
-                }
-            }
+            _drawableIds.PushBack(CubismFramework::GetIdManager()->GetId(drawableIds[i]));
+            _userDrawableCullings.PushBack(userCulling);
         }
     }
-
-    // blendMode
-    InitializeBlendMode();
 
     // Offscreen
-    InitializeOffscreen();
-
-    if (_isBlendModeEnabled)
     {
-        SetupPartsHierarchy();
+        _userOffscreenCullings.PrepareCapacity(offscreenCount);
+        for (csmInt32 i = 0; i < offscreenCount; ++i)
+        {
+            _userOffscreenCullings.PushBack(CullingData());
+        }
     }
+
+    // Multiply and Screen
+    _overrideMultiplyAndScreenColors.Initialize(partCount, drawableCount, offscreenCount);
+
+    // BlendMode
+    InitializeBlendMode();
+
+    // PartsHierarchy
+    SetupPartsHierarchy();
 }
 
 void CubismModel::InitializeBlendMode()
@@ -627,36 +577,6 @@ void CubismModel::InitializeBlendMode()
                 break;
             }
         }
-    }
-}
-
-void CubismModel::InitializeOffscreen()
-{
-    // 乗算色
-    ColorData userMultiplyColor;
-    userMultiplyColor.IsOverridden = false;
-    userMultiplyColor.Color = Rendering::CubismRenderer::CubismTextureColor();
-
-    // スクリーン色
-    ColorData userScreenColor;
-    userScreenColor.IsOverridden = false;
-    userScreenColor.Color = Rendering::CubismRenderer::CubismTextureColor();
-    userScreenColor.Color.R = 0.0f;
-    userScreenColor.Color.G = 0.0f;
-    userScreenColor.Color.B = 0.0f;
-    userScreenColor.Color.A = 1.0f;
-
-    const csmInt32 offscreenCount = Core::csmGetOffscreenCount(_model);
-
-    _userOffscreenMultiplyColors.PrepareCapacity(offscreenCount);
-    _userOffscreenScreenColors.PrepareCapacity(offscreenCount);
-    _userOffscreenCullings.PrepareCapacity(offscreenCount);
-
-    for (csmInt32 i = 0; i < offscreenCount; ++i)
-    {
-        _userOffscreenMultiplyColors.PushBack(userMultiplyColor);
-        _userOffscreenScreenColors.PushBack(userScreenColor);
-        _userOffscreenCullings.PushBack(CullingData());
     }
 }
 
@@ -771,11 +691,6 @@ csmInt32 CubismModel::GetDrawableCount() const
     return drawableCount;
 }
 
-csmInt32 CubismModel::GetDrawableTextureIndices(csmInt32 drawableIndex) const
-{
-    return GetDrawableTextureIndex(drawableIndex);
-}
-
 csmInt32 CubismModel::GetDrawableTextureIndex(csmInt32 drawableIndex) const
 {
     const csmInt32* textureIndices = Core::csmGetDrawableTextureIndices(_model);
@@ -852,7 +767,6 @@ csmInt32 CubismModel::GetPartParentPartIndex(csmUint32 partIndex) const
     return Core::csmGetPartParentPartIndices(_model)[partIndex];
 }
 
-
 csmBool CubismModel::GetDrawableDynamicFlagIsVisible(csmInt32 drawableIndex) const
 {
     const Core::csmFlags* dynamicFlags = Core::csmGetDrawableDynamicFlags(_model);
@@ -893,18 +807,6 @@ csmBool CubismModel::GetDrawableDynamicFlagBlendColorDidChange(csmInt32 drawable
 {
     const Core::csmFlags* dynamicFlags = Core::csmGetDrawableDynamicFlags(_model);
     return IsBitSet(dynamicFlags[drawableIndex], Core::csmBlendColorDidChange) != 0 ? true : false;
-}
-
-Rendering::CubismRenderer::CubismBlendMode CubismModel::GetDrawableBlendMode(csmInt32 drawableIndex) const
-{
-    CubismLogWarning("GetDrawableBlendMode() is a deprecated function. Please use GetDrawableBlendModeType().");
-
-    const csmUint8* constantFlags = Core::csmGetDrawableConstantFlags(_model);
-    return (IsBitSet(constantFlags[drawableIndex], Core::csmBlendAdditive)) ?
-        Rendering::CubismRenderer::CubismBlendMode_Additive :
-        (IsBitSet(constantFlags[drawableIndex], Core::csmBlendMultiplicative)) ?
-            Rendering::CubismRenderer::CubismBlendMode_Multiplicative :
-            Rendering::CubismRenderer::CubismBlendMode_Normal;
 }
 
 csmBlendMode CubismModel::GetDrawableBlendModeType(csmInt32 drawableIndex) const
@@ -1007,156 +909,6 @@ void CubismModel::SaveParameters()
     }
 }
 
-Rendering::CubismRenderer::CubismTextureColor CubismModel::GetMultiplyColor(csmInt32 drawableIndex) const
-{
-    if (GetOverrideFlagForModelMultiplyColors() || GetOverrideFlagForDrawableMultiplyColors(drawableIndex))
-    {
-        return _userDrawableMultiplyColors[drawableIndex].Color;
-    }
-    const Core::csmVector4 tmpColor = GetDrawableMultiplyColor(drawableIndex);
-
-    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
-}
-
-Rendering::CubismRenderer::CubismTextureColor CubismModel::GetScreenColor(csmInt32 drawableIndex) const
-{
-    if (GetOverrideFlagForModelScreenColors() || GetOverrideFlagForDrawableScreenColors(drawableIndex))
-    {
-        return _userDrawableScreenColors[drawableIndex].Color;
-    }
-    const Core::csmVector4 tmpColor = GetDrawableScreenColor(drawableIndex);
-
-    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
-}
-
-void CubismModel::SetMultiplyColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
-{
-    SetMultiplyColor(drawableIndex, color.R, color.G, color.B, color.A);
-}
-
-void CubismModel::SetMultiplyColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
-{
-    _userDrawableMultiplyColors[drawableIndex].Color.R = r;
-    _userDrawableMultiplyColors[drawableIndex].Color.G = g;
-    _userDrawableMultiplyColors[drawableIndex].Color.B = b;
-    _userDrawableMultiplyColors[drawableIndex].Color.A = a;
-}
-
-void CubismModel::SetScreenColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
-{
-    SetScreenColor(drawableIndex, color.R, color.G, color.B, color.A);
-}
-
-void CubismModel::SetScreenColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
-{
-    _userDrawableScreenColors[drawableIndex].Color.R = r;
-    _userDrawableScreenColors[drawableIndex].Color.G = g;
-    _userDrawableScreenColors[drawableIndex].Color.B = b;
-    _userDrawableScreenColors[drawableIndex].Color.A = a;
-}
-
-Rendering::CubismRenderer::CubismTextureColor CubismModel::GetPartMultiplyColor(csmInt32 partIndex) const
-{
-    return _userPartMultiplyColors[partIndex].Color;
-}
-
-Rendering::CubismRenderer::CubismTextureColor CubismModel::GetPartScreenColor(csmInt32 partIndex) const
-{
-    return _userPartScreenColors[partIndex].Color;
-}
-
-void CubismModel::SetPartMultiplyColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
-{
-    SetPartMultiplyColor(partIndex, color.R, color.G, color.B, color.A);
-}
-
-void CubismModel::SetPartColor(
-    csmUint32 partIndex,
-    csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a,
-    csmVector<ColorData>& partColors,
-    csmVector<ColorData>& drawableColors)
-{
-    partColors[partIndex].Color.R = r;
-    partColors[partIndex].Color.G = g;
-    partColors[partIndex].Color.B = b;
-    partColors[partIndex].Color.A = a;
-
-    if (partColors[partIndex].IsOverridden)
-    {
-        for (csmUint32 i = 0; i < _partChildDrawables[partIndex].GetSize(); ++i)
-        {
-            csmUint32 drawableIndex = _partChildDrawables[partIndex][i];
-            drawableColors[drawableIndex].Color.R = r;
-            drawableColors[drawableIndex].Color.G = g;
-            drawableColors[drawableIndex].Color.B = b;
-            drawableColors[drawableIndex].Color.A = a;
-        }
-    }
-}
-
-void CubismModel::SetPartMultiplyColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
-{
-    SetPartColor(partIndex, r, g, b, a, _userPartMultiplyColors, _userDrawableMultiplyColors);
-}
-
-void CubismModel::SetPartScreenColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
-{
-    SetPartScreenColor(partIndex, color.R, color.G, color.B, color.A);
-}
-
-void CubismModel::SetPartScreenColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
-{
-    SetPartColor(partIndex, r, g, b, a, _userPartScreenColors, _userDrawableScreenColors);
-}
-
-Rendering::CubismRenderer::CubismTextureColor CubismModel::GetMultiplyColorOffscreen(csmInt32 offscreenIndex) const
-{
-    if (GetOverrideFlagForModelMultiplyColors() || GetOverrideFlagForOffscreenMultiplyColors(offscreenIndex))
-    {
-        return _userOffscreenMultiplyColors[offscreenIndex].Color;
-    }
-    const Core::csmVector4 tmpColor = GetOffscreenMultiplyColor(offscreenIndex);
-
-    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
-}
-
-Rendering::CubismRenderer::CubismTextureColor CubismModel::GetScreenColorOffscreen(csmInt32 offscreenIndex) const
-{
-    if (GetOverrideFlagForModelScreenColors() || GetOverrideFlagForOffscreenScreenColors(offscreenIndex))
-    {
-        return _userOffscreenScreenColors[offscreenIndex].Color;
-    }
-    const Core::csmVector4 tmpColor = GetOffscreenScreenColor(offscreenIndex);
-
-    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
-}
-
-void CubismModel::SetMultiplyColorOffscreen(csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
-{
-    SetMultiplyColorOffscreen(offscreenIndex, color.R, color.G, color.B, color.A);
-}
-
-void CubismModel::SetMultiplyColorOffscreen(csmInt32 offscreenIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
-{
-    _userOffscreenMultiplyColors[offscreenIndex].Color.R = r;
-    _userOffscreenMultiplyColors[offscreenIndex].Color.G = g;
-    _userOffscreenMultiplyColors[offscreenIndex].Color.B = b;
-    _userOffscreenMultiplyColors[offscreenIndex].Color.A = a;
-}
-
-void CubismModel::SetScreenColorOffscreen(csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
-{
-    SetScreenColorOffscreen(offscreenIndex, color.R, color.G, color.B, color.A);
-}
-
-void CubismModel::SetScreenColorOffscreen(csmInt32 offscreenIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a)
-{
-    _userOffscreenScreenColors[offscreenIndex].Color.R = r;
-    _userOffscreenScreenColors[offscreenIndex].Color.G = g;
-    _userOffscreenScreenColors[offscreenIndex].Color.B = b;
-    _userOffscreenScreenColors[offscreenIndex].Color.A = a;
-}
-
 csmBool CubismModel::GetOverrideFlagForModelParameterRepeat() const
 {
     return _isOverriddenParameterRepeat;
@@ -1187,192 +939,14 @@ void CubismModel::SetRepeatFlagForParameterRepeat(csmInt32 parameterIndex, csmBo
     _userParameterRepeatDataList[parameterIndex].IsParameterRepeated = value;
 }
 
-csmBool CubismModel::GetOverwriteFlagForModelMultiplyColors() const
+CubismModelMultiplyAndScreenColor& CubismModel::GetOverrideMultiplyAndScreenColor()
 {
-    CubismLogWarning("GetOverwriteFlagForModelMultiplyColors() is a deprecated function. Please use GetOverrideFlagForModelMultiplyColors().");
-
-    return GetOverrideFlagForModelMultiplyColors();
+    return _overrideMultiplyAndScreenColors;
 }
 
-csmBool CubismModel::GetOverrideFlagForModelMultiplyColors() const
+const CubismModelMultiplyAndScreenColor& CubismModel::GetOverrideMultiplyAndScreenColor() const
 {
-    return _isOverriddenModelMultiplyColors;
-}
-
-csmBool CubismModel::GetOverwriteFlagForModelScreenColors() const
-{
-    CubismLogWarning("GetOverwriteFlagForModelScreenColors() is a deprecated function. Please use GetOverrideFlagForModelScreenColors().");
-
-    return GetOverrideFlagForModelScreenColors();
-}
-
-csmBool CubismModel::GetOverrideFlagForModelScreenColors() const
-{
-    return _isOverriddenModelScreenColors;
-}
-
-void CubismModel::SetOverwriteFlagForModelMultiplyColors(csmBool value)
-{
-    CubismLogWarning("SetOverwriteFlagForModelMultiplyColors(csmBool value) is a deprecated function. Please use SetOverrideFlagForModelMultiplyColors(csmBool value).");
-
-    SetOverrideFlagForModelMultiplyColors(value);
-}
-
-void CubismModel::SetOverrideFlagForModelMultiplyColors(csmBool value)
-{
-    _isOverriddenModelMultiplyColors = value;
-}
-
-void CubismModel::SetOverwriteFlagForModelScreenColors(csmBool value)
-{
-    CubismLogWarning("SetOverwriteFlagForModelScreenColors(csmBool value) is a deprecated function. Please use SetOverrideFlagForModelScreenColors(csmBool value).");
-
-    SetOverrideFlagForModelScreenColors(value);
-}
-
-void CubismModel::SetOverrideFlagForModelScreenColors(csmBool value)
-{
-    _isOverriddenModelScreenColors = value;
-}
-
-csmBool CubismModel::GetOverwriteFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const
-{
-    CubismLogWarning("GetOverwriteFlagForDrawableMultiplyColors(csmInt32 drawableIndex) is a deprecated function. Please use GetOverrideFlagForDrawableMultiplyColors(csmInt32 drawableIndex).");
-
-    return GetOverrideFlagForDrawableMultiplyColors(drawableIndex);
-}
-
-csmBool CubismModel::GetOverrideFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const
-{
-    return _userDrawableMultiplyColors[drawableIndex].IsOverridden;
-}
-
-csmBool CubismModel::GetOverwriteFlagForDrawableScreenColors(csmInt32 drawableIndex) const
-{
-    CubismLogWarning("GetOverwriteFlagForDrawableScreenColors(csmInt32 drawableIndex) is a deprecated function. Please use GetOverrideFlagForDrawableScreenColors(csmInt32 drawableIndex).");
-
-    return GetOverrideFlagForDrawableScreenColors(drawableIndex);
-}
-
-csmBool CubismModel::GetOverrideFlagForDrawableScreenColors(csmInt32 drawableIndex) const
-{
-    return _userDrawableScreenColors[drawableIndex].IsOverridden;
-}
-
-void CubismModel::SetOverwriteFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value)
-{
-    CubismLogWarning("SetOverwriteFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value) is a deprecated function. Please use SetOverrideFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value).");
-
-    SetOverrideFlagForDrawableMultiplyColors(drawableIndex, value);
-}
-
-void CubismModel::SetOverrideFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value)
-{
-    _userDrawableMultiplyColors[drawableIndex].IsOverridden = value;
-}
-
-void CubismModel::SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value)
-{
-    CubismLogWarning("SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value) is a deprecated function. Please use SetOverrideFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value).");
-
-    SetOverrideFlagForDrawableScreenColors(drawableIndex, value);
-}
-
-void CubismModel::SetOverrideFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value)
-{
-    _userDrawableScreenColors[drawableIndex].IsOverridden = value;
-}
-
-csmBool CubismModel::GetOverwriteColorForPartMultiplyColors(csmInt32 partIndex) const
-{
-    CubismLogWarning("GetOverwriteColorForPartMultiplyColors(csmInt32 partIndex) is a deprecated function. Please use GetOverrideColorForPartMultiplyColors(csmInt32 partIndex).");
-
-    return GetOverrideColorForPartMultiplyColors(partIndex);
-}
-
-csmBool CubismModel::GetOverrideColorForPartMultiplyColors(csmInt32 partIndex) const
-{
-    return _userPartMultiplyColors[partIndex].IsOverridden;
-}
-
-csmBool CubismModel::GetOverwriteColorForPartScreenColors(csmInt32 partIndex) const
-{
-    CubismLogWarning("GetOverwriteColorForPartScreenColors(csmInt32 partIndex) is a deprecated function. Please use GetOverrideColorForPartScreenColors(csmInt32 partIndex).");
-
-    return GetOverrideColorForPartScreenColors(partIndex);
-}
-
-csmBool CubismModel::GetOverrideColorForPartScreenColors(csmInt32 partIndex) const
-{
-    return _userPartScreenColors[partIndex].IsOverridden;
-}
-
-void CubismModel::SetOverrideColorForPartColors(
-    csmUint32 partIndex,
-    csmBool value,
-    csmVector<ColorData>& partColors,
-    csmVector<ColorData>& drawableColors)
-{
-    partColors[partIndex].IsOverridden = value;
-
-    for (csmUint32 i = 0; i < _partChildDrawables[partIndex].GetSize(); ++i)
-    {
-        csmUint32 drawableIndex = _partChildDrawables[partIndex][i];
-        drawableColors[drawableIndex].IsOverridden = value;
-        if (value)
-        {
-            drawableColors[drawableIndex].Color.R = partColors[partIndex].Color.R;
-            drawableColors[drawableIndex].Color.G = partColors[partIndex].Color.G;
-            drawableColors[drawableIndex].Color.B = partColors[partIndex].Color.B;
-            drawableColors[drawableIndex].Color.A = partColors[partIndex].Color.A;
-        }
-    }
-}
-
-void CubismModel::SetOverwriteColorForPartMultiplyColors(csmUint32 partIndex, csmBool value)
-{
-    CubismLogWarning("SetOverwriteColorForPartMultiplyColors(csmUint32 partIndex, csmBool value) is a deprecated function. Please use SetOverrideColorForPartMultiplyColors(csmUint32 partIndex, csmBool value).");
-
-    SetOverrideColorForPartMultiplyColors(partIndex, value);
-}
-
-void CubismModel::SetOverrideColorForPartMultiplyColors(csmUint32 partIndex, csmBool value)
-{
-    _userPartMultiplyColors[partIndex].IsOverridden = value;
-    SetOverrideColorForPartColors(partIndex, value, _userPartMultiplyColors, _userDrawableMultiplyColors);
-}
-
-void CubismModel::SetOverwriteColorForPartScreenColors(csmUint32 partIndex, csmBool value)
-{
-    CubismLogWarning("SetOverwriteColorForPartScreenColors(csmUint32 partIndex, csmBool value) is a deprecated function. Please use SetOverrideColorForPartScreenColors(csmUint32 partIndex, csmBool value).");
-
-    SetOverrideColorForPartScreenColors(partIndex, value);
-}
-
-void CubismModel::SetOverrideColorForPartScreenColors(csmUint32 partIndex, csmBool value)
-{
-    _userPartScreenColors[partIndex].IsOverridden = value;
-    SetOverrideColorForPartColors(partIndex, value, _userPartScreenColors, _userDrawableScreenColors);
-}
-
-csmBool CubismModel::GetOverrideFlagForOffscreenMultiplyColors(csmInt32 offscreenIndex) const
-{
-    return _userOffscreenMultiplyColors[offscreenIndex].IsOverridden;
-}
-
-csmBool CubismModel::GetOverrideFlagForOffscreenScreenColors(csmInt32 offscreenIndex) const
-{
-    return _userOffscreenScreenColors[offscreenIndex].IsOverridden;
-}
-
-void CubismModel::SetOverrideFlagForOffscreenMultiplyColors(csmUint32 offscreenIndex, csmBool value)
-{
-    _userOffscreenMultiplyColors[offscreenIndex].IsOverridden = value;
-}
-
-void CubismModel::SetOverrideFlagForOffscreenScreenColors(csmUint32 offscreenIndex, csmBool value)
-{
-    _userOffscreenScreenColors[offscreenIndex].IsOverridden = value;
+    return _overrideMultiplyAndScreenColors;
 }
 
 csmInt32 CubismModel::GetDrawableCulling(csmInt32 drawableIndex) const
@@ -1407,23 +981,9 @@ void CubismModel::SetOffscreenCulling(csmInt32 offscreenIndex, csmInt32 isCullin
     _userOffscreenCullings[offscreenIndex].IsCulling = isCulling;
 }
 
-csmBool CubismModel::GetOverwriteFlagForModelCullings() const
-{
-    CubismLogWarning("GetOverwriteFlagForModelCullings() is a deprecated function. Please use GetOverrideFlagForModelCullings().");
-
-    return GetOverrideFlagForModelCullings();
-}
-
 csmBool CubismModel::GetOverrideFlagForModelCullings() const
 {
     return _isOverriddenCullings;
-}
-
-void CubismModel::SetOverwriteFlagForModelCullings(csmBool value)
-{
-    CubismLogWarning("SetOverwriteFlagForModelCullings(csmBool value) is a deprecated function. Please use SetOverrideFlagForModelCullings(csmBool value).");
-
-    SetOverrideFlagForModelCullings(value);
 }
 
 void CubismModel::SetOverrideFlagForModelCullings(csmBool value)
@@ -1431,23 +991,9 @@ void CubismModel::SetOverrideFlagForModelCullings(csmBool value)
     _isOverriddenCullings = value;
 }
 
-csmBool CubismModel::GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex) const
-{
-    CubismLogWarning("GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex) is a deprecated function. Please use GetOverrideFlagForDrawableCullings(csmInt32 drawableIndex).");
-
-    return GetOverrideFlagForDrawableCullings(drawableIndex);
-}
-
 csmBool CubismModel::GetOverrideFlagForDrawableCullings(csmInt32 drawableIndex) const
 {
     return _userDrawableCullings[drawableIndex].IsOverridden;
-}
-
-void CubismModel::SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value)
-{
-    CubismLogWarning("SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value) is a deprecated function. Please use SetOverrideFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value).");
-
-    SetOverrideFlagForDrawableCullings(drawableIndex, value);
 }
 
 void CubismModel::SetOverrideFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value)
@@ -1535,7 +1081,7 @@ void CubismModel::GetPartChildDrawObjects(csmInt32 partInfoIndex)
     }
 }
 
-csmVector<CubismModel::CubismModelPartInfo> CubismModel::GetPartsHierarchy() const
+csmVector<CubismModelPartInfo> CubismModel::GetPartsHierarchy() const
 {
     return _partsHierarchy;
 }

--- a/src/Model/CubismModel.hpp
+++ b/src/Model/CubismModel.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "CubismFramework.hpp"
+#include "CubismModelMultiplyAndScreenColor.hpp"
 #include "Rendering/csmBlendMode.hpp"
 #include "Type/csmMap.hpp"
 #include "Type/csmVector.hpp"
@@ -17,6 +18,126 @@
 namespace Live2D { namespace Cubism { namespace Framework {
 
 class CubismMoc;
+
+/**
+ * Information for a Cubism model object.
+ */
+struct CubismModelObjectInfo
+{
+    /**
+     * type used in object information
+     */
+    enum ObjectType
+    {
+        ObjectType_Drawable = 0,
+        ObjectType_Parts = 1
+    };
+
+    /**
+     * Constructor.
+     *
+     * @param objectIndex index of the object
+     * @param type type of the object (Drawable or Parts)
+     */
+    CubismModelObjectInfo(csmUint32 objectIndex, ObjectType type)
+        : ObjectIndex(objectIndex)
+        , ObjectType(type)
+    {
+    }
+
+    /**
+     * Destructor
+     */
+    ~CubismModelObjectInfo()
+    {
+    }
+
+    ObjectType ObjectType;  ///< Type of the object (Drawable or Parts)
+    csmUint32 ObjectIndex;  ///< Index of the object
+};
+
+/**
+ * Information for part child draw objects.
+ */
+struct PartChildDrawObjects
+{
+    /**
+     * Constructor
+     */
+    PartChildDrawObjects()
+        : DrawableIndices()
+        , OffscreenIndices()
+    {
+    }
+    /**
+     * Constructor
+     *
+     * @param drawableIndices collection of Drawable indices
+     * @param offscreenIndices collection of Offscreen indices
+     */
+    PartChildDrawObjects(csmVector<csmUint32> drawableIndices, csmVector<csmUint32> offscreenIndices)
+        : DrawableIndices(drawableIndices)
+        , OffscreenIndices(offscreenIndices)
+    {
+    }
+
+    /**
+     * Destructor.
+     */
+    ~PartChildDrawObjects()
+    {
+    }
+
+    csmVector<csmUint32> DrawableIndices;  ///< Collection of Drawable indices
+    csmVector<csmUint32> OffscreenIndices; ///< Collection of Offscreen indices
+};
+
+/**
+ * Information for a Cubism model part.
+ */
+struct CubismModelPartInfo
+{
+    /**
+     * Constructor
+     */
+    CubismModelPartInfo()
+        : Objects()
+        , ChildDrawObjects()
+    {
+    }
+
+    /**
+     * Constructor
+     *
+     * @param objects collection of CubismModelObjectInfo
+     * @param childDrawObjects information of part child draw objects
+     */
+    CubismModelPartInfo(csmVector<CubismModelObjectInfo> objects, PartChildDrawObjects childDrawObjects)
+        : Objects(objects)
+        , ChildDrawObjects(childDrawObjects)
+    {
+    }
+
+    /**
+     * Destructor
+     */
+    ~CubismModelPartInfo()
+    {
+    }
+
+    csmVector<CubismModelObjectInfo> Objects; ///< Collection of object information
+    PartChildDrawObjects ChildDrawObjects;    ///< Information of part child draw objects
+
+    /**
+     * Returns the number of child objects.
+     *
+     * @return Number of child objects
+     */
+    csmInt32 GetChildObjectCount() const
+    {
+        return static_cast<csmInt32>(Objects.GetSize());
+    }
+};
 
 /**
  * Handles models created from MOC data.
@@ -29,43 +150,6 @@ public:
     {
         CubismNoIndex_Parent = -1,    ///< Index value when no parent exists.
         CubismNoIndex_Offscreen = -1  ///< Index value when no referenced offscreen exists.
-    };
-
-    /**
-     * Structure for color information of drawing object
-     */
-    struct ColorData
-    {
-        /**
-         * Constructor
-         */
-        ColorData()
-            : IsOverridden(false)
-            , Color()
-        {
-        }
-
-        /**
-         * Constructor
-         *
-         * @param isOverridden whether to be overridden
-         * @param color Texture color
-         */
-        ColorData(csmBool isOverridden, Rendering::CubismRenderer::CubismTextureColor color)
-            : IsOverridden(isOverridden)
-            , Color(color)
-        {
-        }
-
-        /**
-         * Destructor
-         */
-        ~ColorData()
-        {
-        }
-
-        csmBool IsOverridden;                                      ///< Whether to be overridden
-        Rendering::CubismRenderer::CubismTextureColor Color;        ///< Color
     };
 
     /**
@@ -106,121 +190,6 @@ public:
     };
 
     /**
-     * (deprecated) Structure for color information of drawing object
-     */
-    struct DrawableColorData
-    {
-        /**
-         * Constructor
-         */
-        DrawableColorData()
-            : IsOverridden(false)
-            , Color()
-        {
-        }
-
-        /**
-         * Constructor
-         *
-         * @param isOverridden whether to be overridden
-         * @param color Texture color
-         */
-        DrawableColorData(csmBool isOverridden, Rendering::CubismRenderer::CubismTextureColor color)
-            : IsOverridden(isOverridden)
-            , Color(color)
-        {
-        }
-
-        /**
-         * Destructor
-         */
-        virtual ~DrawableColorData()
-        {
-        }
-
-        csmBool IsOverwritten;                                     ///< (deprecated) Whether to be overwritten
-        csmBool IsOverridden;                                      ///< Whether to be overridden
-        Rendering::CubismRenderer::CubismTextureColor Color;        ///< Color
-
-    };
-
-    /**
-     * (deprecated) Structure to manage texture culling settings
-     */
-    struct DrawableCullingData
-    {
-        /**
-         * Constructor
-         */
-        DrawableCullingData()
-            : IsOverridden(false)
-            , IsCulling(0)
-        {
-        }
-
-        /**
-         * Constructor
-         *
-         * @param isOverridden whether to be overridden
-         * @param isCulling Culling information
-         */
-        DrawableCullingData(csmBool isOverridden, csmInt32 isCulling)
-            : IsOverridden(isOverridden)
-            , IsCulling(isCulling)
-        {
-        }
-
-        /**
-         * Destructor
-         */
-        ~DrawableCullingData()
-        {
-        }
-
-        csmBool IsOverwritten;      ///< (deprecated) Whether to be overwritten
-        csmBool IsOverridden;      ///< Whether to be overridden
-        csmInt32 IsCulling;         ///< Culling information
-    };
-
-    /**
-     * (deprecated) Structure to handle texture color in RGBA
-     */
-    struct PartColorData
-    {
-        /**
-         * Constructor
-         */
-        PartColorData()
-            : IsOverridden(false)
-            , Color()
-        {
-        }
-
-        /**
-         * Constructor
-         *
-         * @param isOverridden whether to be overridden
-         * @param color Texture color
-         */
-        PartColorData(csmBool isOverridden, Rendering::CubismRenderer::CubismTextureColor color)
-            : IsOverridden(isOverridden)
-            , Color(color)
-        {
-        }
-
-        /**
-         * Destructor
-         */
-        virtual ~PartColorData()
-        {
-        }
-
-        csmBool IsOverwritten;                                     ///< (deprecated) Whether to be overwritten
-        csmBool IsOverridden;                                      ///< Whether to be overridden
-        Rendering::CubismRenderer::CubismTextureColor Color;        ///< Color
-    };
-
-    /**
      * Structure for managing the override of parameter repetition settings
      */
     struct ParameterRepeatData
@@ -258,165 +227,44 @@ public:
     };
 
     /**
-     * Information for part child draw objects.
-     */
-    struct PartChildDrawObjects
-    {
-        /**
-         * Constructor
-         */
-        PartChildDrawObjects()
-            : DrawableIndices()
-            , OffscreenIndices()
-        {
-        }
-        /**
-         * Constructor
-         *
-         * @param drawableIndices collection of Drawable indices
-         * @param offscreenIndices collection of Offscreen indices
-         */
-        PartChildDrawObjects(csmVector<csmUint32> drawableIndices, csmVector<csmUint32> offscreenIndices)
-            : DrawableIndices(drawableIndices)
-            , OffscreenIndices(offscreenIndices)
-        {
-        }
-
-        /**
-         * Destructor.
-         */
-        ~PartChildDrawObjects()
-        {
-        }
-
-        csmVector<csmUint32> DrawableIndices;  ///< Collection of Drawable indices
-        csmVector<csmUint32> OffscreenIndices; ///< Collection of Offscreen indices
-
-    };
-
-    /**
-     * Information for a Cubism model object.
-     */
-    struct CubismModelObjectInfo
-    {
-        /**
-         * type used in object information
-         */
-        enum ObjectType
-        {
-            ObjectType_Drawable = 0,
-            ObjectType_Parts = 1
-        };
-
-        /**
-         * Constructor.
-         *
-         * @param objectIndex index of the object
-         * @param type type of the object (Drawable or Parts)
-         */
-        CubismModelObjectInfo(csmUint32 objectIndex, ObjectType type)
-            : ObjectIndex(objectIndex)
-            , ObjectType(type)
-        {
-        }
-
-        /**
-         * Destructor
-         */
-        ~CubismModelObjectInfo()
-        {
-        }
-
-        ObjectType ObjectType;  ///< Type of the object (Drawable or Parts)
-        csmUint32 ObjectIndex;  ///< Index of the object
-    };
-
-    /**
-     * Information for a Cubism model part.
-     */
-    struct CubismModelPartInfo
-    {
-        /**
-         * Constructor
-         */
-        CubismModelPartInfo()
-            : Objects()
-            , ChildDrawObjects()
-        {
-        }
-
-        /**
-         * Constructor
-         *
-         * @param objects collection of CubismModelObjectInfo
-         * @param childDrawObjects information of part child draw objects
-         */
-        CubismModelPartInfo(csmVector<CubismModelObjectInfo> objects, PartChildDrawObjects childDrawObjects)
-            : Objects(objects)
-            , ChildDrawObjects(childDrawObjects)
-        {
-        }
-
-        /**
-         * Destructor
-         */
-        ~CubismModelPartInfo()
-        {
-        }
-
-        csmVector<CubismModelObjectInfo> Objects; ///< Collection of object information
-        PartChildDrawObjects ChildDrawObjects;    ///< Information of part child draw objects
-
-        /**
-         * Returns the number of child objects.
-         *
-         * @return Number of child objects
-         */
-        csmInt32 GetChildObjectCount() const
-        {
-            return static_cast<csmInt32>(Objects.GetSize());
-        }
-    };
-
-    /**
      * Calculates and updates the model state based on the set parameters.
      */
-    void    Update() const;
+    void Update() const;
 
     /**
      * Returns the width of the canvas.
      *
      * @return Width of the canvas in pixels
      */
-    csmFloat32  GetCanvasWidthPixel() const;
+    csmFloat32 GetCanvasWidthPixel() const;
 
     /**
      * Returns the height of the canvas.
      *
      * @return Height of the canvas in pixels
      */
-    csmFloat32  GetCanvasHeightPixel() const;
+    csmFloat32 GetCanvasHeightPixel() const;
 
     /**
      * Returns the pixels per unit (PPU).
      *
      * @return Pixels per unit
      */
-    csmFloat32  GetPixelsPerUnit() const;
+    csmFloat32 GetPixelsPerUnit() const;
 
     /**
      * Returns the width of the canvas.
      *
      * @return Width of the canvas in PPU (pixels per unit)
      */
-    csmFloat32  GetCanvasWidth() const;
+    csmFloat32 GetCanvasWidth() const;
 
     /**
      * Returns the height of the canvas.
      *
      * @return Height of the canvas in PPU (pixels per unit)
      */
-    csmFloat32  GetCanvasHeight() const;
+    csmFloat32 GetCanvasHeight() const;
 
     /**
      * Returns the list of object render orders.
@@ -436,7 +284,7 @@ public:
      *
      * @return Index of the part
      */
-    csmInt32    GetPartIndex(CubismIdHandle partId);
+    csmInt32 GetPartIndex(CubismIdHandle partId);
 
     /**
      * Returns the ID of the part.
@@ -444,14 +292,14 @@ public:
      * @param partIndex Index of the part
      * @return Part ID
      */
-    CubismIdHandle    GetPartId(csmUint32 partIndex);
+    CubismIdHandle GetPartId(csmUint32 partIndex);
 
     /**
      * Returns the number of parts.
      *
      * @return Number of parts
      */
-    csmInt32    GetPartCount() const;
+    csmInt32 GetPartCount() const;
 
     /**
      * Returns the index of the parent parts for the parts.
@@ -473,7 +321,7 @@ public:
      * @param partId Part ID
      * @param opacity Opacity
      */
-    void        SetPartOpacity(CubismIdHandle partId, csmFloat32 opacity);
+    void SetPartOpacity(CubismIdHandle partId, csmFloat32 opacity);
 
     /**
      * Sets the opacity of the part.
@@ -481,7 +329,7 @@ public:
      * @param partIndex Part index
      * @param opacity Part opacity
      */
-    void        SetPartOpacity(csmInt32 partIndex, csmFloat32 opacity);
+    void SetPartOpacity(csmInt32 partIndex, csmFloat32 opacity);
 
     /**
      * Returns the opacity of the part.
@@ -490,7 +338,7 @@ public:
      *
      * @return Part opacity
      */
-    csmFloat32  GetPartOpacity(CubismIdHandle partId);
+    csmFloat32 GetPartOpacity(CubismIdHandle partId);
 
     /**
      * Returns the opacity of the part.
@@ -499,7 +347,7 @@ public:
      *
      * @return Part opacity
      */
-    csmFloat32  GetPartOpacity(csmInt32 partIndex);
+    csmFloat32 GetPartOpacity(csmInt32 partIndex);
 
     /**
      * Returns the index of the parent part of the part.
@@ -535,7 +383,7 @@ public:
      *
      * @return Parameter index
      */
-    csmInt32    GetParameterIndex(CubismIdHandle parameterId);
+    csmInt32 GetParameterIndex(CubismIdHandle parameterId);
 
     /**
      * Returns the ID of the parameter
@@ -545,14 +393,14 @@ public:
      * @param parameterIndex Index of the parameter
      * @return Parameter ID
      */
-    CubismIdHandle    GetParameterId(csmUint32 parameterIndex);
+    CubismIdHandle GetParameterId(csmUint32 parameterIndex);
 
     /**
      * Returns the number of parameters.
      *
      * @return Number of parameters
      */
-    csmInt32    GetParameterCount() const;
+    csmInt32 GetParameterCount() const;
 
     /**
      * Returns the type of the parameter.
@@ -570,7 +418,7 @@ public:
      *
      * @return Maximum value of the parameter
      */
-    csmFloat32  GetParameterMaximumValue(csmUint32 parameterIndex) const;
+    csmFloat32 GetParameterMaximumValue(csmUint32 parameterIndex) const;
 
     /**
      * Returns the minimum value of the parameter.
@@ -579,7 +427,7 @@ public:
      *
      * @return Minimum value of the parameter
      */
-    csmFloat32  GetParameterMinimumValue(csmUint32 parameterIndex) const;
+    csmFloat32 GetParameterMinimumValue(csmUint32 parameterIndex) const;
 
     /**
      * Returns the default value of the parameter.
@@ -588,7 +436,7 @@ public:
      *
      * @return Default value of the parameter
      */
-    csmFloat32  GetParameterDefaultValue(csmUint32 parameterIndex) const;
+    csmFloat32 GetParameterDefaultValue(csmUint32 parameterIndex) const;
 
     /**
      * Returns the value of the parameter.
@@ -597,7 +445,7 @@ public:
      *
      * @return Parameter value
      */
-    csmFloat32  GetParameterValue(CubismIdHandle parameterId);
+    csmFloat32 GetParameterValue(CubismIdHandle parameterId);
 
     /**
      * Returns the value of the parameter.
@@ -606,7 +454,7 @@ public:
      *
      * @return Parameter value
      */
-    csmFloat32  GetParameterValue(csmInt32 parameterIndex);
+    csmFloat32 GetParameterValue(csmInt32 parameterIndex);
 
     /**
      * Sets the value of the parameter.
@@ -615,7 +463,7 @@ public:
      * @param value Parameter value
      * @param weight Weight
      */
-    void        SetParameterValue(CubismIdHandle parameterId, csmFloat32 value, csmFloat32 weight = 1.0f);
+    void SetParameterValue(CubismIdHandle parameterId, csmFloat32 value, csmFloat32 weight = 1.0f);
 
     /**
      * Sets the value of the parameter.
@@ -624,7 +472,7 @@ public:
      * @param value Parameter value
      * @param weight Weight
      */
-    void        SetParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
+    void SetParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
 
     /**
      * Gets whether the parameter has the repeat setting.
@@ -671,7 +519,7 @@ public:
      * @param value Value to be added
      * @param weight Weight
      */
-    void        AddParameterValue(CubismIdHandle parameterId, csmFloat32 value, csmFloat32 weight = 1.0f);
+    void AddParameterValue(CubismIdHandle parameterId, csmFloat32 value, csmFloat32 weight = 1.0f);
 
     /**
      * Adds to the value of the parameter.
@@ -680,7 +528,7 @@ public:
      * @param value Value to be added
      * @param weight Weight
      */
-    void        AddParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
+    void AddParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
 
     /**
      * Multiplies the value of the parameter.
@@ -689,7 +537,7 @@ public:
      * @param value Value to be multiplied
      * @param weight Weight
      */
-    void        MultiplyParameterValue(CubismIdHandle parameterId, csmFloat32 value, csmFloat32 weight = 1.0f);
+    void MultiplyParameterValue(CubismIdHandle parameterId, csmFloat32 value, csmFloat32 weight = 1.0f);
 
     /**
      * Multiplies the value of the parameter.
@@ -698,7 +546,7 @@ public:
      * @param value Value to be multiplied
      * @param weight Weight
      */
-    void        MultiplyParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
+    void MultiplyParameterValue(csmInt32 parameterIndex, csmFloat32 value, csmFloat32 weight = 1.0f);
 
     //========================================================
     //  Drawable Functions.
@@ -711,14 +559,14 @@ public:
      *
      * @return Index of the drawable
      */
-    csmInt32            GetDrawableIndex(CubismIdHandle drawableId) const;
+    csmInt32 GetDrawableIndex(CubismIdHandle drawableId) const;
 
     /**
      * Returns the number of drawables.
      *
      * @return Number of drawables
      */
-    csmInt32            GetDrawableCount() const;
+    csmInt32 GetDrawableCount() const;
 
     /**
      * Returns the ID of the drawable.
@@ -727,18 +575,7 @@ public:
      *
      * @return Drawable ID
      */
-    CubismIdHandle      GetDrawableId(csmInt32 drawableIndex) const;
-
-    /**
-     * Returns the list of texture indices attached to the drawable.
-     *
-     * @deprecated This function is deprecated due to a naming error, use GetDrawableTextureIndex instead.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return List of texture indices
-     */
-    csmInt32            GetDrawableTextureIndices(csmInt32 drawableIndex) const;
+    CubismIdHandle GetDrawableId(csmInt32 drawableIndex) const;
 
     /**
      * Returns the texture index attached to the drawable.
@@ -747,7 +584,7 @@ public:
      *
      * @return Texture index attached to the drawable
      */
-    csmInt32            GetDrawableTextureIndex(csmInt32 drawableIndex) const;
+    csmInt32 GetDrawableTextureIndex(csmInt32 drawableIndex) const;
 
     /**
      * Returns the number of vertex indices in the drawable.
@@ -756,7 +593,7 @@ public:
      *
      * @return Number of vertex indices in the drawable
      */
-    csmInt32            GetDrawableVertexIndexCount(csmInt32 drawableIndex) const;
+    csmInt32 GetDrawableVertexIndexCount(csmInt32 drawableIndex) const;
 
     /**
      * Returns the number of vertices in the drawable.
@@ -765,7 +602,7 @@ public:
      *
      * @return Number of vertices in the drawable
      */
-    csmInt32            GetDrawableVertexCount(csmInt32 drawableIndex) const;
+    csmInt32 GetDrawableVertexCount(csmInt32 drawableIndex) const;
 
     /**
      * Returns the list of vertices in the drawable.
@@ -774,7 +611,7 @@ public:
      *
      * @return List of vertices in the drawable
      */
-    const csmFloat32*   GetDrawableVertices(csmInt32 drawableIndex) const;
+    const csmFloat32* GetDrawableVertices(csmInt32 drawableIndex) const;
 
     /**
      * Returns the list of vertex indices in the drawable.
@@ -783,7 +620,7 @@ public:
      *
      * @return List of vertex indices in the drawable
      */
-    const csmUint16*            GetDrawableVertexIndices(csmInt32 drawableIndex) const;
+    const csmUint16* GetDrawableVertexIndices(csmInt32 drawableIndex) const;
 
     /**
      * Returns the list of vertices in the drawable.
@@ -792,7 +629,7 @@ public:
      *
      * @return List of vertices in the drawable
      */
-    const Core::csmVector2*     GetDrawableVertexPositions(csmInt32 drawableIndex) const;
+    const Core::csmVector2* GetDrawableVertexPositions(csmInt32 drawableIndex) const;
 
     /**
      * Returns the list of vertex UVs in the drawable.
@@ -801,7 +638,7 @@ public:
      *
      * @return List of vertex UVs in the drawable
      */
-    const Core::csmVector2*     GetDrawableVertexUvs(csmInt32 drawableIndex) const;
+    const Core::csmVector2* GetDrawableVertexUvs(csmInt32 drawableIndex) const;
 
     /**
      * Returns the opacity of the drawable.
@@ -810,7 +647,7 @@ public:
      *
      * @return Opacity of the drawable
      */
-    csmFloat32                  GetDrawableOpacity(csmInt32 drawableIndex) const;
+    csmFloat32 GetDrawableOpacity(csmInt32 drawableIndex) const;
 
     /**
      * Returns the multiply color of the drawable.
@@ -842,17 +679,6 @@ public:
     /**
      * Returns the blend mode of the drawable.
      *
-     * @deprecated This function is deprecated due to a naming change, use GetDrawableBlendModeType instead.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return Blend mode of the drawable
-     */
-    Rendering::CubismRenderer::CubismBlendMode   GetDrawableBlendMode(csmInt32 drawableIndex) const;
-
-    /**
-     * Returns the blend mode of the drawable.
-     *
      * @param drawableIndex Drawable index
      *
      * @return Blend mode of the drawable
@@ -877,7 +703,7 @@ public:
      *
      * @return Visibility state of the drawable. true if visible.
      */
-    csmBool                  GetDrawableDynamicFlagIsVisible(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagIsVisible(csmInt32 drawableIndex) const;
 
     /**
      * Returns whether the visibility state of the drawable has changed from the dynamic flag.
@@ -886,7 +712,7 @@ public:
      *
      * @return true if the visibility state of the drawable has changed.
      */
-    csmBool                  GetDrawableDynamicFlagVisibilityDidChange(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagVisibilityDidChange(csmInt32 drawableIndex) const;
 
     /**
      * Returns whether the opacity of the drawable has changed from the dynamic flag.
@@ -895,7 +721,7 @@ public:
      *
      * @return true if the opacity of the drawable has changed.
      */
-    csmBool                  GetDrawableDynamicFlagOpacityDidChange(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagOpacityDidChange(csmInt32 drawableIndex) const;
 
     /**
      * Returns whether the draw order of the drawable has changed from the dynamic flag.
@@ -906,7 +732,7 @@ public:
      *
      * @note Draw order is information specified from 0 to 1000 on the ArtMesh.
      */
-    csmBool                  GetDrawableDynamicFlagDrawOrderDidChange(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagDrawOrderDidChange(csmInt32 drawableIndex) const;
 
     /**
      * Returns whether the render order of the drawable has changed from the dynamic flag.
@@ -915,7 +741,7 @@ public:
      *
      * @return true if the render order of the drawable has changed.
      */
-    csmBool                  GetDrawableDynamicFlagRenderOrderDidChange(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagRenderOrderDidChange(csmInt32 drawableIndex) const;
 
     /**
      * Returns whether the vertex information of the drawable has changed from the dynamic flag.
@@ -924,7 +750,7 @@ public:
      *
      * @return true if the vertex information of the drawable has changed.
      */
-    csmBool                  GetDrawableDynamicFlagVertexPositionsDidChange(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagVertexPositionsDidChange(csmInt32 drawableIndex) const;
 
     /**
      * Returns whether the multiply or screen color of the drawable has changed from the dynamic flag.
@@ -933,21 +759,21 @@ public:
      *
      * @return true if the multiply or screen color of the drawable has changed.
      */
-    csmBool                  GetDrawableDynamicFlagBlendColorDidChange(csmInt32 drawableIndex) const;
+    csmBool GetDrawableDynamicFlagBlendColorDidChange(csmInt32 drawableIndex) const;
 
     /**
      * Returns the list of clipping masks of the drawables.
      *
      * @return List of clipping masks of the drawables
      */
-    const csmInt32**            GetDrawableMasks() const;
+    const csmInt32** GetDrawableMasks() const;
 
     /**
      * Returns the list of the number of clipping masks of the drawables.
      *
      * @return List of the number of clipping masks of the drawables
      */
-    const csmInt32*             GetDrawableMaskCounts() const;
+    const csmInt32* GetDrawableMaskCounts() const;
 
     //========================================================
     //  Offscreen Functions.
@@ -1046,7 +872,7 @@ public:
      *
      * @return true if the model uses clipping masks.
      */
-    csmBool     IsUsingMasking() const;
+    csmBool IsUsingMasking() const;
 
     /**
      * Checks whether the offscreen uses clipping masks.
@@ -1058,158 +884,12 @@ public:
     /**
      * Loads temporarily stored parameter values.
      */
-    void    LoadParameters();
+    void LoadParameters();
 
     /**
      * Stores the value of the parameter temporarily.
      */
-    void    SaveParameters();
-
-    //========================================================
-    //  Color Functions.
-    //========================================================
-
-    /**
-     * Returns the multiply color from the list of drawables.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return Multiply color (CubismTextureColor)
-     */
-    Rendering::CubismRenderer::CubismTextureColor GetMultiplyColor(csmInt32 drawableIndex) const;
-
-    /**
-     * Returns the screen color from the list of drawables.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return Screen color (CubismTextureColor)
-     */
-    Rendering::CubismRenderer::CubismTextureColor GetScreenColor(csmInt32 drawableIndex) const;
-
-    /**
-     * Sets the multiply color of the drawable.
-     *
-     * @param drawableIndex Drawable index
-     * @param color Multiply color to be set (CubismTextureColor)
-     */
-    void SetMultiplyColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
-
-    /**
-     * Sets the multiply color of the drawable.
-     *
-     * @param drawableIndex Drawable index
-     * @param r Red value of the multiply color to be set
-     * @param g Green value of the multiply color to be set
-     * @param b Blue value of the multiply color to be set
-     * @param a Alpha value of the multiply color to be set
-     */
-    void SetMultiplyColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
-
-    /**
-     * Sets the screen color of the drawable.
-     *
-     * @param drawableIndex Drawable index
-     * @param color Screen color to be set (CubismTextureColor)
-     */
-    void SetScreenColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
-
-    /**
-     * Sets the screen color of the drawable.
-     *
-     * @param drawableIndex Drawable index
-     * @param r Red value of the screen color to be set
-     * @param g Green value of the screen color to be set
-     * @param b Blue value of the screen color to be set
-     * @param a Alpha value of the screen color to be set
-     */
-    void SetScreenColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
-
-    /**
-     * Returns the multiply color of the part.
-     */
-    Rendering::CubismRenderer::CubismTextureColor GetPartMultiplyColor(csmInt32 partIndex) const;
-
-    /**
-     * Returns the screen color of the part.
-     */
-    Rendering::CubismRenderer::CubismTextureColor GetPartScreenColor(csmInt32 partIndex) const;
-
-    /**
-     * Sets the multiply color of the part.
-     */
-    void SetPartMultiplyColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
-
-    /**
-     * Sets the multiply color of the part.
-     */
-    void SetPartMultiplyColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
-
-    /**
-     * Sets the screen color of the part.
-     */
-    void SetPartScreenColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
-
-    /**
-     * Sets the screen color of the part.
-     */
-    void SetPartScreenColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
-
-    /**
-     * Returns the multiply color from the list of offscreen.
-     *
-     * @param offscreenIndex Offsscreen index
-     *
-     * @return Multiply color (CubismTextureColor)
-     */
-    Rendering::CubismRenderer::CubismTextureColor GetMultiplyColorOffscreen(csmInt32 offscreenIndex) const;
-
-    /**
-     * Returns the screen color from the list of offscreen.
-     *
-     * @param offscreenIndex Offsscreen index
-     *
-     * @return Screen color (CubismTextureColor)
-     */
-    Rendering::CubismRenderer::CubismTextureColor GetScreenColorOffscreen(csmInt32 offscreenIndex) const;
-
-    /**
-     * Sets the multiply color of the offscreen.
-     *
-     * @param offscreenIndex Offsscreen index
-     * @param color Multiply color to be set (CubismTextureColor)
-     */
-    void SetMultiplyColorOffscreen(csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
-
-    /**
-     * Sets the multiply color of the offscreen.
-     *
-     * @param offscreenIndex Offsscreen index
-     * @param r Red value of the multiply color to be set
-     * @param g Green value of the multiply color to be set
-     * @param b Blue value of the multiply color to be set
-     * @param a Alpha value of the multiply color to be set
-     */
-    void SetMultiplyColorOffscreen(csmInt32 offscreenIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
-
-    /**
-     * Sets the screen color of the offscreen.
-     *
-     * @param offscreenIndex Offsscreen index
-     * @param color Screen color to be set (CubismTextureColor)
-     */
-    void SetScreenColorOffscreen(csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
-
-    /**
-     * Sets the screen color of the offscreen.
-     *
-     * @param offscreenIndex Offsscreen index
-     * @param r Red value of the screen color to be set
-     * @param g Green value of the screen color to be set
-     * @param b Blue value of the screen color to be set
-     * @param a Alpha value of the screen color to be set
-     */
-    void SetScreenColorOffscreen(csmInt32 offscreenIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+    void SaveParameters();
 
     /**
      * Checks whether parameter repetition is performed for the entire model.
@@ -1259,260 +939,18 @@ public:
     void SetRepeatFlagForParameterRepeat(csmInt32 parameterIndex, csmBool value);
 
     /**
-     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     * Returns the multiply and screen color settings.
      *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForModelMultiplyColors instead.
-     *
-     * @return true if the color set at runtime is used; otherwise false.
+     * @return Multiply and screen color settings.
      */
-    csmBool GetOverwriteFlagForModelMultiplyColors() const;
+    CubismModelMultiplyAndScreenColor& GetOverrideMultiplyAndScreenColor();
 
     /**
-     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     * Returns the multiply and screen color settings.
      *
-     * @return true if the color set at runtime is used; otherwise false.
+     * @return Multiply and screen color settings.
      */
-    csmBool GetOverrideFlagForModelMultiplyColors() const;
-
-    /**
-     * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForModelScreenColors instead.
-     *
-     * @return true if the color set at runtime is used; otherwise false.
-     */
-    csmBool GetOverwriteFlagForModelScreenColors() const;
-
-    /**
-     * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
-     *
-     * @return true if the color set at runtime is used; otherwise false.
-     */
-    csmBool GetOverrideFlagForModelScreenColors() const;
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForModelMultiplyColors instead.
-     *
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverwriteFlagForModelMultiplyColors(csmBool value);
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
-     *
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverrideFlagForModelMultiplyColors(csmBool value);
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForModelScreenColors instead.
-     *
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverwriteFlagForModelScreenColors(csmBool value);
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
-     *
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverrideFlagForModelScreenColors(csmBool value);
-
-    /**
-     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForDrawableMultiplyColors instead.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return true if the color set at runtime is used; otherwise false.
-     */
-    csmBool GetOverwriteFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const;
-
-    /**
-     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return true if the color set at runtime is used; otherwise false.
-     */
-    csmBool GetOverrideFlagForDrawableMultiplyColors(csmInt32 drawableIndex) const;
-
-    /**
-     * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForDrawableScreenColors instead.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return true if the color set at runtime is used; otherwise false.
-     */
-    csmBool GetOverwriteFlagForDrawableScreenColors(csmInt32 drawableIndex) const;
-
-    /**
-     * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return true if the color set at runtime is used; otherwise false.
-     */
-    csmBool GetOverrideFlagForDrawableScreenColors(csmInt32 drawableIndex) const;
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForDrawableMultiplyColors instead.
-     *
-     * @param drawableIndex Drawable index
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverwriteFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value);
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
-     *
-     * @param drawableIndex Drawable index
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverrideFlagForDrawableMultiplyColors(csmUint32 drawableIndex, csmBool value);
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForDrawableScreenColors instead.
-     *
-     * @param drawableIndex Drawable index
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverwriteFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
-
-    /**
-     * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
-     *
-     * @param drawableIndex Drawable index
-     * @param value true if the color set at runtime is to be used; otherwise false.
-     */
-    void SetOverrideFlagForDrawableScreenColors(csmUint32 drawableIndex, csmBool value);
-
-    /**
-     * Checks whether the part multiply color is overridden by the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideColorForPartMultiplyColors instead.
-     *
-     * @param partIndex Part index
-     *
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    csmBool GetOverwriteColorForPartMultiplyColors(csmInt32 partIndex) const;
-
-    /**
-     * Checks whether the part multiply color is overridden by the SDK.
-     *
-     * @param partIndex Part index
-     *
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    csmBool GetOverrideColorForPartMultiplyColors(csmInt32 partIndex) const;
-
-    /**
-     * Checks whether the part screen color is overridden by the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideColorForPartScreenColors instead.
-     *
-     * @param partIndex Part index
-     *
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    csmBool GetOverwriteColorForPartScreenColors(csmInt32 partIndex) const;
-
-    /**
-     * Checks whether the part screen color is overridden by the SDK.
-     *
-     * @param partIndex Part index
-     *
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    csmBool GetOverrideColorForPartScreenColors(csmInt32 partIndex) const;
-
-    /**
-     * Sets whether the part multiply color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideColorForPartMultiplyColors instead.
-     *
-     * @param partIndex Part index
-     * @param value Offscreen True enable override, false to disable
-     */
-    void SetOverwriteColorForPartMultiplyColors(csmUint32 partIndex, csmBool value);
-
-    /**
-     * Sets whether the part multiply color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @param partIndex Part index
-     * @param value Offscreen True enable override, false to disable
-     */
-    void SetOverrideColorForPartMultiplyColors(csmUint32 partIndex, csmBool value);
-
-    /**
-     * Sets whether the part screen color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideColorForPartScreenColors instead.
-     *
-     * @param partIndex Part index
-     * @param value Offscreen True enable override, false to disable
-     */
-    void SetOverwriteColorForPartScreenColors(csmUint32 partIndex, csmBool value);
-
-    /**
-     * Sets whether the part screen color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @param partIndex Part index
-     * @param value Offscreen True enable override, false to disable
-     */
-    void SetOverrideColorForPartScreenColors(csmUint32 partIndex, csmBool value);
-
-    /**
-     * Checks whether the offscreen multiply color is overridden by the SDK.
-     *
-     * @param offscreenIndex Offscreen index
-     *
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    csmBool GetOverrideFlagForOffscreenMultiplyColors(csmInt32 offscreenIndex) const;
-
-    /**
-     * Checks whether the offscreen screen color is overridden by the SDK.
-     *
-     * @param offscreenIndex Offscreen index
-     *
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    csmBool GetOverrideFlagForOffscreenScreenColors(csmInt32 offscreenIndex) const;
-
-    /**
-     * Sets whether the offscreen multiply color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @param offscreenIndex Offscreen index
-     * @param value Offscreen True enable override, false to disable
-     */
-    void SetOverrideFlagForOffscreenMultiplyColors(csmUint32 offscreenIndex, csmBool value);
-
-    /**
-     * Sets whether the offscreen screen color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @param offscreenIndex Offscreen index
-     * @param value Offscreen True enable override, false to disable
-     */
-    void SetOverrideFlagForOffscreenScreenColors(csmUint32 offscreenIndex, csmBool value);
+    const CubismModelMultiplyAndScreenColor& GetOverrideMultiplyAndScreenColor() const;
 
     //========================================================
     //  Culling Functions.
@@ -1555,28 +993,9 @@ public:
     /**
      * Checks whether the culling settings for the entire model are overridden by the SDK.
      *
-     * @deprecated This function is deprecated due to a naming change, use GetOverwriteFlagForModelCullings instead.
-     *
-     * @return true if the culling settings from the SDK are used; otherwise false.
-     */
-    csmBool GetOverwriteFlagForModelCullings() const;
-
-    /**
-     * Checks whether the culling settings for the entire model are overridden by the SDK.
-     *
      * @return true if the culling settings from the SDK are used; otherwise false.
      */
     csmBool GetOverrideFlagForModelCullings() const;
-
-    /**
-     * Sets whether the culling settings for the entire model are overridden by the SDK.
-     * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForModelCullings instead.
-     *
-     * @param value True to use the override, false to keep the model's own culling settings
-     */
-    void SetOverwriteFlagForModelCullings(csmBool value);
 
     /**
      * Sets whether the culling settings for the entire model are overridden by the SDK.
@@ -1589,33 +1008,11 @@ public:
     /**
      * Checks whether the culling settings for the drawable are overridden by the SDK.
      *
-     * @deprecated This function is deprecated due to a naming change, use GetOverrideFlagForDrawableCullings instead.
-     *
-     * @param drawableIndex Drawable index
-     *
-     * @return true if the culling settings from the SDK are used; otherwise false.
-     */
-    csmBool GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex) const;
-
-    /**
-     * Checks whether the culling settings for the drawable are overridden by the SDK.
-     *
      * @param drawableIndex Drawable index
      *
      * @return true if the culling settings from the SDK are used; otherwise false.
      */
     csmBool GetOverrideFlagForDrawableCullings(csmInt32 drawableIndex) const;
-
-    /**
-     * Sets whether the culling settings for the drawable are overridden by the SDK.
-     * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
-     *
-     * @deprecated This function is deprecated due to a naming change, use SetOverrideFlagForDrawableCullings instead.
-     *
-     * @param drawableIndex Drawable index
-     * @param value True to use the override, false to keep the model's own culling settings
-     */
-    void SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value);
 
     /**
      * Sets whether the culling settings for the drawable are overridden by the SDK.
@@ -1665,35 +1062,28 @@ public:
      */
     void SetModelOpacity(csmFloat32 value);
 
-    Core::csmModel*     GetModel() const;
+    Core::csmModel* GetModel() const;
 
-private:
+    /**
+     * Delete copy constructor.
+     */
+    CubismModel(const CubismModel&) = delete;
+
+    /**
+     * Delete copy assignment operator.
+     */
+    CubismModel& operator=(const CubismModel&) = delete;
+
+protected:
     CubismModel(Core::csmModel* model);
 
     virtual ~CubismModel();
-
-    CubismModel(const CubismModel&);
-    CubismModel& operator=(const CubismModel&);
 
     void Initialize();
 
     void InitializeBlendMode();
 
-    void InitializeOffscreen();
-
     void SetupPartsHierarchy();
-
-    void SetPartColor(
-        csmUint32 partIndex,
-        csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a,
-        csmVector<ColorData>& partColors,
-        csmVector<ColorData>& drawableColors);
-
-    void SetOverrideColorForPartColors(
-        csmUint32 partIndex,
-        csmBool value,
-        csmVector<ColorData>& partColors,
-        csmVector<ColorData>& drawableColors);
 
     csmMap<csmInt32, csmFloat32>        _notExistPartOpacities;
     csmMap<CubismIdHandle, csmInt32>   _notExistPartId;
@@ -1716,22 +1106,14 @@ private:
     csmVector<CubismIdHandle> _parameterIds;
     csmVector<CubismIdHandle> _partIds;
     csmVector<CubismIdHandle> _drawableIds;
+    csmVector<CubismModelPartInfo> _partsHierarchy;
     csmVector<ParameterRepeatData> _userParameterRepeatDataList;
-    csmVector<ColorData> _userDrawableScreenColors;
-    csmVector<ColorData> _userDrawableMultiplyColors;
-    csmVector<ColorData> _userPartScreenColors;
-    csmVector<ColorData> _userPartMultiplyColors;
-    csmVector<ColorData> _userOffscreenScreenColors;
-    csmVector<ColorData> _userOffscreenMultiplyColors;
     csmVector<CullingData> _userDrawableCullings;
     csmVector<CullingData> _userOffscreenCullings;
-    csmVector<csmVector<csmUint32> > _partChildDrawables;
+    CubismModelMultiplyAndScreenColor _overrideMultiplyAndScreenColors;
     csmBool _isOverriddenParameterRepeat;
-    csmBool _isOverriddenModelMultiplyColors;
-    csmBool _isOverriddenModelScreenColors;
     csmBool _isOverriddenCullings;
     csmBool _isBlendModeEnabled;
-    csmVector<CubismModelPartInfo> _partsHierarchy;
 };
 
 }}}

--- a/src/Model/CubismModelMultiplyAndScreenColor.cpp
+++ b/src/Model/CubismModelMultiplyAndScreenColor.cpp
@@ -1,0 +1,521 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismModelMultiplyAndScreenColor.hpp"
+#include "CubismModel.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+namespace
+{
+    // 警告ログメッセージ
+    void WarnIndexOutOfRange(const csmChar* const funcName, const csmInt32 partIndex, const csmInt32 range)
+    {
+        CubismLogWarning("%s() : index is out of range. index = %d, valid range = [0, %d].", funcName, partIndex, range);
+    }
+}
+
+CubismModelMultiplyAndScreenColor::CubismModelMultiplyAndScreenColor(const CubismModel* model, const csmVector<CubismModelPartInfo>* partsHierarchy)
+    : _model(model)
+    , _partsHierarchy(partsHierarchy)
+    , _isOverriddenModelMultiplyColors(false)
+    , _isOverriddenModelScreenColors(false)
+{
+}
+
+void CubismModelMultiplyAndScreenColor::Initialize(const csmInt32 partCount, const csmInt32 drawableCount, const csmInt32 offscreenCount)
+{
+    // 乗算色
+    ColorData userMultiplyColor;
+    userMultiplyColor.IsOverridden = false;
+    userMultiplyColor.Color = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+    // スクリーン色
+    ColorData userScreenColor;
+    userScreenColor.IsOverridden = false;
+    userScreenColor.Color = { 0.0f, 0.0f, 0.0f, 1.0f };
+
+    // Part
+    _userPartMultiplyColors.PrepareCapacity(partCount);
+    _userPartScreenColors.PrepareCapacity(partCount);
+    for (csmInt32 i = 0; i < partCount; ++i)
+    {
+        _userPartMultiplyColors.PushBack(userMultiplyColor);
+        _userPartScreenColors.PushBack(userScreenColor);
+    }
+
+    // Drawable
+    _userDrawableMultiplyColors.PrepareCapacity(drawableCount);
+    _userDrawableScreenColors.PrepareCapacity(drawableCount);
+    for (csmInt32 i = 0; i < drawableCount; ++i)
+    {
+        _userDrawableMultiplyColors.PushBack(userMultiplyColor);
+        _userDrawableScreenColors.PushBack(userScreenColor);
+    }
+
+    // Offscreen
+    _userOffscreenMultiplyColors.PrepareCapacity(offscreenCount);
+    _userOffscreenScreenColors.PrepareCapacity(offscreenCount);
+    for (csmInt32 i = 0; i < offscreenCount; ++i)
+    {
+        _userOffscreenMultiplyColors.PushBack(userMultiplyColor);
+        _userOffscreenScreenColors.PushBack(userScreenColor);
+    }
+}
+
+void CubismModelMultiplyAndScreenColor::SetMultiplyColorEnabled(const csmBool value)
+{
+    _isOverriddenModelMultiplyColors = value;
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetMultiplyColorEnabled() const
+{
+    return _isOverriddenModelMultiplyColors;
+}
+
+void CubismModelMultiplyAndScreenColor::SetScreenColorEnabled(const csmBool value)
+{
+    _isOverriddenModelScreenColors = value;
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetScreenColorEnabled() const
+{
+    return _isOverriddenModelScreenColors;
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartMultiplyColorEnabled(const csmInt32 partIndex, const csmBool value)
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return;
+    }
+
+    SetPartColorEnabled(partIndex, value, _userPartMultiplyColors, _userDrawableMultiplyColors, _userOffscreenMultiplyColors);
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetPartMultiplyColorEnabled(const csmInt32 partIndex) const
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return false;
+    }
+
+    return _userPartMultiplyColors[partIndex].IsOverridden;
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartScreenColorEnabled(const csmInt32 partIndex, const csmBool value)
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return;
+    }
+
+    SetPartColorEnabled(partIndex, value, _userPartScreenColors, _userDrawableScreenColors, _userOffscreenScreenColors);
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetPartScreenColorEnabled(const csmInt32 partIndex) const
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return false;
+    }
+
+    return _userPartScreenColors[partIndex].IsOverridden;
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartMultiplyColor(const csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
+{
+    SetPartMultiplyColor(partIndex, color.R, color.G, color.B, color.A);
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartMultiplyColor(const csmInt32 partIndex, const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a)
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return;
+    }
+
+    SetPartColor(partIndex, r, g, b, a, _userPartMultiplyColors, _userDrawableMultiplyColors, _userOffscreenMultiplyColors);
+}
+
+Rendering::CubismRenderer::CubismTextureColor CubismModelMultiplyAndScreenColor::GetPartMultiplyColor(const csmInt32 partIndex) const
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return { 1.0f, 1.0f, 1.0f, 1.0f };
+    }
+
+    return _userPartMultiplyColors[partIndex].Color;
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartScreenColor(const csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
+{
+    SetPartScreenColor(partIndex, color.R, color.G, color.B, color.A);
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartScreenColor(const csmInt32 partIndex, const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a)
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return;
+    }
+
+    SetPartColor(partIndex, r, g, b, a, _userPartScreenColors, _userDrawableScreenColors, _userOffscreenScreenColors);
+}
+
+Rendering::CubismRenderer::CubismTextureColor CubismModelMultiplyAndScreenColor::GetPartScreenColor(const csmInt32 partIndex) const
+{
+    if (partIndex < 0 || _model->GetPartCount() <= partIndex)
+    {
+        WarnIndexOutOfRange(__func__, partIndex, _model->GetPartCount() - 1);
+        return { 0.0f, 0.0f, 0.0f, 1.0f };
+    }
+
+    return _userPartScreenColors[partIndex].Color;
+}
+
+void CubismModelMultiplyAndScreenColor::SetDrawableMultiplyColorEnabled(const csmInt32 drawableIndex, const csmBool value)
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return;
+    }
+
+    _userDrawableMultiplyColors[drawableIndex].IsOverridden = value;
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetDrawableMultiplyColorEnabled(const csmInt32 drawableIndex) const
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return false;
+    }
+
+    return _userDrawableMultiplyColors[drawableIndex].IsOverridden;
+}
+
+void CubismModelMultiplyAndScreenColor::SetDrawableScreenColorEnabled(const csmInt32 drawableIndex, const csmBool value)
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return;
+    }
+
+    _userDrawableScreenColors[drawableIndex].IsOverridden = value;
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetDrawableScreenColorEnabled(const csmInt32 drawableIndex) const
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return false;
+    }
+
+    return _userDrawableScreenColors[drawableIndex].IsOverridden;
+}
+
+void CubismModelMultiplyAndScreenColor::SetDrawableMultiplyColor(const csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
+{
+    SetDrawableMultiplyColor(drawableIndex, color.R, color.G, color.B, color.A);
+}
+
+void CubismModelMultiplyAndScreenColor::SetDrawableMultiplyColor(const csmInt32 drawableIndex, const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a)
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return;
+    }
+
+    _userDrawableMultiplyColors[drawableIndex].Color.R = r;
+    _userDrawableMultiplyColors[drawableIndex].Color.G = g;
+    _userDrawableMultiplyColors[drawableIndex].Color.B = b;
+    _userDrawableMultiplyColors[drawableIndex].Color.A = a;
+}
+
+Rendering::CubismRenderer::CubismTextureColor CubismModelMultiplyAndScreenColor::GetDrawableMultiplyColor(const csmInt32 drawableIndex) const
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return { 1.0f, 1.0f, 1.0f, 1.0f };
+    }
+
+    if (GetMultiplyColorEnabled() || GetDrawableMultiplyColorEnabled(drawableIndex))
+    {
+        return _userDrawableMultiplyColors[drawableIndex].Color;
+    }
+    const Core::csmVector4 tmpColor = _model->GetDrawableMultiplyColor(drawableIndex);
+
+    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
+}
+
+void CubismModelMultiplyAndScreenColor::SetDrawableScreenColor(const csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
+{
+    SetDrawableScreenColor(drawableIndex, color.R, color.G, color.B, color.A);
+}
+
+void CubismModelMultiplyAndScreenColor::SetDrawableScreenColor(const csmInt32 drawableIndex, const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a)
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return;
+    }
+
+    _userDrawableScreenColors[drawableIndex].Color.R = r;
+    _userDrawableScreenColors[drawableIndex].Color.G = g;
+    _userDrawableScreenColors[drawableIndex].Color.B = b;
+    _userDrawableScreenColors[drawableIndex].Color.A = a;
+}
+
+Rendering::CubismRenderer::CubismTextureColor CubismModelMultiplyAndScreenColor::GetDrawableScreenColor(const csmInt32 drawableIndex) const
+{
+    if (drawableIndex < 0 || _model->GetDrawableCount() <= drawableIndex)
+    {
+        WarnIndexOutOfRange(__func__, drawableIndex, _model->GetDrawableCount() - 1);
+        return { 0.0f, 0.0f, 0.0f, 1.0f };
+    }
+
+    if (GetScreenColorEnabled() || GetDrawableScreenColorEnabled(drawableIndex))
+    {
+        return _userDrawableScreenColors[drawableIndex].Color;
+    }
+    const Core::csmVector4 tmpColor = _model->GetDrawableScreenColor(drawableIndex);
+
+    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
+}
+
+void CubismModelMultiplyAndScreenColor::SetOffscreenMultiplyColorEnabled(const csmInt32 offscreenIndex, const csmBool value)
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return;
+    }
+
+    _userOffscreenMultiplyColors[offscreenIndex].IsOverridden = value;
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetOffscreenMultiplyColorEnabled(const csmInt32 offscreenIndex) const
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return false;
+    }
+
+    return _userOffscreenMultiplyColors[offscreenIndex].IsOverridden;
+}
+
+void CubismModelMultiplyAndScreenColor::SetOffscreenScreenColorEnabled(const csmInt32 offscreenIndex, const csmBool value)
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return;
+    }
+
+    _userOffscreenScreenColors[offscreenIndex].IsOverridden = value;
+}
+
+csmBool CubismModelMultiplyAndScreenColor::GetOffscreenScreenColorEnabled(const csmInt32 offscreenIndex) const
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return false;
+    }
+
+    return _userOffscreenScreenColors[offscreenIndex].IsOverridden;
+}
+
+void CubismModelMultiplyAndScreenColor::SetOffscreenMultiplyColor(const csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
+{
+    SetOffscreenMultiplyColor(offscreenIndex, color.R, color.G, color.B, color.A);
+}
+
+void CubismModelMultiplyAndScreenColor::SetOffscreenMultiplyColor(const csmInt32 offscreenIndex, const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a)
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return;
+    }
+
+    _userOffscreenMultiplyColors[offscreenIndex].Color.R = r;
+    _userOffscreenMultiplyColors[offscreenIndex].Color.G = g;
+    _userOffscreenMultiplyColors[offscreenIndex].Color.B = b;
+    _userOffscreenMultiplyColors[offscreenIndex].Color.A = a;
+}
+
+Rendering::CubismRenderer::CubismTextureColor CubismModelMultiplyAndScreenColor::GetOffscreenMultiplyColor(const csmInt32 offscreenIndex) const
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return { 1.0f, 1.0f, 1.0f, 1.0f };
+    }
+
+    if (GetMultiplyColorEnabled() || GetOffscreenMultiplyColorEnabled(offscreenIndex))
+    {
+        return _userOffscreenMultiplyColors[offscreenIndex].Color;
+    }
+    const Core::csmVector4 tmpColor = _model->GetOffscreenMultiplyColor(offscreenIndex);
+
+    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
+}
+
+void CubismModelMultiplyAndScreenColor::SetOffscreenScreenColor(const csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color)
+{
+    SetOffscreenScreenColor(offscreenIndex, color.R, color.G, color.B, color.A);
+}
+
+void CubismModelMultiplyAndScreenColor::SetOffscreenScreenColor(const csmInt32 offscreenIndex, const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a)
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return;
+    }
+
+    _userOffscreenScreenColors[offscreenIndex].Color.R = r;
+    _userOffscreenScreenColors[offscreenIndex].Color.G = g;
+    _userOffscreenScreenColors[offscreenIndex].Color.B = b;
+    _userOffscreenScreenColors[offscreenIndex].Color.A = a;
+}
+
+Rendering::CubismRenderer::CubismTextureColor CubismModelMultiplyAndScreenColor::GetOffscreenScreenColor(const csmInt32 offscreenIndex) const
+{
+    if (offscreenIndex < 0 || _model->GetOffscreenCount() <= offscreenIndex)
+    {
+        WarnIndexOutOfRange(__func__, offscreenIndex, _model->GetOffscreenCount() - 1);
+        return { 0.0f, 0.0f, 0.0f, 1.0f };
+    }
+
+    if (GetScreenColorEnabled() || GetOffscreenScreenColorEnabled(offscreenIndex))
+    {
+        return _userOffscreenScreenColors[offscreenIndex].Color;
+    }
+    const Core::csmVector4 tmpColor = _model->GetOffscreenScreenColor(offscreenIndex);
+
+    return Rendering::CubismRenderer::CubismTextureColor(tmpColor.X, tmpColor.Y, tmpColor.Z, tmpColor.W);
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartColor(
+    const csmInt32 partIndex,
+    const csmFloat32 r, const csmFloat32 g, const csmFloat32 b, const csmFloat32 a,
+    csmVector<ColorData>& partColors,
+    csmVector<ColorData>& drawableColors,
+    csmVector<ColorData>& offscreenColors)
+{
+    partColors[partIndex].Color.R = r;
+    partColors[partIndex].Color.G = g;
+    partColors[partIndex].Color.B = b;
+    partColors[partIndex].Color.A = a;
+
+    if (partColors[partIndex].IsOverridden)
+    {
+        const csmInt32 offscreenIndex = Core::csmGetPartOffscreenIndices(_model->GetModel())[partIndex];
+        if (offscreenIndex == CubismModel::CubismNoIndex_Offscreen)
+        {
+            // If no offscreen buffer is attached, the effect is applied to the children.
+            for (csmUint32 i = 0; i < (*_partsHierarchy)[partIndex].Objects.GetSize(); ++i)
+            {
+                if ((*_partsHierarchy)[partIndex].Objects[i].ObjectType == CubismModelObjectInfo::ObjectType_Drawable)
+                {
+                    const csmUint32 drawableIndex = (*_partsHierarchy)[partIndex].Objects[i].ObjectIndex;
+                    drawableColors[drawableIndex].Color.R = r;
+                    drawableColors[drawableIndex].Color.G = g;
+                    drawableColors[drawableIndex].Color.B = b;
+                    drawableColors[drawableIndex].Color.A = a;
+                }
+                else
+                {
+                    const csmUint32 childPartIndex = (*_partsHierarchy)[partIndex].Objects[i].ObjectIndex;
+                    SetPartColor(childPartIndex, r, g, b, a, partColors, drawableColors, offscreenColors);
+                }
+            }
+        }
+        else
+        {
+            // If an offscreen buffer is attached, only that offscreen buffer is affected.
+            offscreenColors[offscreenIndex].Color.R = r;
+            offscreenColors[offscreenIndex].Color.G = g;
+            offscreenColors[offscreenIndex].Color.B = b;
+            offscreenColors[offscreenIndex].Color.A = a;
+        }
+    }
+}
+
+void CubismModelMultiplyAndScreenColor::SetPartColorEnabled(
+    const csmInt32 partIndex,
+    const csmBool value,
+    csmVector<ColorData>& partColors,
+    csmVector<ColorData>& drawableColors,
+    csmVector<ColorData>& offscreenColors)
+{
+    partColors[partIndex].IsOverridden = value;
+
+    const csmInt32 offscreenIndex = Core::csmGetPartOffscreenIndices(_model->GetModel())[partIndex];
+    if (offscreenIndex == CubismModel::CubismNoIndex_Offscreen)
+    {
+        // If no offscreen buffer is attached, the effect is applied to the children.
+        for (csmUint32 i = 0; i < (*_partsHierarchy)[partIndex].Objects.GetSize(); ++i)
+        {
+            if ((*_partsHierarchy)[partIndex].Objects[i].ObjectType == CubismModelObjectInfo::ObjectType_Drawable)
+            {
+                const csmUint32 drawableIndex = (*_partsHierarchy)[partIndex].Objects[i].ObjectIndex;
+                drawableColors[drawableIndex].IsOverridden = value;
+                if (value)
+                {
+                    drawableColors[drawableIndex].Color.R = partColors[partIndex].Color.R;
+                    drawableColors[drawableIndex].Color.G = partColors[partIndex].Color.G;
+                    drawableColors[drawableIndex].Color.B = partColors[partIndex].Color.B;
+                    drawableColors[drawableIndex].Color.A = partColors[partIndex].Color.A;
+                }
+            }
+            else
+            {
+                const csmUint32 childPartIndex = (*_partsHierarchy)[partIndex].Objects[i].ObjectIndex;
+                if (value)
+                {
+                    partColors[childPartIndex].Color.R = partColors[partIndex].Color.R;
+                    partColors[childPartIndex].Color.G = partColors[partIndex].Color.G;
+                    partColors[childPartIndex].Color.B = partColors[partIndex].Color.B;
+                    partColors[childPartIndex].Color.A = partColors[partIndex].Color.A;
+                }
+                SetPartColorEnabled(childPartIndex, value, partColors, drawableColors, offscreenColors);
+            }
+        }
+    }
+    else
+    {
+        // If an offscreen buffer is attached, only that offscreen buffer is affected.
+        offscreenColors[offscreenIndex].IsOverridden = value;
+        if (value)
+        {
+            offscreenColors[offscreenIndex].Color.R = partColors[partIndex].Color.R;
+            offscreenColors[offscreenIndex].Color.G = partColors[partIndex].Color.G;
+            offscreenColors[offscreenIndex].Color.B = partColors[partIndex].Color.B;
+            offscreenColors[offscreenIndex].Color.A = partColors[partIndex].Color.A;
+        }
+    }
+}
+
+}}}

--- a/src/Model/CubismModelMultiplyAndScreenColor.hpp
+++ b/src/Model/CubismModelMultiplyAndScreenColor.hpp
@@ -1,0 +1,414 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "Rendering/CubismRenderer.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+class CubismModel;
+struct CubismModelPartInfo;
+
+/**
+ * Handling multiply and screen colors of the model.
+ */
+class CubismModelMultiplyAndScreenColor
+{
+public:
+    /**
+     * Structure for color information of drawing object
+     */
+    struct ColorData
+    {
+        /**
+         * Constructor
+         */
+        ColorData()
+            : IsOverridden(false)
+            , Color()
+        {
+        }
+
+        /**
+         * Constructor
+         *
+         * @param isOverridden whether to be overridden
+         * @param color Texture color
+         */
+        ColorData(const csmBool isOverridden, const Rendering::CubismRenderer::CubismTextureColor& color)
+            : IsOverridden(isOverridden)
+            , Color(color)
+        {
+        }
+
+        /**
+         * Destructor
+         */
+        ~ColorData() = default;
+
+        csmBool IsOverridden;                                      ///< Whether to be overridden
+        Rendering::CubismRenderer::CubismTextureColor Color;        ///< Color
+    };
+
+    /**
+     * Delete default constructor.
+     */
+    CubismModelMultiplyAndScreenColor() = delete;
+
+    /**
+     * Constructor.
+     *
+     * @param model cubism model.
+     * @param partsHierarchy parts hierarchy.
+     */
+    CubismModelMultiplyAndScreenColor(const CubismModel* model, const csmVector<CubismModelPartInfo>* partsHierarchy);
+
+    /**
+     * Destructor.
+     */
+    ~CubismModelMultiplyAndScreenColor() = default;
+
+    /**
+     * Initialization for using multiply and screen colors.
+     *
+     * @param partCount number of parts.
+     * @param drawableCount number of drawables.
+     * @param offscreenCount number of offscreen.
+     */
+    void Initialize(csmInt32 partCount, csmInt32 drawableCount, csmInt32 offscreenCount);
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetMultiplyColorEnabled(csmBool value);
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetMultiplyColorEnabled() const;
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetScreenColorEnabled(csmBool value);
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetScreenColorEnabled() const;
+
+    /**
+     * Sets whether the part multiply color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param partIndex Part index
+     * @param value Offscreen True enable override, false to disable
+     */
+    void SetPartMultiplyColorEnabled(csmInt32 partIndex, csmBool value);
+
+    /**
+     * Checks whether the part multiply color is overridden by the SDK.
+     *
+     * @param partIndex Part index
+     *
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    csmBool GetPartMultiplyColorEnabled(csmInt32 partIndex) const;
+
+    /**
+     * Sets whether the part screen color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param partIndex Part index
+     * @param value Offscreen True enable override, false to disable
+     */
+    void SetPartScreenColorEnabled(csmInt32 partIndex, csmBool value);
+
+    /**
+     * Checks whether the part screen color is overridden by the SDK.
+     *
+     * @param partIndex Part index
+     *
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    csmBool GetPartScreenColorEnabled(csmInt32 partIndex) const;
+
+    /**
+     * Sets the multiply color of the part.
+     *
+     * @param partIndex Part index
+     * @param color Multiply color to be set (CubismTextureColor)
+     */
+    void SetPartMultiplyColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * Sets the multiply color of the part.
+     *
+     * @param partIndex Part index
+     * @param r Red value of the multiply color to be set
+     * @param g Green value of the multiply color to be set
+     * @param b Blue value of the multiply color to be set
+     * @param a Alpha value of the multiply color to be set
+     */
+    void SetPartMultiplyColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * Returns the multiply color of the part.
+     *
+     * @param partIndex Part index
+     *
+     * @return Multiply color (CubismTextureColor)
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetPartMultiplyColor(csmInt32 partIndex) const;
+
+    /**
+     * Sets the screen color of the part.
+     *
+     * @param partIndex Part index
+     * @param color Screen color to be set (CubismTextureColor)
+     */
+    void SetPartScreenColor(csmInt32 partIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * Sets the screen color of the part.
+     *
+     * @param partIndex Part index
+     * @param r Red value of the screen color to be set
+     * @param g Green value of the screen color to be set
+     * @param b Blue value of the screen color to be set
+     * @param a Alpha value of the screen color to be set
+     */
+    void SetPartScreenColor(csmInt32 partIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * Returns the screen color of the part.
+     *
+     * @param partIndex Part index
+     *
+     * @return Screen color (CubismTextureColor)
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetPartScreenColor(csmInt32 partIndex) const;
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetDrawableMultiplyColorEnabled(csmInt32 drawableIndex, csmBool value);
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetDrawableMultiplyColorEnabled(csmInt32 drawableIndex) const;
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    void SetDrawableScreenColorEnabled(csmInt32 drawableIndex, csmBool value);
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @param drawableIndex Drawable index
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    csmBool GetDrawableScreenColorEnabled(csmInt32 drawableIndex) const;
+
+    /**
+     * Sets the multiply color of the drawable.
+     *
+     * @param drawableIndex Drawable index
+     * @param color Multiply color to be set (CubismTextureColor)
+     */
+    void SetDrawableMultiplyColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * Sets the multiply color of the drawable.
+     *
+     * @param drawableIndex Drawable index
+     * @param r Red value of the multiply color to be set
+     * @param g Green value of the multiply color to be set
+     * @param b Blue value of the multiply color to be set
+     * @param a Alpha value of the multiply color to be set
+     */
+    void SetDrawableMultiplyColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * Returns the multiply color from the list of drawables.
+     *
+     * @param drawableIndex Drawable index
+     *
+     * @return Multiply color (CubismTextureColor)
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetDrawableMultiplyColor(csmInt32 drawableIndex) const;
+
+    /**
+     * Sets the screen color of the drawable.
+     *
+     * @param drawableIndex Drawable index
+     * @param color Screen color to be set (CubismTextureColor)
+     */
+    void SetDrawableScreenColor(csmInt32 drawableIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * Sets the screen color of the drawable.
+     *
+     * @param drawableIndex Drawable index
+     * @param r Red value of the screen color to be set
+     * @param g Green value of the screen color to be set
+     * @param b Blue value of the screen color to be set
+     * @param a Alpha value of the screen color to be set
+     */
+    void SetDrawableScreenColor(csmInt32 drawableIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * Returns the screen color from the list of drawables.
+     *
+     * @param drawableIndex Drawable index
+     *
+     * @return Screen color (CubismTextureColor)
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetDrawableScreenColor(csmInt32 drawableIndex) const;
+
+    /**
+     * Sets whether the offscreen multiply color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param offscreenIndex Offscreen index
+     * @param value Offscreen True enable override, false to disable
+     */
+    void SetOffscreenMultiplyColorEnabled(csmInt32 offscreenIndex, csmBool value);
+
+    /**
+     * Checks whether the offscreen multiply color is overridden by the SDK.
+     *
+     * @param offscreenIndex Offscreen index
+     *
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    csmBool GetOffscreenMultiplyColorEnabled(csmInt32 offscreenIndex) const;
+
+    /**
+     * Sets whether the offscreen screen color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param offscreenIndex Offscreen index
+     * @param value Offscreen True enable override, false to disable
+     */
+    void SetOffscreenScreenColorEnabled(csmInt32 offscreenIndex, csmBool value);
+
+    /**
+     * Checks whether the offscreen screen color is overridden by the SDK.
+     *
+     * @param offscreenIndex Offscreen index
+     *
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    csmBool GetOffscreenScreenColorEnabled(csmInt32 offscreenIndex) const;
+
+    /**
+     * Sets the multiply color of the offscreen.
+     *
+     * @param offscreenIndex Offsscreen index
+     * @param color Multiply color to be set (CubismTextureColor)
+     */
+    void SetOffscreenMultiplyColor(csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * Sets the multiply color of the offscreen.
+     *
+     * @param offscreenIndex Offsscreen index
+     * @param r Red value of the multiply color to be set
+     * @param g Green value of the multiply color to be set
+     * @param b Blue value of the multiply color to be set
+     * @param a Alpha value of the multiply color to be set
+     */
+    void SetOffscreenMultiplyColor(csmInt32 offscreenIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * Returns the multiply color from the list of offscreen.
+     *
+     * @param offscreenIndex Offsscreen index
+     *
+     * @return Multiply color (CubismTextureColor)
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetOffscreenMultiplyColor(csmInt32 offscreenIndex) const;
+
+    /**
+     * Sets the screen color of the offscreen.
+     *
+     * @param offscreenIndex Offsscreen index
+     * @param color Screen color to be set (CubismTextureColor)
+     */
+    void SetOffscreenScreenColor(csmInt32 offscreenIndex, const Rendering::CubismRenderer::CubismTextureColor& color);
+
+    /**
+     * Sets the screen color of the offscreen.
+     *
+     * @param offscreenIndex Offsscreen index
+     * @param r Red value of the screen color to be set
+     * @param g Green value of the screen color to be set
+     * @param b Blue value of the screen color to be set
+     * @param a Alpha value of the screen color to be set
+     */
+    void SetOffscreenScreenColor(csmInt32 offscreenIndex, csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a = 1.0f);
+
+    /**
+     * Returns the screen color from the list of offscreen.
+     *
+     * @param offscreenIndex Offsscreen index
+     *
+     * @return Screen color (CubismTextureColor)
+     */
+    Rendering::CubismRenderer::CubismTextureColor GetOffscreenScreenColor(csmInt32 offscreenIndex) const;
+
+private:
+    void SetPartColor(
+        csmInt32 partIndex,
+        csmFloat32 r, csmFloat32 g, csmFloat32 b, csmFloat32 a,
+        csmVector<ColorData>& partColors,
+        csmVector<ColorData>& drawableColors,
+        csmVector<ColorData>& offscreenColors);
+
+    void SetPartColorEnabled(
+        csmInt32 partIndex,
+        csmBool value,
+        csmVector<ColorData>& partColors,
+        csmVector<ColorData>& drawableColors,
+        csmVector<ColorData>& offscreenColors);
+
+    const CubismModel* const _model;
+    const csmVector<CubismModelPartInfo>* _partsHierarchy;
+    csmBool _isOverriddenModelMultiplyColors;
+    csmBool _isOverriddenModelScreenColors;
+    csmVector<ColorData> _userPartScreenColors;
+    csmVector<ColorData> _userPartMultiplyColors;
+    csmVector<ColorData> _userDrawableScreenColors;
+    csmVector<ColorData> _userDrawableMultiplyColors;
+    csmVector<ColorData> _userOffscreenScreenColors;
+    csmVector<ColorData> _userOffscreenMultiplyColors;
+};
+
+}}}

--- a/src/Model/CubismUserModel.cpp
+++ b/src/Model/CubismUserModel.cpp
@@ -23,13 +23,11 @@ CubismUserModel::CubismUserModel()
     , _dragManager(NULL)
     , _physics(NULL)
     , _modelUserData(NULL)
+    , _look(NULL)
     , _initialized(false)
     , _updating(false)
     , _opacity(1.0f)
-    , _lipSync(true)
     , _lastLipSyncValue(0.0f)
-    , _dragX(0.0f)
-    , _dragY(0.0f)
     , _accelerationX(0.0f)
     , _accelerationY(0.0f)
     , _accelerationZ(0.0f)
@@ -67,6 +65,7 @@ CubismUserModel::~CubismUserModel()
     CSM_DELETE(_dragManager);
     CubismPhysics::Delete(_physics);
     CubismModelUserData::Delete(_modelUserData);
+    CubismLook::Delete(_look);
 
     DeleteRenderer();
 }

--- a/src/Model/CubismUserModel.hpp
+++ b/src/Model/CubismUserModel.hpp
@@ -10,6 +10,7 @@
 #include "Effect/CubismPose.hpp"
 #include "Effect/CubismEyeBlink.hpp"
 #include "Effect/CubismBreath.hpp"
+#include "Effect/CubismLook.hpp"
 #include "Math/CubismModelMatrix.hpp"
 #include "Math/CubismTargetPoint.hpp"
 #include "Model/CubismMoc.hpp"
@@ -20,6 +21,7 @@
 #include "Rendering/CubismRenderer.hpp"
 #include "Model/CubismModelUserData.hpp"
 #include "Motion/CubismExpressionMotionManager.hpp"
+#include "Motion/CubismUpdateScheduler.hpp"
 
 namespace Live2D { namespace Cubism { namespace Framework {
 
@@ -247,6 +249,8 @@ protected:
     CubismMoc*              _moc;
     CubismModel*            _model;
 
+    CubismUpdateScheduler _updateScheduler;
+
     CubismMotionManager*    _motionManager;
     CubismExpressionMotionManager*    _expressionManager;
     CubismEyeBlink*         _eyeBlink;
@@ -256,14 +260,12 @@ protected:
     CubismTargetPoint*      _dragManager;
     CubismPhysics*          _physics;
     CubismModelUserData*    _modelUserData;
+    CubismLook*             _look;
 
     csmBool     _initialized;
     csmBool     _updating;
     csmFloat32  _opacity;
-    csmBool     _lipSync;
     csmFloat32  _lastLipSyncValue;
-    csmFloat32  _dragX;
-    csmFloat32  _dragY;
     csmFloat32  _accelerationX;
     csmFloat32  _accelerationY;
     csmFloat32  _accelerationZ;

--- a/src/Motion/CMakeLists.txt
+++ b/src/Motion/CMakeLists.txt
@@ -17,4 +17,24 @@ target_sources(${LIB_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueEntry.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismMotionQueueManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismUpdateScheduler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismUpdateScheduler.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismBreathUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismBreathUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismExpressionUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismEyeBlinkUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismEyeBlinkUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismLipSyncUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismLipSyncUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismLookUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismLookUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysicsUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPhysicsUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPoseUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismPoseUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ICubismUpdater.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ICubismUpdater.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/IParameterProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/IParameterProvider.hpp
 )

--- a/src/Motion/CubismBreathUpdater.cpp
+++ b/src/Motion/CubismBreathUpdater.cpp
@@ -1,0 +1,34 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismBreathUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismBreathUpdater::CubismBreathUpdater(CubismBreath& breath)
+    : ICubismUpdater(CubismUpdateOrder_Breath)
+    , _breath(breath)
+{
+}
+
+CubismBreathUpdater::CubismBreathUpdater(CubismBreath& breath, const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _breath(breath)
+{
+}
+
+void CubismBreathUpdater::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    _breath.UpdateParameters(model, deltaTimeSeconds);
+}
+
+}}}

--- a/src/Motion/CubismBreathUpdater.hpp
+++ b/src/Motion/CubismBreathUpdater.hpp
@@ -1,0 +1,59 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "Effect/CubismBreath.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating breathing motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismBreathUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismBreathUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param breath `CubismBreath` reference
+     */
+    CubismBreathUpdater(CubismBreath& breath);
+
+    /**
+     * Constructor
+     *
+     * @param breath `CubismBreath` reference
+     * @param executionOrder Order of operations
+     */
+    CubismBreathUpdater(CubismBreath& breath, csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismBreathUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    CubismBreath& _breath;
+};
+
+}}}

--- a/src/Motion/CubismExpressionMotion.cpp
+++ b/src/Motion/CubismExpressionMotion.cpp
@@ -83,9 +83,7 @@ void CubismExpressionMotion::CalculateExpressionParameters(CubismModel* model, c
         return;
     }
 
-    // CubismExpressionMotion._fadeWeight は廃止予定です。
-    // 互換性のために処理は残りますが、実際には使用しておりません。
-    _fadeWeight = UpdateFadeWeight(motionQueueEntry, userTimeSeconds);
+    UpdateFadeWeight(motionQueueEntry, userTimeSeconds);
 
     // モデルに適用する値を計算
     for (csmInt32 i = 0; i < expressionParameterValues->GetSize(); ++i)
@@ -178,13 +176,6 @@ void CubismExpressionMotion::CalculateExpressionParameters(CubismModel* model, c
 csmVector<CubismExpressionMotion::ExpressionParameter> CubismExpressionMotion::GetExpressionParameters()
 {
     return _parameters;
-}
-
-csmFloat32 CubismExpressionMotion::GetFadeWeight()
-{
-    CubismLogWarning("GetFadeWeight() is a deprecated function. Please use CubismExpressionMotionManager.GetFadeWeight(int index).");
-
-    return _fadeWeight;
 }
 
 void CubismExpressionMotion::Parse(const csmByte* buffer, csmSizeInt size)

--- a/src/Motion/CubismExpressionMotion.hpp
+++ b/src/Motion/CubismExpressionMotion.hpp
@@ -77,18 +77,6 @@ public:
      */
     csmVector<ExpressionParameter> GetExpressionParameters();
 
-    /**
-     * Returns the current fade weight value of the facial expression.
-     *
-     * @return fade weight value of the facial expression
-     *
-     * @deprecated Not recommended due to the planned removal of CubismExpressionMotion._fadeWeight.
-     *             Use CubismExpressionMotionManager.getFadeWeight(int index) instead.
-     *
-     * @see CubismExpressionMotionManager#getFadeWeight(int index)
-     */
-    csmFloat32 GetFadeWeight();
-
     static const csmFloat32 DefaultAdditiveValue;
     static const csmFloat32 DefaultMultiplyValue;
 
@@ -104,9 +92,6 @@ protected:
 private:
 
     csmFloat32 CalculateValue(csmFloat32 source, csmFloat32 destination, csmFloat32 fadeWeight);
-
-
-    csmFloat32 _fadeWeight;
 };
 
 }}}

--- a/src/Motion/CubismExpressionMotionManager.cpp
+++ b/src/Motion/CubismExpressionMotionManager.cpp
@@ -14,9 +14,7 @@
 namespace Live2D { namespace Cubism { namespace Framework {
 
 CubismExpressionMotionManager::CubismExpressionMotionManager()
-    : _currentPriority(0)
-    , _reservePriority(0)
-    , _expressionParameterValues(CSM_NEW csmVector<ExpressionParameterValue>())
+    : _expressionParameterValues(CSM_NEW csmVector<ExpressionParameterValue>())
     , _fadeWeights(CSM_NEW csmVector<csmFloat32>())
 { }
 
@@ -35,37 +33,6 @@ CubismExpressionMotionManager::~CubismExpressionMotionManager()
 
         _fadeWeights = NULL;
     }
-}
-
-csmInt32 CubismExpressionMotionManager::GetCurrentPriority() const
-{
-    CubismLogWarning("CubismExpressionMotionManager::GetCurrentPriority() is deprecated because a priority value is not actually used during expression motion playback.");
-    return _currentPriority;
-}
-
-csmInt32 CubismExpressionMotionManager::GetReservePriority() const
-{
-    CubismLogWarning("CubismExpressionMotionManager::GetReservePriority() is deprecated because a priority value is not actually used during expression motion playback.");
-    return _reservePriority;
-}
-
-void CubismExpressionMotionManager::SetReservePriority(csmInt32 priority)
-{
-    CubismLogWarning("CubismExpressionMotionManager::SetReservePriority() is deprecated because a priority value is not actually used during expression motion playback.");
-    _reservePriority = priority;
-}
-
-CubismMotionQueueEntryHandle CubismExpressionMotionManager::StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority)
-{
-    CubismLogWarning("CubismExpressionMotionManager::StartMotionPriority() is deprecated because a priority value is not actually used during expression motion playback.");
-
-    if (priority == _reservePriority)
-    {
-        _reservePriority = 0;           // 予約を解除
-    }
-    _currentPriority = priority;        // 再生中モーションの優先度を設定
-
-    return CubismMotionQueueManager::StartMotion(motion, autoDelete);
 }
 
 csmBool CubismExpressionMotionManager::UpdateMotion(CubismModel* model, csmFloat32 deltaTimeSeconds)

--- a/src/Motion/CubismExpressionMotionManager.hpp
+++ b/src/Motion/CubismExpressionMotionManager.hpp
@@ -41,46 +41,6 @@ public:
     virtual ~CubismExpressionMotionManager();
 
     /**
-     * Returns the priority of the playing facial expression motion.
-     *
-     * @deprecated This function is deprecated because a priority value is not actually used during expression motion playback.
-     *
-     * @return priority of the facial expression motion
-     */
-    csmInt32 GetCurrentPriority() const;
-
-    /**
-     * Returns the priority of the reserved facial expression motion.
-     *
-     * @deprecated This function is deprecated because a priority value is not actually used during expression motion playback.
-     *
-     * @return priority of the facial expression motion
-     */
-    csmInt32 GetReservePriority() const;
-
-    /**
-     * Sets the priority of the reserved facial expression motion.
-     *
-     * @deprecated This function is deprecated because a priority value is not actually used during expression motion playback.
-     *
-     * @param[in] priority priority to set
-     */
-    void SetReservePriority(csmInt32 priority);
-
-    /**
-     * Starts the facial expression motion with the specified priority.
-     *
-     * @deprecated This function is deprecated because a priority value is not actually used during expression motion playback.
-     *             Use CubismMotionQueueManager::StartMotion(ACubismMotion* motion, csmBool autoDelete) instead.
-     *
-     * @param[in] motion motion
-     * @param[in] autoDelete true to delete the instance of the motion when playback ends
-     * @param[in] priority priority
-     * @return identifier of the started motion. Use this as an argument to IsFinished() to determine if the individual motion has finished. Returns -1 if the motion could not be started.
-     */
-    CubismMotionQueueEntryHandle StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority);
-
-    /**
      * Updates the facial expression motion and reflects the parameter values on the model.
      *
      * @param[in] model target model
@@ -113,9 +73,6 @@ private:
 
     // Weights of the currently playing expression
     csmVector<csmFloat32>* _fadeWeights;
-
-    csmInt32 _currentPriority;    ///< @deprecated This variable is deprecated because a priority value is not actually used during expression motion playback.
-    csmInt32 _reservePriority;    ///< @deprecated This variable is deprecated because a priority value is not actually used during expression motion playback.
 };
 
 }}}

--- a/src/Motion/CubismExpressionUpdater.cpp
+++ b/src/Motion/CubismExpressionUpdater.cpp
@@ -1,0 +1,35 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismExpressionUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismExpressionUpdater::CubismExpressionUpdater(CubismExpressionMotionManager& expressionManager)
+    : ICubismUpdater(CubismUpdateOrder_Expression)
+    , _expressionManager(expressionManager)
+{
+}
+
+CubismExpressionUpdater::CubismExpressionUpdater(CubismExpressionMotionManager& expressionManager, const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _expressionManager(expressionManager)
+{
+}
+
+void CubismExpressionUpdater::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    // 表情でパラメータ更新（相対変化）
+    _expressionManager.UpdateMotion(model, deltaTimeSeconds);
+}
+
+}}}

--- a/src/Motion/CubismExpressionUpdater.hpp
+++ b/src/Motion/CubismExpressionUpdater.hpp
@@ -1,0 +1,59 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "Motion/CubismExpressionMotion.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating expressions motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismExpressionUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismExpressionUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param expressionManager `CubismExpressionMotionManager` reference
+     */
+    CubismExpressionUpdater(CubismExpressionMotionManager& expressionManager);
+
+    /**
+     * Constructor
+     *
+     * @param expressionManager `CubismExpressionMotionManager` reference
+     * @param executionOrder Order of operations
+     */
+    CubismExpressionUpdater(CubismExpressionMotionManager& expressionManager, csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismExpressionUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    CubismExpressionMotionManager& _expressionManager;
+};
+
+}}}

--- a/src/Motion/CubismEyeBlinkUpdater.cpp
+++ b/src/Motion/CubismEyeBlinkUpdater.cpp
@@ -1,0 +1,41 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismEyeBlinkUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismEyeBlinkUpdater::CubismEyeBlinkUpdater(const csmBool& motionUpdated, CubismEyeBlink& eyeBlink)
+    : ICubismUpdater(CubismUpdateOrder_EyeBlink)
+    , _motionUpdated(motionUpdated)
+    , _eyeBlink(eyeBlink)
+{
+}
+
+CubismEyeBlinkUpdater::CubismEyeBlinkUpdater(const csmBool& motionUpdated, CubismEyeBlink& eyeBlink, const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _motionUpdated(motionUpdated)
+    , _eyeBlink(eyeBlink)
+{
+}
+
+void CubismEyeBlinkUpdater::OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    if (!_motionUpdated)
+    {
+        // メインモーションの更新がないとき
+        // 目パチ
+        _eyeBlink.UpdateParameters(model, deltaTimeSeconds);
+    }
+}
+
+}}}

--- a/src/Motion/CubismEyeBlinkUpdater.hpp
+++ b/src/Motion/CubismEyeBlinkUpdater.hpp
@@ -1,0 +1,62 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "Effect/CubismEyeBlink.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating eye blink motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismEyeBlinkUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismEyeBlinkUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param motionUpdated Motion update flag reference
+     * @param eyeBlink `CubismEyeBlink` reference
+     */
+    CubismEyeBlinkUpdater(const csmBool& motionUpdated, CubismEyeBlink& eyeBlink);
+
+    /**
+     * Constructor
+     *
+     * @param motionUpdated Motion update flag reference
+     * @param eyeBlink `CubismEyeBlink` reference
+     * @param executionOrder Order of operations
+     */
+    CubismEyeBlinkUpdater(const csmBool& motionUpdated, CubismEyeBlink& eyeBlink, csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismEyeBlinkUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    const csmBool& _motionUpdated;
+    CubismEyeBlink& _eyeBlink;
+};
+
+}}}

--- a/src/Motion/CubismLipSyncUpdater.cpp
+++ b/src/Motion/CubismLipSyncUpdater.cpp
@@ -1,0 +1,46 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismLipSyncUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismLipSyncUpdater::CubismLipSyncUpdater(csmVector<CubismIdHandle>& lipSyncIds, IParameterProvider& wavFileHandler)
+    : ICubismUpdater(CubismUpdateOrder_LipSync)
+    , _wavFileHandler(wavFileHandler)
+    , _lipSyncIds(lipSyncIds)
+{
+}
+
+CubismLipSyncUpdater::CubismLipSyncUpdater(csmVector<CubismIdHandle>& lipSyncIds, IParameterProvider& wavFileHandler, const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _wavFileHandler(wavFileHandler)
+    , _lipSyncIds(lipSyncIds)
+{
+}
+
+void CubismLipSyncUpdater::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    // リアルタイムでリップシンクを行う場合、システムから音量を取得して0〜1の範囲で値を入力します。
+    csmFloat32 value = 0.0f;
+
+    // 状態更新/パラメータ値取得
+    _wavFileHandler.Update(deltaTimeSeconds);
+    value = _wavFileHandler.GetParameter();
+
+    for (csmUint32 i = 0; i < _lipSyncIds.GetSize(); ++i)
+    {
+        model->AddParameterValue(_lipSyncIds[i], value, 0.8f);
+    }
+}
+
+}}}

--- a/src/Motion/CubismLipSyncUpdater.hpp
+++ b/src/Motion/CubismLipSyncUpdater.hpp
@@ -1,0 +1,62 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "IParameterProvider.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating lip sync motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismLipSyncUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismLipSyncUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param lipSyncIds `csmVector<CubismIdHandle>` reference
+     * @param wavFileHandler `CubismWavFileHandler` reference
+     */
+    CubismLipSyncUpdater(csmVector<CubismIdHandle>& lipSyncIds, IParameterProvider& wavFileHandler);
+
+    /**
+     * Constructor
+     *
+     * @param lipSyncIds `csmVector<CubismIdHandle>` reference
+     * @param wavFileHandler `CubismWavFileHandler` reference
+     * @param executionOrder Order of operations
+     */
+    CubismLipSyncUpdater(csmVector<CubismIdHandle>& lipSyncIds, IParameterProvider& wavFileHandler, csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismLipSyncUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    IParameterProvider& _wavFileHandler;
+    const csmVector<CubismIdHandle>& _lipSyncIds;
+};
+
+}}}

--- a/src/Motion/CubismLookUpdater.cpp
+++ b/src/Motion/CubismLookUpdater.cpp
@@ -1,0 +1,45 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismLookUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismLookUpdater::CubismLookUpdater(
+    const CubismLook& look,
+  CubismTargetPoint& dragManager)
+    : ICubismUpdater(CubismUpdateOrder_Look)
+    , _look(look)
+    , _dragManager(dragManager)
+{
+}
+
+CubismLookUpdater::CubismLookUpdater(
+    const CubismLook& look,
+    CubismTargetPoint& dragManager,
+    const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _look(look)
+    , _dragManager(dragManager)
+{
+}
+
+void CubismLookUpdater::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    _dragManager.Update(deltaTimeSeconds);
+    const csmFloat32 dragX = _dragManager.GetX();
+    const csmFloat32 dragY = _dragManager.GetY();
+
+    _look.UpdateParameters(model, dragX, dragY);
+}
+
+}}}

--- a/src/Motion/CubismLookUpdater.hpp
+++ b/src/Motion/CubismLookUpdater.hpp
@@ -1,0 +1,70 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "Effect/CubismLook.hpp"
+#include "Math/CubismTargetPoint.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating drag motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismLookUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismLookUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param look        `CubismLook` reference
+     * @param dragManager `CubismTargetPoint` reference
+     */
+    CubismLookUpdater(
+        const CubismLook& look,
+        CubismTargetPoint& dragManager
+    );
+
+    /**
+     * Constructor
+     *
+     * @param look        `CubismLook` reference
+     * @param dragManager `CubismTargetPoint` reference
+     * @param executionOrder Order of operations
+     */
+    CubismLookUpdater(
+        const CubismLook& look,
+        CubismTargetPoint& dragManager,
+        csmInt32 executionOrder
+    );
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismLookUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    const CubismLook& _look;
+    CubismTargetPoint& _dragManager;
+};
+
+}}}

--- a/src/Motion/CubismMotion.cpp
+++ b/src/Motion/CubismMotion.cpp
@@ -876,34 +876,6 @@ csmFloat32 CubismMotion::GetParameterFadeOutTime(CubismIdHandle parameterId) con
     return -1;
 }
 
-void CubismMotion::IsLoop(csmBool loop)
-{
-    CubismLogWarning("IsLoop(csmBool loop) is a deprecated function. Please use SetLoop(csmBool loop).");
-
-    this->_isLoop = loop;
-}
-
-csmBool CubismMotion::IsLoop() const
-{
-    CubismLogWarning("IsLoop() is a deprecated function. Please use GetLoop().");
-
-    return this->_isLoop;
-}
-
-void CubismMotion::IsLoopFadeIn(csmBool loopFadeIn)
-{
-    CubismLogWarning("IsLoopFadeIn(csmBool loopFadeIn) is a deprecated function. Please use SetLoopFadeIn(csmBool loopFadeIn).");
-
-    this->_isLoopFadeIn = loopFadeIn;
-}
-
-csmBool CubismMotion::IsLoopFadeIn() const
-{
-    CubismLogWarning("IsLoopFadeIn() is a deprecated function. Please use GetLoopFadeIn().");
-
-    return this->_isLoopFadeIn;
-}
-
 void CubismMotion::SetMotionBehavior(MotionBehavior motionBehavior)
 {
     _motionBehavior = motionBehavior;

--- a/src/Motion/CubismMotion.hpp
+++ b/src/Motion/CubismMotion.hpp
@@ -57,46 +57,6 @@ public:
     virtual void        DoUpdateParameters(CubismModel* model, csmFloat32 userTimeSeconds, csmFloat32 fadeWeight, CubismMotionQueueEntry* motionQueueEntry);
 
     /**
-     * @deprecated Not recommended due to the relocation of _isLoop to the base class.
-     *             Use ACubismMotion.SetLoop(csmBool loop) instead.
-     *
-     * Sets whether the motion should loop.
-     *
-     * @param loop true to set the motion to loop
-     */
-    void                IsLoop(csmBool loop);
-
-    /**
-     * @deprecated Not recommended due to the relocation of _isLoop to the base class.
-     *             Use ACubismMotion.GetLoop() instead.
-     *
-     * Checks whether the motion is set to loop.
-     *
-     * @return true if the motion is set to loop; otherwise false.
-     */
-    csmBool             IsLoop() const;
-
-    /**
-     * @deprecated Not recommended due to the relocation of _isLoopFadeIn to the base class.
-     *             Use ACubismMotion.SetLoopFadeIn(csmBool loopFadeIn) instead.
-     *
-     * Sets whether to perform fade-in for looping motion.
-     *
-     * @param loopFadeIn true to perform fade-in for looping motion
-     */
-    void                IsLoopFadeIn(csmBool loopFadeIn);
-
-    /**
-     * @deprecated Not recommended due to the relocation of _isLoopFadeIn to the base class.
-     *             Use ACubismMotion.GetLoopFadeIn() instead.
-     *
-     * Checks the setting for fade-in of looping motion.
-     *
-     * @return true if fade-in for looping motion is set; otherwise false.
-     */
-    csmBool             IsLoopFadeIn() const;
-
-    /**
      * Sets the version of the Motion Behavior.
      *
      * @param Specifies the version of the Motion Behavior.

--- a/src/Motion/CubismMotionQueueManager.cpp
+++ b/src/Motion/CubismMotionQueueManager.cpp
@@ -61,38 +61,6 @@ CubismMotionQueueEntryHandle CubismMotionQueueManager::StartMotion(ACubismMotion
     return motionQueueEntry->_motionQueueEntryHandle;
 }
 
-CubismMotionQueueEntryHandle CubismMotionQueueManager::StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds)
-{
-    CubismLogWarning("StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds) is a deprecated function. Please use StartMotion(ACubismMotion* motion, csmBool autoDelete).");
-
-    if (motion == NULL)
-    {
-        return InvalidMotionQueueEntryHandleValue;
-    }
-
-    CubismMotionQueueEntry* motionQueueEntry = NULL;
-
-    // 既にモーションがあれば終了フラグを立てる
-    for (csmUint32 i = 0; i < _motions.GetSize(); ++i)
-    {
-        motionQueueEntry = _motions.At(i);
-        if (motionQueueEntry == NULL)
-        {
-            continue;
-        }
-
-        motionQueueEntry->SetFadeout(motionQueueEntry->_motion->GetFadeOutTime());
-    }
-
-    motionQueueEntry = CSM_NEW CubismMotionQueueEntry(); // 終了時に破棄する
-    motionQueueEntry->_autoDelete = autoDelete;
-    motionQueueEntry->_motion = motion;
-
-    _motions.PushBack(motionQueueEntry, false);
-
-    return motionQueueEntry->_motionQueueEntryHandle;
-}
-
 csmBool CubismMotionQueueManager::DoUpdateMotion(CubismModel* model, csmFloat32 userTimeSeconds)
 {
     csmBool updated = false;

--- a/src/Motion/CubismMotionQueueManager.hpp
+++ b/src/Motion/CubismMotionQueueManager.hpp
@@ -60,24 +60,6 @@ public:
     CubismMotionQueueEntryHandle    StartMotion(ACubismMotion* motion, csmBool autoDelete);
 
     /**
-     * @deprecated Not recommended as the third parameter userTimeSeconds is not used within the function.
-     *             Use StartMotion(ACubismMotion* motion, csmBool autoDelete) instead.
-     *
-     * Plays the motion.<br>
-     * If a motion of the same type is already playing, it ends the currently playing motion and starts fading it out.
-     *
-     * @param motion motion to play
-     * @param autoDelete true to delete the instance of the motion when playback ends
-     * @param userTimeSeconds current time in seconds
-     *
-     * @return ID of the played motion.<br>
-     *         -1 if the motion could not be started.
-     *
-     * @note The return value can be used as an argument to IsFinished() to determine if the motion has finished playing.
-     */
-    CubismMotionQueueEntryHandle    StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds);
-
-    /**
      * Checks whether all motions have finished playing.
      *
      * @return true if all motions have finished playing; otherwise false.

--- a/src/Motion/CubismPhysicsUpdater.cpp
+++ b/src/Motion/CubismPhysicsUpdater.cpp
@@ -1,0 +1,34 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismPhysicsUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismPhysicsUpdater::CubismPhysicsUpdater(CubismPhysics& physics)
+    : ICubismUpdater(CubismUpdateOrder_Physics)
+    , _physics(physics)
+{
+}
+
+CubismPhysicsUpdater::CubismPhysicsUpdater(CubismPhysics& physics, const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _physics(physics)
+{
+}
+
+void CubismPhysicsUpdater::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    _physics.Evaluate(model, deltaTimeSeconds);
+}
+
+}}}

--- a/src/Motion/CubismPhysicsUpdater.hpp
+++ b/src/Motion/CubismPhysicsUpdater.hpp
@@ -1,0 +1,59 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "Physics/CubismPhysics.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating pyhsucs motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismPhysicsUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismPhysicsUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param physics `CubismPhysics` reference
+     */
+    CubismPhysicsUpdater(CubismPhysics& physics);
+
+    /**
+     * Constructor
+     *
+     * @param physics `CubismPhysics` reference
+     * @param executionOrder Order of operations
+     */
+    CubismPhysicsUpdater(CubismPhysics& physics, csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismPhysicsUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    CubismPhysics& _physics;
+};
+
+}}}

--- a/src/Motion/CubismPoseUpdater.cpp
+++ b/src/Motion/CubismPoseUpdater.cpp
@@ -1,0 +1,34 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismPoseUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismPoseUpdater::CubismPoseUpdater(CubismPose& pose)
+    : ICubismUpdater(CubismUpdateOrder_Pose)
+    , _pose(pose)
+{
+}
+
+CubismPoseUpdater::CubismPoseUpdater(CubismPose& pose, const csmInt32 executionOrder)
+    : ICubismUpdater(executionOrder)
+    , _pose(pose)
+{
+}
+
+void CubismPoseUpdater::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (model == nullptr)
+    {
+        return;
+    }
+
+    _pose.UpdateParameters(model, deltaTimeSeconds);
+}
+
+}}}

--- a/src/Motion/CubismPoseUpdater.hpp
+++ b/src/Motion/CubismPoseUpdater.hpp
@@ -1,0 +1,59 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "ICubismUpdater.hpp"
+#include "Effect/CubismPose.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating pose motion.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class CubismPoseUpdater : public ICubismUpdater
+{
+public:
+    /**
+     * Delete constructor
+     */
+    CubismPoseUpdater() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param pose `CubismPose` reference
+     */
+    CubismPoseUpdater(CubismPose& pose);
+
+    /**
+     * Constructor
+     *
+     * @param pose `CubismPose` reference
+     * @param executionOrder Order of operations
+     */
+    CubismPoseUpdater(CubismPose& pose, csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~CubismPoseUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) override;
+
+private:
+    CubismPose& _pose;
+};
+
+}}}

--- a/src/Motion/CubismUpdateScheduler.cpp
+++ b/src/Motion/CubismUpdateScheduler.cpp
@@ -1,0 +1,56 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismUpdateScheduler.hpp"
+#include "Type/csmVectorSort.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+CubismUpdateScheduler::CubismUpdateScheduler()
+    : _needsSort(true)
+{
+}
+
+CubismUpdateScheduler::~CubismUpdateScheduler()
+{
+    for (csmUint32 i = 0; i < _cubismUpdatableList.GetSize(); ++i)
+    {
+        CSM_DELETE(_cubismUpdatableList[i]);
+    }
+}
+
+void CubismUpdateScheduler::AddUpdatableList(ICubismUpdater* updatable)
+{
+    if (updatable == nullptr)
+    {
+        return;
+    }
+
+    _cubismUpdatableList.PushBack(updatable);
+    _needsSort = true;
+}
+
+void CubismUpdateScheduler::SortUpdatableList()
+{
+    csmVectorSort::MergeSort(_cubismUpdatableList.Begin(), _cubismUpdatableList.End(), ICubismUpdater::SortFunction);
+    _needsSort = false;
+}
+
+void CubismUpdateScheduler::OnLateUpdate(CubismModel* model, const csmFloat32 deltaTimeSeconds)
+{
+    if (_needsSort)
+    {
+        SortUpdatableList();
+    }
+
+    for (csmUint32 i = 0; i < _cubismUpdatableList.GetSize(); ++i)
+    {
+        _cubismUpdatableList[i]->OnLateUpdate(model, deltaTimeSeconds);
+    }
+}
+
+}}}

--- a/src/Motion/CubismUpdateScheduler.hpp
+++ b/src/Motion/CubismUpdateScheduler.hpp
@@ -1,0 +1,72 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "Type/csmVector.hpp"
+#include "ICubismUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Class for updating registered motions in sequence.
+ */
+class CubismUpdateScheduler
+{
+public:
+    /**
+     * Constructor
+     */
+    CubismUpdateScheduler();
+
+    /**
+     * Delete Copy Constructor
+     */
+    CubismUpdateScheduler(const CubismUpdateScheduler&) = delete;
+
+    /**
+     * Delete Move Constructor
+     */
+    CubismUpdateScheduler(CubismUpdateScheduler&&) = delete;
+
+    /**
+     * Destructor
+     */
+    ~CubismUpdateScheduler();
+
+    /**
+     * Adds ICubismUpdater to the update list.
+     *
+     * @param updatable The ICubismUpdater instance to be added.
+     */
+    void AddUpdatableList(ICubismUpdater* updatable);
+
+    /**
+     * Sorts the update list.
+     */
+    void SortUpdatableList();
+
+    /**
+     * Updates every element in the list.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds);
+
+    /**
+     * Deleting the assignment operators
+     */
+    CubismUpdateScheduler& operator=(const CubismUpdateScheduler&) = delete;
+    CubismUpdateScheduler& operator=(CubismUpdateScheduler&&) = delete;
+
+private:
+    csmVector<ICubismUpdater*> _cubismUpdatableList;
+    csmBool _needsSort;
+};
+
+}}}

--- a/src/Motion/ICubismUpdater.cpp
+++ b/src/Motion/ICubismUpdater.cpp
@@ -1,0 +1,26 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "ICubismUpdater.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+csmBool ICubismUpdater::SortFunction(ICubismUpdater* left, ICubismUpdater* right)
+{
+    return left->_executionOrder < right->_executionOrder;
+}
+
+ICubismUpdater::ICubismUpdater()
+    : _executionOrder(CubismUpdateOrder_Max)
+{
+}
+
+ICubismUpdater::ICubismUpdater(const csmInt32 executionOrder)
+    : _executionOrder(executionOrder)
+{
+}
+}}}

--- a/src/Motion/ICubismUpdater.hpp
+++ b/src/Motion/ICubismUpdater.hpp
@@ -1,0 +1,75 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include <climits>
+#include "CubismFramework.hpp"
+#include "Model/CubismModel.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+enum CubismUpdateOrder
+{
+    CubismUpdateOrder_EyeBlink = 200,
+    CubismUpdateOrder_Expression = 300,
+    CubismUpdateOrder_Look = 400,
+    CubismUpdateOrder_Breath = 500,
+    CubismUpdateOrder_Physics = 600,
+    CubismUpdateOrder_LipSync = 700,
+    CubismUpdateOrder_Pose = 800,
+    CubismUpdateOrder_Max = INT_MAX
+};
+
+/**
+ * Abstract base class for motions.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+class ICubismUpdater
+{
+public:
+    /**
+     * Comparison function used when sorting ICubismUpdater objects.
+     *
+     * @param left Pointer to the first ICubismUpdater object to be compared.
+     * @param right Pointer to the second ICubismUpdater object to be compared.
+     *
+     * @return true if left should be placed before right in the sorted sequence.
+     *         false otherwise.
+     */
+    static csmBool SortFunction(ICubismUpdater* left, ICubismUpdater* right);
+
+    /**
+     * Constructor
+     */
+    ICubismUpdater();
+
+    /**
+     * Constructor
+     *
+     * @param executionOrder Order of operations
+     */
+    ICubismUpdater(csmInt32 executionOrder);
+
+    /**
+     * Destructor
+     */
+    virtual ~ICubismUpdater() = default;
+
+    /**
+     * Update process.
+     *
+     * @param model Model to update
+     * @param deltaTimeSeconds Delta time in seconds.
+     */
+    virtual void OnLateUpdate(CubismModel* model, csmFloat32 deltaTimeSeconds) = 0;
+
+private:
+    csmInt32 _executionOrder;
+};
+
+}}}

--- a/src/Motion/IParameterProvider.cpp
+++ b/src/Motion/IParameterProvider.cpp
@@ -1,0 +1,21 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "IParameterProvider.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+csmBool IParameterProvider::Update()
+{
+    return false;
+}
+
+csmBool IParameterProvider::Update(const csmFloat32 deltaTimeSeconds)
+{
+    return false;
+}
+}}}

--- a/src/Motion/IParameterProvider.hpp
+++ b/src/Motion/IParameterProvider.hpp
@@ -1,0 +1,55 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "CubismFramework.hpp"
+
+namespace Live2D { namespace Cubism { namespace Framework {
+
+/**
+ * Interface class for providing parameter values.<br>
+ * Defines the base interface for classes that supply parameter values to the model.
+ */
+class IParameterProvider
+{
+public:
+    /**
+     * Constructor
+     */
+    IParameterProvider() = default;
+
+    /**
+     * Destructor
+     */
+    virtual ~IParameterProvider() = default;
+
+    /**
+     * Update process.
+     *
+     * @return  true if the update is successful.
+     */
+    virtual csmBool Update();
+
+    /**
+     * Update process.
+     *
+     * @param deltaTimeSeconds Delta time in seconds.
+     *
+     * @return  true if the update is successful.
+     */
+    virtual csmBool Update(csmFloat32 deltaTimeSeconds);
+
+    /**
+     * Retrieves the current value of the parameter.
+     *
+     * @return  The parameter value as a floating-point number..
+     */
+    virtual csmFloat32 GetParameter() = 0;
+};
+
+}}}

--- a/src/Rendering/CubismClippingManager.tpp
+++ b/src/Rendering/CubismClippingManager.tpp
@@ -602,7 +602,7 @@ void CubismClippingManager<T_ClippingContext, T_RenderTarget>::CollectOffscreenC
 template <class T_ClippingContext, class T_RenderTarget>
 void CubismClippingManager<T_ClippingContext, T_RenderTarget>::CollectPartChildDrawableIndexList(CubismModel& model, csmInt32 partIndex, csmVector<csmInt32>& childDrawableIndexList)
 {
-    CubismModel::PartChildDrawObjects childDrawObjects = model.GetPartsHierarchy()[partIndex].ChildDrawObjects;
+    PartChildDrawObjects childDrawObjects = model.GetPartsHierarchy()[partIndex].ChildDrawObjects;
     for (csmInt32 i = 0; i < childDrawObjects.DrawableIndices.GetSize(); ++i)
     {
         childDrawableIndexList.PushBack(childDrawObjects.DrawableIndices[i]);

--- a/src/Rendering/D3D11/CubismDeviceInfo_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismDeviceInfo_D3D11.cpp
@@ -20,6 +20,8 @@ CubismDeviceInfo_D3D11* CubismDeviceInfo_D3D11::GetDeviceInfo(ID3D11Device* devi
     if (!s_deviceInfoList.IsExist(device))
     {
         s_deviceInfoList[device]._renderState = CSM_NEW CubismRenderState_D3D11(device);
+        // シェーダの事前初期化
+        s_deviceInfoList[device]._shader.SetupShader(device);
     }
     return &s_deviceInfoList[device];
 }

--- a/src/Rendering/D3D11/CubismRenderState_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismRenderState_D3D11.cpp
@@ -200,7 +200,7 @@ void CubismRenderState_D3D11::Create(ID3D11Device* device)
     // origin
     _samplerState.PushBack(NULL);
 
-    // normal
+    // drawable
     samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
     samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_WRAP;
     samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_WRAP;
@@ -209,7 +209,12 @@ void CubismRenderState_D3D11::Create(ID3D11Device* device)
     samplerDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
     samplerDesc.MinLOD = -D3D11_FLOAT32_MAX;
     samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
-    samplerDesc.BorderColor[0] = samplerDesc.BorderColor[1] = samplerDesc.BorderColor[2] = samplerDesc.BorderColor[3] = 1.0f;
+    samplerDesc.BorderColor[0] = samplerDesc.BorderColor[1] = samplerDesc.BorderColor[2] = samplerDesc.BorderColor[3] = 0.0f;
+    device->CreateSamplerState(&samplerDesc, &sampler);
+    _samplerState.PushBack(sampler);
+
+    // other
+    samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
     device->CreateSamplerState(&samplerDesc, &sampler);
     _samplerState.PushBack(sampler);
 
@@ -407,6 +412,9 @@ void CubismRenderState_D3D11::SetSampler(ID3D11DeviceContext* renderContext, Sam
         // 0番だけ使用している
         renderContext->PSSetSamplers(0, 1, &_samplerState[sample]);
     }
+
+    renderContext->PSSetSamplers(1, 1, &_samplerState[Sampler_Other]);
+    renderContext->PSSetSamplers(2, 1, &_samplerState[Sampler_Other]);
 
     _stored._sampler = sample;
     _stored._anisotropy = anisotropy;

--- a/src/Rendering/D3D11/CubismRenderState_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismRenderState_D3D11.hpp
@@ -69,7 +69,8 @@ public:
     enum Sampler
     {
         Sampler_Origin,     ///< 元々の設定
-        Sampler_Normal,     ///< 使用ステート
+        Sampler_Drawable,   ///< アートメッシュ用の使用ステート
+        Sampler_Other,      ///< アートメッシュ以外用の使用ステート
         Sampler_Anisotropy, ///< 異方性フィルタリング使用
         Sampler_Max,
     };
@@ -97,7 +98,7 @@ public:
             _viewportMinZ = 0.0f;
             _viewportMaxZ = 0.0f;
 
-            _sampler = Sampler_Normal;
+            _sampler = Sampler_Drawable;
             _anisotropy = 0.0f;
 
             memset(_valid, 0, sizeof(_valid));

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.cpp
@@ -165,23 +165,23 @@ DirectX::XMMATRIX ConvertToD3DX(CubismMatrix44& mtx)
 {
     DirectX::XMMATRIX retMtx;
     retMtx.r[0].m128_f32[0] = mtx.GetArray()[ 0];
-    retMtx.r[0].m128_f32[1] = mtx.GetArray()[ 1];
-    retMtx.r[0].m128_f32[2] = mtx.GetArray()[ 2];
-    retMtx.r[0].m128_f32[3] = mtx.GetArray()[ 3];
+    retMtx.r[0].m128_f32[1] = mtx.GetArray()[ 4];
+    retMtx.r[0].m128_f32[2] = mtx.GetArray()[ 8];
+    retMtx.r[0].m128_f32[3] = mtx.GetArray()[12];
 
-    retMtx.r[1].m128_f32[0] = mtx.GetArray()[ 4];
+    retMtx.r[1].m128_f32[0] = mtx.GetArray()[ 1];
     retMtx.r[1].m128_f32[1] = mtx.GetArray()[ 5];
-    retMtx.r[1].m128_f32[2] = mtx.GetArray()[ 6];
-    retMtx.r[1].m128_f32[3] = mtx.GetArray()[ 7];
+    retMtx.r[1].m128_f32[2] = mtx.GetArray()[ 9];
+    retMtx.r[1].m128_f32[3] = mtx.GetArray()[13];
 
-    retMtx.r[2].m128_f32[0] = mtx.GetArray()[ 8];
-    retMtx.r[2].m128_f32[1] = mtx.GetArray()[ 9];
+    retMtx.r[2].m128_f32[0] = mtx.GetArray()[ 2];
+    retMtx.r[2].m128_f32[1] = mtx.GetArray()[ 6];
     retMtx.r[2].m128_f32[2] = mtx.GetArray()[10];
-    retMtx.r[2].m128_f32[3] = mtx.GetArray()[11];
+    retMtx.r[2].m128_f32[3] = mtx.GetArray()[14];
 
-    retMtx.r[3].m128_f32[0] = mtx.GetArray()[12];
-    retMtx.r[3].m128_f32[1] = mtx.GetArray()[13];
-    retMtx.r[3].m128_f32[2] = mtx.GetArray()[14];
+    retMtx.r[3].m128_f32[0] = mtx.GetArray()[ 3];
+    retMtx.r[3].m128_f32[1] = mtx.GetArray()[ 7];
+    retMtx.r[3].m128_f32[2] = mtx.GetArray()[11];
     retMtx.r[3].m128_f32[3] = mtx.GetArray()[15];
 
     return retMtx;
@@ -544,8 +544,8 @@ void CubismRenderer_D3D11::StartFrame(ID3D11DeviceContext* context)
     // レンダーステートフレーム先頭処理
     _deviceInfo->GetRenderState()->StartFrame();
 
-    // シェーダ・頂点宣言
-    _deviceInfo->GetShader()->SetupShader(_device, _context);
+    // コンテキストにシェーダーをバインド
+    _deviceInfo->GetShader()->BindShader(_context);
 }
 
 void CubismRenderer_D3D11::EndFrame()
@@ -835,15 +835,15 @@ void CubismRenderer_D3D11::ReleaseCommandBuffer()
         CSM_FREE(_constantBuffers);
         _constantBuffers = NULL;
     }
-    if (_constantBuffers != NULL)
+    if (_indexBuffers != NULL)
     {
         CSM_FREE(_indexBuffers);
-        _constantBuffers = NULL;
+        _indexBuffers = NULL;
     }
-    if (_constantBuffers != NULL)
+    if (_vertexBuffers != NULL)
     {
         CSM_FREE(_vertexBuffers);
-        _constantBuffers = NULL;
+        _vertexBuffers = NULL;
     }
 }
 
@@ -1303,7 +1303,7 @@ void CubismRenderer_D3D11::ExecuteDrawForMask(const CubismModel& model, const cs
 
     // テクスチャ + サンプラーセット
     SetTextureViewForDrawable(model, index);
-    SetSamplerAccordingToAnisotropy();
+    SetSamplerAccordingToAnisotropy(true);
 
     // シェーダーセット
     _context->VSSetShader(_deviceInfo->GetShader()->GetVertexShader(ShaderNames_SetupMask), NULL, 0);
@@ -1321,9 +1321,7 @@ void CubismRenderer_D3D11::ExecuteDrawForMask(const CubismModel& model, const cs
         // 色
         csmRectF* rect = GetClippingContextBufferForMask()->_layoutBounds;
         CubismTextureColor baseColor = {rect->X * 2.0f - 1.0f, rect->Y * 2.0f - 1.0f, rect->GetRight() * 2.0f - 1.0f, rect->GetBottom() * 2.0f - 1.0f};
-        CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-        CubismTextureColor screenColor = model.GetScreenColor(index);
-        SetColorConstantBuffer(cb, baseColor, multiplyColor, screenColor);
+        XMStoreFloat4(&cb.baseColor, DirectX::XMVectorSet(baseColor.R, baseColor.G, baseColor.B, baseColor.A));
 
         // プロジェクションMtx
         SetProjectionMatrix(cb, GetClippingContextBufferForMask()->_matrixForMask);
@@ -1348,7 +1346,7 @@ void CubismRenderer_D3D11::ExecuteDrawForDrawable(const CubismModel& model, cons
 
     // テクスチャ+サンプラーセット
     SetTextureViewForDrawable(model, index, isBlendMode);
-    SetSamplerAccordingToAnisotropy();
+    SetSamplerAccordingToAnisotropy(true);
 
     // シェーダーセット
     SetShaderForDrawable(model, index, blendMode);
@@ -1363,7 +1361,7 @@ void CubismRenderer_D3D11::ExecuteDrawForDrawable(const CubismModel& model, cons
         {
             // View座標をClippingContextの座標に変換するための行列を設定
             DirectX::XMMATRIX clip = ConvertToD3DX(GetClippingContextBufferForDrawable()->_matrixForDraw);
-            XMStoreFloat4x4(&cb.clipMatrix, DirectX::XMMatrixTranspose(clip));
+            XMStoreFloat4x4(&cb.clipMatrix, clip);
 
             // 使用するカラーチャンネルを設定
             CubismClippingContext_D3D11* contextBuffer = GetClippingContextBufferForDrawable();
@@ -1389,8 +1387,9 @@ void CubismRenderer_D3D11::ExecuteDrawForDrawable(const CubismModel& model, cons
             // ブレンドモード使用しない場合はDrawable単位でモデルカラーを処理する
             baseColor = GetModelColorWithOpacity(model.GetDrawableOpacity(index));
         }
-        CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-        CubismTextureColor screenColor = model.GetScreenColor(index);
+        const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+        CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetDrawableMultiplyColor(index);
+        CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetDrawableScreenColor(index);
         SetColorConstantBuffer(cb, baseColor, multiplyColor, screenColor);
 
         // プロジェクションMtx
@@ -1418,7 +1417,7 @@ void CubismRenderer_D3D11::ExecuteDrawForOffscreen(const CubismModel& model, Cub
 
     // テクスチャ + サンプラーセット
     SetTextureViewForOffscreen(model, offscreen);
-    SetSamplerAccordingToAnisotropy();
+    SetSamplerAccordingToAnisotropy(false);
 
     // シェーダーセット
     SetShaderForOffscreen(model, offscreenIndex, blendMode);
@@ -1433,7 +1432,7 @@ void CubismRenderer_D3D11::ExecuteDrawForOffscreen(const CubismModel& model, Cub
         {
             // View座標をClippingContextの座標に変換するための行列を設定
             DirectX::XMMATRIX clip = ConvertToD3DX(GetClippingContextBufferForOffscreen()->_matrixForDraw);
-            XMStoreFloat4x4(&cb.clipMatrix, DirectX::XMMatrixTranspose(clip));
+            XMStoreFloat4x4(&cb.clipMatrix, clip);
 
             // 使用するカラーチャンネルを設定
             CubismClippingContext_D3D11* contextBuffer = GetClippingContextBufferForOffscreen();
@@ -1444,8 +1443,9 @@ void CubismRenderer_D3D11::ExecuteDrawForOffscreen(const CubismModel& model, Cub
         csmFloat32 offscreenOpacity = model.GetOffscreenOpacity(offscreenIndex);
         // PMAなのと不透明度だけを変更したいためすべてOpacityで初期化
         CubismTextureColor baseColor(offscreenOpacity, offscreenOpacity, offscreenOpacity, offscreenOpacity);
-        CubismTextureColor multiplyColor = model.GetMultiplyColorOffscreen(offscreenIndex);
-        CubismTextureColor screenColor = model.GetScreenColorOffscreen(offscreenIndex);
+        const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+        CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetOffscreenMultiplyColor(offscreenIndex);
+        CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetOffscreenScreenColor(offscreenIndex);
         SetColorConstantBuffer(cb, baseColor, multiplyColor, screenColor);
 
         // プロジェクション行列
@@ -1495,7 +1495,7 @@ void CubismRenderer_D3D11::ExecuteDrawForRenderTarget()
     // テクスチャ+サンプラーセット
     ID3D11ShaderResourceView* const viewArray[3] = { _modelRenderTargets[0].GetTextureView(), NULL, NULL };
     _context->PSSetShaderResources(0, 3, viewArray);
-    SetSamplerAccordingToAnisotropy();
+    SetSamplerAccordingToAnisotropy(false);
 
     // シェーダーセット
     _context->VSSetShader(_deviceInfo->GetShader()->GetVertexShader(ShaderNames_Copy), NULL, 0);
@@ -1957,7 +1957,7 @@ void CubismRenderer_D3D11::SetColorChannel(CubismConstantBufferD3D11& cb, Cubism
 void CubismRenderer_D3D11::SetProjectionMatrix(CubismConstantBufferD3D11& cb, CubismMatrix44 matrix)
 {
     DirectX::XMMATRIX proj = ConvertToD3DX(matrix);
-    XMStoreFloat4x4(&cb.projectMatrix, DirectX::XMMatrixTranspose(proj));
+    XMStoreFloat4x4(&cb.projectMatrix, proj);
 }
 
 void CubismRenderer_D3D11::UpdateConstantBuffer(CubismConstantBufferD3D11& cb, csmInt32 index)
@@ -1969,15 +1969,22 @@ void CubismRenderer_D3D11::UpdateConstantBuffer(CubismConstantBufferD3D11& cb, c
     _context->PSSetConstantBuffers(0, 1, &constantBuffer);
 }
 
-void CubismRenderer_D3D11::SetSamplerAccordingToAnisotropy()
+void CubismRenderer_D3D11::SetSamplerAccordingToAnisotropy(const csmBool useDrawable)
 {
-    if (GetAnisotropy() >= 1.0f)
+    if (useDrawable)
     {
-        _deviceInfo->GetRenderState()->SetSampler(_context, CubismRenderState_D3D11::Sampler_Anisotropy, GetAnisotropy(), _device);
+        if (GetAnisotropy() >= 1.0f)
+        {
+            _deviceInfo->GetRenderState()->SetSampler(_context, CubismRenderState_D3D11::Sampler_Anisotropy, GetAnisotropy(), _device);
+        }
+        else
+        {
+            _deviceInfo->GetRenderState()->SetSampler(_context, CubismRenderState_D3D11::Sampler_Drawable);
+        }
     }
     else
     {
-        _deviceInfo->GetRenderState()->SetSampler(_context, CubismRenderState_D3D11::Sampler_Normal);
+        _deviceInfo->GetRenderState()->SetSampler(_context, CubismRenderState_D3D11::Sampler_Other);
     }
 }
 

--- a/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismRenderer_D3D11.hpp
@@ -558,8 +558,10 @@ private:
 
     /**
      * @brief   異方向フィルタリングの値によってサンプラーを設定する。
+     *
+     * @param[in]   useDrawable -> 画像の読み込みとしてDrawableを使用するか
      */
-    void SetSamplerAccordingToAnisotropy();
+    void SetSamplerAccordingToAnisotropy(csmBool useDrawable);
 
     /**
      * @brief   マスク生成時かを判定する

--- a/src/Rendering/D3D11/CubismShader_D3D11.cpp
+++ b/src/Rendering/D3D11/CubismShader_D3D11.cpp
@@ -95,9 +95,22 @@ void CubismShader_D3D11::GenerateShaders(ID3D11Device* device)
 
         csmSizeInt effectShaderSize;
         csmByte* effectShaderSrc = fileLoader(frameworkShaderPath, &effectShaderSize);
-        csmString shaderString = csmString(reinterpret_cast<const csmChar*>(effectShaderSrc), effectShaderSize);
+        if (effectShaderSrc == NULL)
+        {
+            CubismLogError("Failed to load effect shader");
+            break;
+        }
+
         csmSizeInt blendShaderSize;
         csmByte* blendShaderSrc = fileLoader(frameworkBlendShaderPath, &blendShaderSize);
+        if (blendShaderSrc == NULL)
+        {
+            CubismLogError("Failed to load blend shader");
+            bytesReleaser(effectShaderSrc);
+            break;
+        }
+
+        csmString shaderString = csmString(reinterpret_cast<const csmChar*>(effectShaderSrc), effectShaderSize);
         shaderString += csmString(reinterpret_cast<const csmChar*>(blendShaderSrc), blendShaderSize);
 
         // ファイル読み込みで確保したバイト列を開放
@@ -157,26 +170,6 @@ void CubismShader_D3D11::GenerateShaders(ID3D11Device* device)
         CSM_SET_SHADER_53(COLOR, Out) \
         CSM_SET_SHADER_53(COLOR, ConjointOver) \
         CSM_SET_SHADER_53(COLOR, DisjointOver) \
-    }
-
-        // 5.2以前 copy
-        if (!LoadShaderProgram(device, false, ShaderNames_Copy, "VertCopy", shaderString))
-        {
-            break;
-        }
-        if (!LoadShaderProgram(device, true, ShaderNames_Copy, "PixelCopy", shaderString))
-        {
-            break;
-        }
-
-        // 5.2以前 setup mask
-        if (!LoadShaderProgram(device, false, ShaderNames_SetupMask, "VertSetupMask", shaderString))
-        {
-            break;
-        }
-        if (!LoadShaderProgram(device, true, ShaderNames_SetupMask, "PixelSetupMask", shaderString))
-        {
-            break;
     }
 
         // 5.2以前 normal
@@ -385,17 +378,21 @@ ID3D11PixelShader* CubismShader_D3D11::GetPixelShader(csmUint32 assign)
     return NULL;
 }
 
-void CubismShader_D3D11::SetupShader(ID3D11Device* device, ID3D11DeviceContext* renderContext)
+void CubismShader_D3D11::SetupShader(ID3D11Device* device)
 {
     // まだシェーダ・頂点宣言未作成ならば作成する
     GenerateShaders(device);
+}
 
-    if (!renderContext || !_vertexFormat)
+void CubismShader_D3D11::BindShader(ID3D11DeviceContext* context)
+{
+
+    if (!context || !_vertexFormat)
     {
         return;
     }
 
-    renderContext->IASetInputLayout(_vertexFormat);
+    context->IASetInputLayout(_vertexFormat);
 }
 
 }}}}

--- a/src/Rendering/D3D11/CubismShader_D3D11.hpp
+++ b/src/Rendering/D3D11/CubismShader_D3D11.hpp
@@ -146,8 +146,17 @@ public:
 
     /**
      * @brief   頂点宣言のデバイスへの設定、シェーダがまだ未設定ならロード
+     *
+     * @param[in]   device      使用デバイス
      */
-    void SetupShader(ID3D11Device* device, ID3D11DeviceContext* renderContext);
+    void SetupShader(ID3D11Device* device);
+
+    /**
+     * @brief   コンテキストにシェーダを設定する
+     *
+     * @param[in]   context      コンテキスト
+     */
+    void BindShader(ID3D11DeviceContext* context);
 
 private:
     /**

--- a/src/Rendering/D3D11/Shaders/CubismBlendMode.fx
+++ b/src/Rendering/D3D11/Shaders/CubismBlendMode.fx
@@ -19,7 +19,7 @@ VS_OUT VertCopy(VS_IN In) {
 }
 
 float4 PixelCopy(VS_OUT In) : SV_Target {
-    float4 color = mainTexture.Sample(mainSampler, In.uv);
+    float4 color = mainTexture.Sample(blendSampler, In.uv);
     return color * baseColor;
 }
 
@@ -355,7 +355,7 @@ ColorInfo GetNormalColorInfo(VS_OUT In) {
     texColor.rgb = (texColor.rgb + screenColor.rgb) - (texColor.rgb * screenColor.rgb);
     ColorInfo color;
     color.source = texColor * baseColor;
-    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(mainSampler, In.blendUv));
+    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(blendSampler, In.blendUv));
     return color;
 }
 
@@ -366,7 +366,7 @@ ColorInfo GetNormalPremultColorInfo(VS_OUT In) {
     texColor.rgb = (texColor.rgb + screenColor.rgb * texColor.a) - (texColor.rgb * screenColor.rgb);
     ColorInfo color;
     color.source = ConvertPremultipliedToStraight(texColor * baseColor);
-    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(mainSampler, In.blendUv));
+    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(blendSampler, In.blendUv));
     return color;
 }
 
@@ -382,7 +382,7 @@ ColorInfo GetMaskedColorInfo(VS_OUT In) {
     float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, maskUv)) * channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     color.source = float4(color.source.rgb, color.source.a * maskVal);
-    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(mainSampler, In.blendUv));
+    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(blendSampler, In.blendUv));
     return color;
 }
 
@@ -398,7 +398,7 @@ ColorInfo GetMaskedInvertedColorInfo(VS_OUT In) {
     float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, maskUv)) * channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     color.source = float4(color.source.rgb, color.source.a * (1.0f - maskVal));
-    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(mainSampler, In.blendUv));
+    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(blendSampler, In.blendUv));
     return color;
 }
 
@@ -414,7 +414,7 @@ ColorInfo GetMaskedPremultColorInfo(VS_OUT In) {
     float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, maskUv)) * channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     color.source = float4(color.source.rgb, color.source.a * maskVal);
-    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(mainSampler, In.blendUv));
+    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(blendSampler, In.blendUv));
     return color;
 }
 
@@ -430,7 +430,7 @@ ColorInfo GetMaskedInvertedPremultColorInfo(VS_OUT In) {
     float4 clipMask = (1.0f - maskTexture.Sample(mainSampler, maskUv)) * channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     color.source = float4(color.source.rgb, color.source.a * (1.0f - maskVal));
-    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(mainSampler, In.blendUv));
+    color.destination = ConvertPremultipliedToStraight(blendTexture.Sample(blendSampler, In.blendUv));
     return color;
 }
 
@@ -466,16 +466,6 @@ CSM_CREATE_BLEND_MODE(COLOR, ConjointOver) \
 CSM_CREATE_BLEND_MODE(COLOR, DisjointOver)
 
 // normal
-CSM_CREATE_PIXEL_FUNC(Masked, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(MaskedInverted, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(NormalPremult, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(MaskedPremult, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(MaskedInvertedPremult, Normal, Over)
-
 CSM_CREATE_BLEND_MODE(Normal, Atop)
 
 CSM_CREATE_BLEND_MODE(Normal, Out)

--- a/src/Rendering/D3D11/Shaders/CubismEffect.fx
+++ b/src/Rendering/D3D11/Shaders/CubismEffect.fx
@@ -15,6 +15,8 @@ cbuffer ConstantBuffer {
 }
 
 SamplerState mainSampler : register(s0);
+SamplerState maskSampler : register(s1);
+SamplerState blendSampler : register(s2);
 Texture2D mainTexture : register(t0);
 Texture2D maskTexture : register(t1);
 Texture2D blendTexture : register(t2);

--- a/src/Rendering/D3D9/CubismDeviceInfo_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismDeviceInfo_D3D9.cpp
@@ -17,6 +17,11 @@ namespace {
 
 CubismDeviceInfo_D3D9* CubismDeviceInfo_D3D9::GetDeviceInfo(LPDIRECT3DDEVICE9 device)
 {
+    if (!s_deviceInfoList.IsExist(device))
+    {
+        // シェーダの事前初期化
+        s_deviceInfoList[device]._shader.SetupShader(device);
+    }
     return &s_deviceInfoList[device];
 }
 

--- a/src/Rendering/D3D9/CubismRenderState_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismRenderState_D3D9.cpp
@@ -78,15 +78,15 @@ void CubismRenderState_D3D9::Restore(LPDIRECT3DDEVICE9 device)
             SetCullMode(device, current.CullModeFaceMode, true);
             isSet[State_CullMode] = true;
         }
-        if (_pushed[i]._valid[State_TextureFilterStage0] && !isSet[State_TextureFilterStage0])
+        for (csmUint32 j = 0; j < 3; ++j)
         {
-            SetTextureFilter(device, 0, current.MinFilter[0], current.MagFilter[0], current.MipFilter[0], current.AddressU[0], current.AddressV[0], current.Anisotropy[0], true);
-            isSet[State_TextureFilterStage0] = true;
-        }
-        if (_pushed[i]._valid[State_TextureFilterStage1] && !isSet[State_TextureFilterStage1])
-        {
-            SetTextureFilter(device, 1, current.MinFilter[1], current.MagFilter[1], current.MipFilter[1], current.AddressU[1], current.AddressV[1], current.Anisotropy[1], true);
-            isSet[State_TextureFilterStage1] = true;
+            csmInt32 stateIndex = State_TextureFilterStage0 + j;
+
+            if (_pushed[i]._valid[stateIndex] && !isSet[stateIndex])
+            {
+                SetTextureFilter(device, j, current.MinFilter[j], current.MagFilter[j], current.MipFilter[j], current.AddressU[j], current.AddressV[j], current.Anisotropy[j], true);
+                isSet[stateIndex] = true;
+            }
         }
     }
 
@@ -202,12 +202,21 @@ void CubismRenderState_D3D9::SetCullMode(LPDIRECT3DDEVICE9 device, D3DCULL cullF
     _stored._valid[State_CullMode] = true;
 }
 
-void CubismRenderState_D3D9::SetTextureFilter(LPDIRECT3DDEVICE9 device, csmInt32 stage, D3DTEXTUREFILTERTYPE minFilter, D3DTEXTUREFILTERTYPE magFilter, D3DTEXTUREFILTERTYPE mipFilter, D3DTEXTUREADDRESS addressU, D3DTEXTUREADDRESS addressV, csmFloat32 anisotropy, csmBool force)
+void CubismRenderState_D3D9::SetTextureFilter(
+    LPDIRECT3DDEVICE9 device,
+    csmInt32 stage,
+    D3DTEXTUREFILTERTYPE minFilter,
+    D3DTEXTUREFILTERTYPE magFilter,
+    D3DTEXTUREFILTERTYPE mipFilter,
+    D3DTEXTUREADDRESS addressU,
+    D3DTEXTUREADDRESS addressV,
+    csmFloat32 anisotropy,
+    csmBool force)
 {
     const csmInt32 stateIndex = State_TextureFilterStage0 + stage;
 
     // ステージインデックスの範囲内検知
-    CSM_ASSERT((stateIndex == State_TextureFilterStage0) || (stateIndex == State_TextureFilterStage1));
+    CSM_ASSERT(State_TextureFilterStage0 <= stateIndex && stateIndex <= State_TextureFilterStage2);
 
     if (!_stored._valid[stateIndex] || force ||
         _stored.MinFilter[stage] != minFilter ||

--- a/src/Rendering/D3D9/CubismRenderState_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismRenderState_D3D9.hpp
@@ -33,6 +33,7 @@ public:
         State_CullMode,     ///< カリングモード
         State_TextureFilterStage0, ///< テクスチャフィルター（ステージ0）
         State_TextureFilterStage1, ///< テクスチャフィルター（ステージ1）
+        State_TextureFilterStage2, ///< テクスチャフィルター（ステージ2）
         State_Max,
     };
 
@@ -80,6 +81,13 @@ public:
             AddressV[1] = D3DTADDRESS_WRAP;
             Anisotropy[1] = 1.0f;
 
+            MinFilter[2] = D3DTEXF_NONE;
+            MagFilter[2] = D3DTEXF_NONE;
+            MipFilter[2] = D3DTEXF_NONE;
+            AddressU[2] = D3DTADDRESS_WRAP;
+            AddressV[2] = D3DTADDRESS_WRAP;
+            Anisotropy[2] = 1.0f;
+
             memset(_valid, 0, sizeof(_valid));
         }
 
@@ -112,12 +120,12 @@ public:
         D3DCULL CullModeFaceMode; // 消す面を指定 CWだと時計回りが消える
 
         // State_TextureFilter サンプラーフィルター(0番, 1番)
-        D3DTEXTUREFILTERTYPE    MinFilter[2];
-        D3DTEXTUREFILTERTYPE    MagFilter[2];
-        D3DTEXTUREFILTERTYPE    MipFilter[2];
-        D3DTEXTUREADDRESS       AddressU[2];
-        D3DTEXTUREADDRESS       AddressV[2];
-        float                   Anisotropy[2];
+        D3DTEXTUREFILTERTYPE    MinFilter[3];
+        D3DTEXTUREFILTERTYPE    MagFilter[3];
+        D3DTEXTUREFILTERTYPE    MipFilter[3];
+        D3DTEXTUREADDRESS       AddressU[3];
+        D3DTEXTUREADDRESS       AddressV[3];
+        float                   Anisotropy[3];
 
         csmBool _valid[State_Max];    ///< 設定したかどうか。現在はStartFrameで一通りは呼んでいる
     };
@@ -198,15 +206,26 @@ public:
     /**
      * @brief   テクスチャサンプラーにフィルタセット
      *
-     * @param   device[in]     描画デバイス
-     * @param   stage[in]       サンプラーステージインデックス（サンプラー番号）
-     * @param   minFilter[in]   縮小時フィルタ
-     * @param   magFilter[in]   拡大時フィルタ
-     * @param   mipFilter[in]   ミップフィルタ
-     * @param   addressU[in]    アドレッシングモードU
-     * @param   addressV[in]    アドレッシングモードV
+     * @param   device[in]       描画デバイス
+     * @param   stage[in]        サンプラーステージインデックス（サンプラー番号）
+     * @param   minFilter[in]    縮小時フィルタ
+     * @param   magFilter[in]    拡大時フィルタ
+     * @param   mipFilter[in]    ミップフィルタ
+     * @param   addressU[in]     アドレッシングモードU
+     * @param   addressV[in]     アドレッシングモードV
+     * @param   anisotropy[in]   異方性フィルタリング
+     * @param   force[in]        強制フラグ
      */
-    void SetTextureFilter(LPDIRECT3DDEVICE9 device, csmInt32 stage, D3DTEXTUREFILTERTYPE minFilter, D3DTEXTUREFILTERTYPE magFilter, D3DTEXTUREFILTERTYPE mipFilter, D3DTEXTUREADDRESS addressU, D3DTEXTUREADDRESS addressV, csmFloat32 anisotropy = 1.0f, csmBool force = false);
+    void SetTextureFilter(
+        LPDIRECT3DDEVICE9 device,
+        csmInt32 stage,
+        D3DTEXTUREFILTERTYPE minFilter,
+        D3DTEXTUREFILTERTYPE magFilter,
+        D3DTEXTUREFILTERTYPE mipFilter,
+        D3DTEXTUREADDRESS addressU,
+        D3DTEXTUREADDRESS addressV,
+        csmFloat32 anisotropy = 1.0f,
+        csmBool force = false);
 
 private:
     /**

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.cpp
@@ -491,8 +491,8 @@ void CubismRenderer_D3D9::StartFrame()
     // レンダーステートフレーム先頭処理
     _deviceInfo->GetRenderState()->StartFrame();
 
-    // シェーダ・頂点宣言
-    _deviceInfo->GetShader()->SetupShader(_device);
+    // シェーダーのバインド
+    _deviceInfo->GetShader()->BindShader(_device);
 }
 
 void CubismRenderer_D3D9::EndFrame()
@@ -1151,11 +1151,7 @@ void CubismRenderer_D3D9::ExecuteDrawForDrawable(const CubismModel& model, const
     csmBool isBlendMode;
     csmBlendMode blendMode = model.GetDrawableBlendModeType(index);
     SetBlendMode(blendMode, isBlendMode);
-    if (isBlendMode)
-    {
-        int stop = 0;
-    }
-    SetTextureFilter();
+    SetTextureFilter(true);
     SetTechniqueForDrawable(model, index, isBlendMode, blendMode);
 
     // numPassには指定のtechnique内に含まれるpassの数が返る
@@ -1203,8 +1199,9 @@ void CubismRenderer_D3D9::ExecuteDrawForDrawable(const CubismModel& model, const
             // ブレンドモード使用しない場合はDrawable単位でモデルカラーを処理する
             baseColor = GetModelColorWithOpacity(model.GetDrawableOpacity(index));
         }
-        CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-        CubismTextureColor screenColor = model.GetScreenColor(index);
+        const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+        CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetDrawableMultiplyColor(index);
+        CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetDrawableScreenColor(index);
         SetColorVectors(shaderEffect, baseColor, multiplyColor, screenColor);
 
         // D3D9はピクセル中心が違うため補正用に渡す
@@ -1234,7 +1231,7 @@ void CubismRenderer_D3D9::ExecuteDrawForOffscreen(const CubismModel& model, Cubi
     csmBool isBlendMode;
     csmBlendMode blendMode = model.GetOffscreenBlendModeType(offscreenIndex);
     SetBlendMode(blendMode, isBlendMode);
-    SetOffscreenTextureFilter();
+    SetTextureFilter(false);
     SetTechniqueForOffscreen(model, offscreenIndex, isBlendMode, blendMode);
 
     // numPassには指定のtechnique内に含まれるpassの数が返る
@@ -1269,8 +1266,9 @@ void CubismRenderer_D3D9::ExecuteDrawForOffscreen(const CubismModel& model, Cubi
         csmFloat32 offscreenOpacity = model.GetOffscreenOpacity(offscreenIndex);
         // PMAなのと不透明度だけを変更したいためすべてOpacityで初期化
         CubismTextureColor modelColorRGBA(offscreenOpacity, offscreenOpacity, offscreenOpacity, offscreenOpacity);
-        CubismTextureColor multiplyColor = model.GetMultiplyColorOffscreen(offscreenIndex);
-        CubismTextureColor screenColor = model.GetScreenColorOffscreen(offscreenIndex);
+        const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+        CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetOffscreenMultiplyColor(offscreenIndex);
+        CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetOffscreenScreenColor(offscreenIndex);
         SetColorVectors(shaderEffect, modelColorRGBA, multiplyColor, screenColor);
 
         // D3D9はピクセル中心が違うため補正用に渡す
@@ -1306,8 +1304,7 @@ void CubismRenderer_D3D9::ExecuteDrawForMask(const CubismModel& model, const csm
     shaderEffect->Begin(&numPass, 0);
     shaderEffect->BeginPass(0);
 
-    // マスクには線形補間を適用
-    _deviceInfo->GetRenderState()->SetTextureFilter(_device, 1, D3DTEXF_LINEAR, D3DTEXF_LINEAR, D3DTEXF_NONE, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
+    SetTextureFilter(true);
 
     // 定数バッファ
     {
@@ -1317,9 +1314,8 @@ void CubismRenderer_D3D9::ExecuteDrawForMask(const CubismModel& model, const csm
         // 色
         csmRectF* rect = GetClippingContextBufferForMask()->_layoutBounds;
         CubismTextureColor baseColor = {rect->X * 2.0f - 1.0f, rect->Y * 2.0f - 1.0f, rect->GetRight() * 2.0f - 1.0f, rect->GetBottom() * 2.0f - 1.0f};
-        CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-        CubismTextureColor screenColor = model.GetScreenColor(index);
-        SetColorVectors(shaderEffect, baseColor, multiplyColor, screenColor);
+        D3DXVECTOR4 shaderBaseColor(baseColor.R, baseColor.G, baseColor.B, baseColor.A);
+        shaderEffect->SetVector("baseColor", &shaderBaseColor);
 
         // 使用するカラーチャンネルを設定
         CubismClippingContext_D3D9* contextBuffer = GetClippingContextBufferForMask();
@@ -1354,7 +1350,7 @@ void CubismRenderer_D3D9::ExecuteDrawForRenderTarget()
     }
 
     shaderEffect->SetTechnique("ShaderNames_Copy");
-    SetOffscreenTextureFilter();
+    SetTextureFilter(false);
     SetBlendMode(CubismBlendMode_Copy);
 
     // numPassには指定のtechnique内に含まれるpassの数が返る
@@ -1363,8 +1359,8 @@ void CubismRenderer_D3D9::ExecuteDrawForRenderTarget()
     shaderEffect->BeginPass(0);
 
     // テスクチャ
-    LPDIRECT3DTEXTURE9 mainTexture = _modelRenderTargets[0].GetTexture();
-    shaderEffect->SetTexture("mainTexture", mainTexture);
+    LPDIRECT3DTEXTURE9 blendTexture = _modelRenderTargets[0].GetTexture();
+    shaderEffect->SetTexture("blendTexture", blendTexture);
 
     // 定数バッファ
     {
@@ -1794,7 +1790,6 @@ void CubismRenderer_D3D9::SetTechniqueForDrawable(const CubismModel& model, cons
     const csmBool masked = GetClippingContextBufferForDrawable() != NULL;  // この描画オブジェクトはマスク対象か
     const csmBool premult = IsPremultipliedAlpha();
     const csmBool invertedMask = model.GetDrawableInvertedMask(index);
-    csmString shaderName = GetTechniqueName(masked, premult, invertedMask, isBlendMode, blendMode);
     shaderEffect->SetTechnique(GetTechniqueName(masked, premult, invertedMask, isBlendMode, blendMode).GetRawString());
 }
 
@@ -1807,21 +1802,26 @@ void CubismRenderer_D3D9::SetTechniqueForOffscreen(const CubismModel& model, csm
     shaderEffect->SetTechnique(GetTechniqueName(masked, premult, invertedMask, isBlendMode, blendMode).GetRawString());
 }
 
-void CubismRenderer_D3D9::SetTextureFilter() const
+void CubismRenderer_D3D9::SetTextureFilter(const csmBool useDrawable) const
 {
-    if (GetAnisotropy() > 1.0f)
+    if (useDrawable)
     {
-        _deviceInfo->GetRenderState()->SetTextureFilter(_device, 0, D3DTEXF_ANISOTROPIC, D3DTEXF_ANISOTROPIC, D3DTEXF_LINEAR, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP, GetAnisotropy());
+        if (GetAnisotropy() > 1.0f)
+        {
+            _deviceInfo->GetRenderState()->SetTextureFilter(_device, 0, D3DTEXF_ANISOTROPIC, D3DTEXF_ANISOTROPIC, D3DTEXF_LINEAR, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP, GetAnisotropy());
+        }
+        else
+        {
+            _deviceInfo->GetRenderState()->SetTextureFilter(_device, 0, D3DTEXF_LINEAR, D3DTEXF_LINEAR, D3DTEXF_LINEAR, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
+        }
     }
     else
     {
-        _deviceInfo->GetRenderState()->SetTextureFilter(_device, 0, D3DTEXF_LINEAR, D3DTEXF_LINEAR, D3DTEXF_LINEAR, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
+        _deviceInfo->GetRenderState()->SetTextureFilter(_device, 0, D3DTEXF_POINT, D3DTEXF_POINT, D3DTEXF_NONE, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
     }
-}
 
-void CubismRenderer_D3D9::SetOffscreenTextureFilter() const
-{
-    _deviceInfo->GetRenderState()->SetTextureFilter(_device, 0, D3DTEXF_POINT, D3DTEXF_POINT, D3DTEXF_NONE, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
+    _deviceInfo->GetRenderState()->SetTextureFilter(_device, 1, D3DTEXF_POINT, D3DTEXF_POINT, D3DTEXF_NONE, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
+    _deviceInfo->GetRenderState()->SetTextureFilter(_device, 2, D3DTEXF_POINT, D3DTEXF_POINT, D3DTEXF_NONE, D3DTADDRESS_WRAP, D3DTADDRESS_WRAP);
 }
 
 void CubismRenderer_D3D9::SetColorVectors(ID3DXEffect* shaderEffect, CubismTextureColor& baseColor, CubismTextureColor& multiplyColor, CubismTextureColor& screenColor)

--- a/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismRenderer_D3D9.hpp
@@ -523,13 +523,10 @@ private:
 
     /**
      * @brief   RenderStateManagerにテクスチャフィルターを設定する
+     *
+     * @param[in]   useDrawable -> 画像の読み込みとしてDrawableを使用するか
      */
-    void SetTextureFilter() const;
-
-    /**
-     * @brief   RenderStateManagerにオフスクリーン用テクスチャフィルターを設定する
-     */
-    void SetOffscreenTextureFilter() const;
+    void SetTextureFilter(csmBool useDrawable) const;
 
     /**
      * @brief  色関連の定数バッファを設定

--- a/src/Rendering/D3D9/CubismShader_D3D9.cpp
+++ b/src/Rendering/D3D9/CubismShader_D3D9.cpp
@@ -68,9 +68,22 @@ void CubismShader_D3D9::GenerateShaders(LPDIRECT3DDEVICE9 device)
 
     csmSizeInt effectShaderSize;
     csmByte* effectShaderSrc = fileLoader(frameworkShaderPath, &effectShaderSize);
-    csmString shaderString = csmString(reinterpret_cast<const csmChar*>(effectShaderSrc), effectShaderSize);
+    if (effectShaderSrc == NULL)
+    {
+        CubismLogError("Failed to load effect shader");
+        return;
+    }
+
     csmSizeInt blendShaderSize;
     csmByte* blendShaderSrc = fileLoader(frameworkBlendShaderPath, &blendShaderSize);
+    if (blendShaderSrc == NULL)
+    {
+        CubismLogError("Failed to load blend shader");
+        bytesReleaser(effectShaderSrc);
+        return;
+    }
+
+    csmString shaderString = csmString(reinterpret_cast<const csmChar*>(effectShaderSrc), effectShaderSize);
     shaderString += csmString(reinterpret_cast<const csmChar*>(blendShaderSrc), blendShaderSize);
 
     // ファイル読み込みで確保したバイト列を開放
@@ -123,8 +136,14 @@ void CubismShader_D3D9::SetupShader(LPDIRECT3DDEVICE9 device)
 {
     // まだシェーダ・頂点宣言未作成ならば作成する
     GenerateShaders(device);
+}
 
-    if (!device || !_vertexFormat) return;
+void CubismShader_D3D9::BindShader(LPDIRECT3DDEVICE9 device)
+{
+    if (!device || !_vertexFormat)
+    {
+        return;
+    }
 
     device->SetVertexDeclaration(_vertexFormat);
 }

--- a/src/Rendering/D3D9/CubismShader_D3D9.hpp
+++ b/src/Rendering/D3D9/CubismShader_D3D9.hpp
@@ -63,9 +63,18 @@ public:
     ID3DXEffect* GetShaderEffect() const;
 
     /**
-     * @brief   頂点宣言のデバイスへの設定、シェーダがまだ未設定ならロード
+     * @brief   シェーダのロード
+     *
+     * @param[in]   device      使用デバイス
      */
     void SetupShader(LPDIRECT3DDEVICE9 pD3dDevice);
+
+    /**
+     * @brief   頂点宣言のデバイスへの設定
+     *
+     * @param[in]   device      使用デバイス
+     */
+    void BindShader(LPDIRECT3DDEVICE9 pD3dDevice);
 
 private:
     /**

--- a/src/Rendering/D3D9/Shaders/CubismBlendMode.fx
+++ b/src/Rendering/D3D9/Shaders/CubismBlendMode.fx
@@ -25,7 +25,7 @@ VS_OUT VertCopy(VS_IN In) {
 }
 
 float4 PixelCopy(VS_OUT In) : COLOR0 {
-    float4 color = tex2D(mainSampler, In.uv);
+    float4 color = tex2D(blendSampler, In.uv);
     return color * baseColor;
 }
 
@@ -474,16 +474,6 @@ CSM_CREATE_BLEND_MODE(COLOR, ConjointOver) \
 CSM_CREATE_BLEND_MODE(COLOR, DisjointOver)
 
 // normal
-CSM_CREATE_PIXEL_FUNC(Masked, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(MaskedInverted, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(NormalPremult, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(MaskedPremult, Normal, Over)
-
-CSM_CREATE_PIXEL_FUNC(MaskedInvertedPremult, Normal, Over)
-
 CSM_CREATE_BLEND_MODE(Normal, Atop)
 
 CSM_CREATE_BLEND_MODE(Normal, Out)
@@ -569,7 +559,10 @@ CSM_CREATE_TECHNIQUE(MASK_NAME, VERT, MASK, COLOR, ConjointOver) \
 CSM_CREATE_TECHNIQUE(MASK_NAME, VERT, MASK, COLOR, DisjointOver)
 
 #define CSM_CREATE_BLEND_MODE_TECHNIQUE(MASK_NAME, VERT, MASK) \
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(MASK_NAME, VERT, MASK, Normal) \
+CSM_CREATE_TECHNIQUE(MASK_NAME, VERT, MASK, Normal, Atop) \
+CSM_CREATE_TECHNIQUE(MASK_NAME, VERT, MASK, Normal, Out) \
+CSM_CREATE_TECHNIQUE(MASK_NAME, VERT, MASK, Normal, ConjointOver) \
+CSM_CREATE_TECHNIQUE(MASK_NAME, VERT, MASK, Normal, DisjointOver) \
 \
 CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(MASK_NAME, VERT, MASK, Add)\
 \
@@ -602,43 +595,7 @@ CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(MASK_NAME, VERT, MASK, Hue) \
 CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(MASK_NAME, VERT, MASK, Color)
 
 // normal
-CSM_CREATE_TECHNIQUE(Normal, VertNormalBlend, Normal, Normal, Atop)
-
-CSM_CREATE_TECHNIQUE(Normal, VertNormalBlend, Normal, Normal, Out)
-
-CSM_CREATE_TECHNIQUE(Normal, VertNormalBlend, Normal, Normal, ConjointOver)
-
-CSM_CREATE_TECHNIQUE(Normal, VertNormalBlend, Normal, Normal, DisjointOver)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Add)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, AddGlow)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Darken)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Multiply)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, ColorBurn)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, LinearBurn)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Lighten)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Screen)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, ColorDodge)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Overlay)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, SoftLight)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, HardLight)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, LinearLight)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Hue)
-
-CSM_CREATE_BLEND_OVERLAP_TECHNIQUE(Normal, VertNormalBlend, Normal, Color)
+CSM_CREATE_BLEND_MODE_TECHNIQUE(Normal, VertNormalBlend, Normal)
 
 // Masked
 CSM_CREATE_BLEND_MODE_TECHNIQUE(Masked, VertMaskedBlend, Masked)

--- a/src/Rendering/Metal/CubismDeviceInfo_Metal.mm
+++ b/src/Rendering/Metal/CubismDeviceInfo_Metal.mm
@@ -17,6 +17,11 @@ namespace {
 
 CubismDeviceInfo_Metal* CubismDeviceInfo_Metal::GetDeviceInfo(id<MTLDevice> device)
 {
+    if (!s_deviceInfoList.IsExist(device))
+    {
+        // シェーダの事前初期化
+        s_deviceInfoList[device]._shader.SetupShader(device);
+    }
     return &s_deviceInfoList[device];
 }
 

--- a/src/Rendering/Metal/CubismRenderer_Metal.hpp
+++ b/src/Rendering/Metal/CubismRenderer_Metal.hpp
@@ -148,6 +148,14 @@ public:
     void StartFrame(id<MTLCommandBuffer> commandBuffer, MTLRenderPassDescriptor* renderPassDescriptor);
 
     /**
+     * @brief  モデル描画時に適用するビューポートを設定
+     *          設定しない場合はMetalのデフォルト値を使用
+     *
+     * @param[in]    viewport-> ビューポート
+     */
+    void SetRenderViewport(MTLViewport viewport);
+
+    /**
      * @brief    レンダラの初期化処理を実行する
      *           引数に渡したモデルからレンダラの初期化処理に必要な情報を取り出すことができる
      *
@@ -531,6 +539,8 @@ private:
 
     CubismCommandBuffer_Metal::DrawCommandBuffer* _copyCommandBuffer;
 
+    MTLViewport _renderViewport;    ///< モデル描画時に使用するビューポート
+    csmBool _renderViewportIsSet;   ///< ビューポートが設定済みかどうか
 };
 
 }}}}

--- a/src/Rendering/Metal/CubismRenderer_Metal.mm
+++ b/src/Rendering/Metal/CubismRenderer_Metal.mm
@@ -317,6 +317,7 @@ CubismRenderer_Metal::CubismRenderer_Metal(csmUint32 width, csmUint32 height)
     , _clippingContextBufferForOffscreen(NULL)
     , _copyCommandBuffer(NULL)
     , _offscreenDrawCommandBuffer(NULL)
+    , _renderViewportIsSet(false)
 {
     // テクスチャ対応マップの容量を確保しておく.
     _textures.PrepareCapacity(32, true);
@@ -582,11 +583,21 @@ void CubismRenderer_Metal::StartFrame(id<MTLCommandBuffer> commandBuffer, MTLRen
     _renderPassDescriptor = renderPassDescriptor;
 }
 
+void CubismRenderer_Metal::SetRenderViewport(MTLViewport viewport)
+{
+    _renderViewport = viewport;
+    _renderViewportIsSet = true;
+}
+
 void CubismRenderer_Metal::PreDraw()
 {
     if (_mtlCommandEncoder == nil)
     {
         _mtlCommandEncoder = [_mtlCommandBuffer renderCommandEncoderWithDescriptor:_renderPassDescriptor];
+        if (_renderViewportIsSet)
+        {
+          [_mtlCommandEncoder setViewport:_renderViewport];
+        }
     }
 }
 

--- a/src/Rendering/Metal/CubismShader_Metal.hpp
+++ b/src/Rendering/Metal/CubismShader_Metal.hpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -98,6 +98,22 @@ public:
     void CopyTexture(id<MTLTexture> texture, CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
                                 , CubismRenderer_Metal* renderer);
 
+    /**
+     * @brief   シェーダがまだ未設定ならロードする
+     *
+     * @param[in]       device  ->  デバイスのインスタンス
+     */
+    void SetupShader(id<MTLDevice> device);
+
+    /**
+     * @brief   サンプラーを設定する。
+     *
+     * @param[in]   device  ->  デバイスのインスタンス
+     * @param[in]   anisotropy ->  異方性フィルタリング
+     * @param[in]   useDrawable -> 画像の読み込みとしてDrawableを使用するか
+     */
+    void SetSampler(id<MTLDevice> device, csmFloat32 anisotropy, csmBool useDrawable);
+
 private:
     struct ShaderProgram
     {
@@ -111,10 +127,20 @@ private:
     */
     struct CubismShaderSet
     {
+        CubismShaderSet()
+            : ShaderProgram(nil)
+            , RenderPipelineState(nil)
+            , DepthStencilState(nil)
+            , MainSamplerState(nil)
+            , SubSamplerState(nil)
+        {
+        }
+
         ShaderProgram *ShaderProgram; ///< シェーダプログラムのアドレス
         id<MTLRenderPipelineState> RenderPipelineState;
         id<MTLDepthStencilState> DepthStencilState;
-        id<MTLSamplerState> SamplerState;
+        id<MTLSamplerState> MainSamplerState;
+        id<MTLSamplerState> SubSamplerState;
     };
 
     enum ShaderNames
@@ -198,8 +224,10 @@ private:
 
     /**
      * @brief   シェーダプログラムを初期化する
+     *
+     * @param[in]       device  ->  デバイスのインスタンス
      */
-    void GenerateShaders(CubismRenderer_Metal* renderer);
+    void GenerateShaders(id<MTLDevice> device);
 
     /**
      * @brief   ブレンドモード用シェーダプログラムを初期化する
@@ -210,9 +238,8 @@ private:
      * @param[in]       vertShaderSrc        ->  頂点シェーダーのソース
      * @param[in]       fragShaderSrc        ->  フラグメントシェーダーのソース
      * @param[in]       device               ->  デバイスのインスタンス
-     * @param[in]       renderer             ->  レンダラのインスタンス
      */
-    void GenerateBlendShader(CubismShaderSet* shaderSet, const csmString& vertShaderFileName, const csmString& fragShaderFileName, const csmString& vertShaderSrc, const csmString& fragShaderSrc, id<MTLDevice> device, CubismRenderer_Metal* renderer);
+    void GenerateBlendShader(CubismShaderSet* shaderSet, const csmString& vertShaderFileName, const csmString& fragShaderFileName, const csmString& vertShaderSrc, const csmString& fragShaderSrc, id<MTLDevice> device);
 
     /**
      * @brief   CubismMatrix44をsimd::float4x4の形式に変換する
@@ -284,10 +311,43 @@ private:
 
     id<MTLRenderPipelineState> MakeRenderPipelineState(id<MTLDevice> device, ShaderProgram* shaderProgram, int blendMode);
     id<MTLDepthStencilState> MakeDepthStencilState(id<MTLDevice> device);
-    id<MTLSamplerState> MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer);
 
+    /**
+     * @brief   アートメッシュ用のサンプラーを作成する。
+     *
+     * @param[in]   device   ->  デバイスのインスタンス
+     * @param[in]   anisotropy ->  異方性フィルタリング
+     *
+     * @return  サンプラーを返す
+     */
+    id<MTLSamplerState> MakeDrawableSamplerState(id<MTLDevice> device, csmFloat32 anisotropy);
+
+    /**
+     * @brief   アートメッシュ以外用のサンプラーを作成する。
+     *
+     * @param[in]   device   ->  デバイスのインスタンス
+     * @param[in]   anisotropy ->  異方性フィルタリング
+     *
+     * @return  サンプラーを返す
+     */
+    id<MTLSamplerState> MakeOtherSamplerState(id<MTLDevice> device, csmFloat32 anisotropy);
+
+    /**
+     * @brief   サンプラーを初期設定する。
+     *
+     * @param[in]   device  ->  デバイスのインスタンス
+     * @param[in]   anisotropy ->  異方性フィルタリング
+     * @param[in]   useDrawable -> 画像の読み込みとしてDrawableを使用するか
+     */
+    void InitializeSampler(id<MTLDevice> device, csmFloat32 anisotropy, const csmBool useDrawable);
+
+    /**
+     * @brief   サンプラーを開放する。
+     */
+    void ReleaseSampler();
 
     csmVector<CubismShaderSet*> _shaderSets;   ///< ロードしたシェーダプログラムを保持する変数
+    csmFloat32 _anisotropy;
 
 };
 

--- a/src/Rendering/Metal/CubismShader_Metal.mm
+++ b/src/Rendering/Metal/CubismShader_Metal.mm
@@ -114,7 +114,6 @@ csmInt32 CubismShader_Metal::GetShaderNamesBegin(const csmBlendMode blendMode)
 #undef CSM_GET_SHADER_NAME
 }
 
-
 //// SetupMask
 static const csmChar* VertShaderSrcSetupMask = "VertShaderSrcSetupMask";
 
@@ -155,23 +154,57 @@ static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha = "FragShaderS
 static const csmChar* ShaderLibsDir = "FrameworkMetallibs";
 
 CubismShader_Metal::CubismShader_Metal()
+    : _anisotropy(0.0f)
 {
 }
 
 CubismShader_Metal::~CubismShader_Metal()
 {
+    ReleaseSampler();
 }
 
-void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
+void CubismShader_Metal::SetupShader(id<MTLDevice> device)
 {
+    GenerateShaders(device);
+}
+
+void CubismShader_Metal::SetSampler(id<MTLDevice> device, csmFloat32 anisotropy, const csmBool useDrawable)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        return;
+    }
+
+    if (_anisotropy != anisotropy)
+    {
+        // 異方性フィルタリングが違うならサンプラを作成しなおす
+        InitializeSampler(device, anisotropy, useDrawable);
+    }
+    else
+    {
+        // 同じならサンプラーを入れ替える
+        for (csmInt32 i = ShaderNames_Normal; i < ShaderNames_ShaderCount; ++i)
+        {
+            _shaderSets[i]->MainSamplerState = useDrawable ?
+                _shaderSets[ShaderNames_SetupMask]->MainSamplerState :
+                _shaderSets[ShaderNames_Copy]->MainSamplerState;
+        }
+    }
+}
+
+void CubismShader_Metal::GenerateShaders(id<MTLDevice> device)
+{
+    if (_shaderSets.GetSize() > 0)
+    {
+        return;
+    }
+
     for (csmInt32 i = 0; i < ShaderNames_ShaderCount; ++i)
     {
         _shaderSets.PushBack(CSM_NEW CubismShaderSet());
     }
 
     //シェーダライブラリのロード（.metal）
-    id <MTLDevice> device = renderer->GetDevice();
-
     NSString *subDir = [NSString stringWithCString:ShaderLibsDir encoding:NSUTF8StringEncoding];
     NSURL *libraryURL = [[NSBundle mainBundle] URLForResource:@"MetalShaders" withExtension:@"metallib" subdirectory:subDir];
     id<MTLLibrary> shaderLib = [device newLibraryWithURL:libraryURL error:nil];
@@ -194,10 +227,8 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
     _shaderSets[ShaderNames_NormalMaskedInvertedPremultipliedAlpha]->ShaderProgram = LoadShaderProgram(VertShaderSrcMasked, FragShaderSrcMaskInvertedPremultipliedAlpha, shaderLib);
 
     _shaderSets[ShaderNames_SetupMask]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[ShaderNames_SetupMask]->ShaderProgram, CubismRenderer::CubismBlendMode_Mask);
-    _shaderSets[ShaderNames_SetupMask]->SamplerState = MakeSamplerState(device, renderer);
 
     _shaderSets[ShaderNames_Copy]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[ShaderNames_Copy]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
-    _shaderSets[ShaderNames_Copy]->SamplerState = MakeSamplerState(device, renderer);
     _shaderSets[ShaderNames_Copy]->DepthStencilState = MakeDepthStencilState(device);
 
     _shaderSets[ShaderNames_Normal]->RenderPipelineState = MakeRenderPipelineState(device, _shaderSets[ShaderNames_Normal]->ShaderProgram, CubismRenderer::CubismBlendMode_Normal);
@@ -213,13 +244,6 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
     _shaderSets[ShaderNames_NormalPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
     _shaderSets[ShaderNames_NormalMaskedPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
     _shaderSets[ShaderNames_NormalMaskedInvertedPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
-
-    _shaderSets[ShaderNames_Normal]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_NormalMasked]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_NormalMaskedInverted]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_NormalPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_NormalMaskedPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_NormalMaskedInvertedPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
 
     // 加算も通常と同じシェーダーを利用する
     _shaderSets[ShaderNames_Add]->ShaderProgram = _shaderSets[ShaderNames_Normal]->ShaderProgram;
@@ -243,13 +267,6 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
     _shaderSets[ShaderNames_AddMaskedPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
     _shaderSets[ShaderNames_AddMaskedInvertedPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
 
-    _shaderSets[ShaderNames_Add]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_AddMasked]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_AddMaskedInverted]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_AddPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_AddMaskedPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_AddMaskedInvertedPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-
     // 乗算も通常と同じシェーダーを利用する
     _shaderSets[ShaderNames_Mult]->ShaderProgram = _shaderSets[ShaderNames_Normal]->ShaderProgram;
     _shaderSets[ShaderNames_MultMasked]->ShaderProgram = _shaderSets[ShaderNames_NormalMasked]->ShaderProgram;
@@ -271,13 +288,6 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
     _shaderSets[ShaderNames_MultPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
     _shaderSets[ShaderNames_MultMaskedPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
     _shaderSets[ShaderNames_MultMaskedInvertedPremultipliedAlpha]->DepthStencilState = _shaderSets[ShaderNames_Normal]->DepthStencilState;
-
-    _shaderSets[ShaderNames_Mult]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_MultMasked]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_MultMaskedInverted]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_MultPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_MultMaskedPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
-    _shaderSets[ShaderNames_MultMaskedInvertedPremultipliedAlpha]->SamplerState = _shaderSets[ShaderNames_SetupMask]->SamplerState;
 
     // 5.3以降
     // ブレンドモードの組み合わせ分作成
@@ -307,8 +317,7 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
                                     fragShaderFileName,
                                     vertShaderFileName,
                                     baseFragShaderFileName,
-                                    device,
-                                    renderer);
+                                    device);
 
                 vertShaderFileName = csmString("VertShaderSrcMaskedBlend");
                 baseFragShaderFileName = csmString("FragShaderSrcMaskBlend");
@@ -318,8 +327,7 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
                                     fragShaderFileName,
                                     vertShaderFileName,
                                     baseFragShaderFileName,
-                                    device,
-                                    renderer);
+                                    device);
 
                 vertShaderFileName = csmString("VertShaderSrcMaskedBlend");
                 baseFragShaderFileName = csmString("FragShaderSrcMaskInvertedBlend");
@@ -329,8 +337,7 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
                                     fragShaderFileName,
                                     vertShaderFileName,
                                     baseFragShaderFileName,
-                                    device,
-                                    renderer);
+                                    device);
 
                 vertShaderFileName = csmString("VertShaderSrcBlend");
                 baseFragShaderFileName = csmString("FragShaderSrcPremultipliedAlphaBlend");
@@ -340,8 +347,7 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
                                     fragShaderFileName,
                                     vertShaderFileName,
                                     baseFragShaderFileName,
-                                    device,
-                                    renderer);
+                                    device);
 
                 vertShaderFileName = csmString("VertShaderSrcMaskedBlend");
                 baseFragShaderFileName = csmString("FragShaderSrcMaskPremultipliedAlphaBlend");
@@ -351,8 +357,7 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
                                     fragShaderFileName,
                                     vertShaderFileName,
                                     baseFragShaderFileName,
-                                    device,
-                                    renderer);
+                                    device);
 
                 vertShaderFileName = csmString("VertShaderSrcMaskedBlend");
                 baseFragShaderFileName = csmString("FragShaderSrcMaskInvertedPremultipliedAlphaBlend");
@@ -362,23 +367,28 @@ void CubismShader_Metal::GenerateShaders(CubismRenderer_Metal* renderer)
                                     fragShaderFileName,
                                     vertShaderFileName,
                                     baseFragShaderFileName,
-                                    device,
-                                    renderer);
+                                    device);
             }
         }
     }
+
+    // サンプラーの初期化
+    InitializeSampler(device, _anisotropy, true);
 }
 
-void CubismShader_Metal::GenerateBlendShader(CubismShaderSet* shaderSet, const csmString& vertShaderFileName, const csmString& fragShaderFileName, const csmString& vertShaderSrc, const csmString& fragShaderSrc, id<MTLDevice> device, CubismRenderer_Metal* renderer)
+void CubismShader_Metal::GenerateBlendShader(CubismShaderSet* shaderSet, const csmString& vertShaderFileName, const csmString& fragShaderFileName, const csmString& vertShaderSrc, const csmString& fragShaderSrc, id<MTLDevice> device)
 {
     shaderSet->ShaderProgram = LoadShaderProgramFromFile(vertShaderFileName,
                                                          fragShaderFileName,
                                                          vertShaderFileName,
                                                          fragShaderSrc,
                                                          device);
+    if (shaderSet->ShaderProgram == NULL)
+    {
+        return;
+    }
     shaderSet->RenderPipelineState = MakeRenderPipelineState(device, shaderSet->ShaderProgram, 10);
 
-    shaderSet->SamplerState = MakeSamplerState(device, renderer);
     shaderSet->DepthStencilState = MakeDepthStencilState(device);
 }
 
@@ -414,11 +424,10 @@ void CubismShader_Metal::SetVertexBufferForVerticesAndUvs(CubismCommandBuffer_Me
 void CubismShader_Metal::SetupShaderProgramForDrawable(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
                                                   , CubismRenderer_Metal* renderer, const CubismModel& model, const csmInt32 index, id<MTLTexture> blendTexture)
 {
-    // シェーダー生成
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders(renderer);
-    }
+    // サンプラーの設定
+    id<MTLDevice> device = renderer->GetDevice();
+    CubismDeviceInfo_Metal* deviceInfo = CubismDeviceInfo_Metal::GetDeviceInfo(device);
+    deviceInfo->GetShader()->SetSampler(device, renderer->GetAnisotropy(), true);
 
     // シェーダーセットの設定
     const csmBool masked = renderer->GetClippingContextBufferForDrawable() != NULL;
@@ -494,8 +503,9 @@ void CubismShader_Metal::SetupShaderProgramForDrawable(CubismCommandBuffer_Metal
         // ブレンドモードを使用しない場合はDrawable単位でモデルカラーを処理する
         baseColor = renderer->GetModelColorWithOpacity(model.GetDrawableOpacity(index));
     }
-    CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-    CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+    const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+    CubismRenderer::CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetDrawableMultiplyColor(index);
+    CubismRenderer::CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetDrawableScreenColor(index);
 
     shaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
     shaderUniforms.multiplyColor = (vector_float4){ multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
@@ -504,7 +514,11 @@ void CubismShader_Metal::SetupShaderProgramForDrawable(CubismCommandBuffer_Metal
     // 転送
     [renderEncoder setVertexBytes:&shaderUniforms length:sizeof(CubismShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
     [renderEncoder setFragmentBytes:&shaderUniforms length:sizeof(CubismShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
-    [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+    [renderEncoder setFragmentSamplerState:shaderSet->MainSamplerState atIndex:0];
+    if (masked || isBlendMode)
+    {
+        [renderEncoder setFragmentSamplerState:shaderSet->SubSamplerState atIndex:1];
+    }
     [renderEncoder setDepthStencilState:shaderSet->DepthStencilState];
 
     drawCommandBuffer->GetCommandDraw()->SetRenderPipelineState(shaderSet->RenderPipelineState);
@@ -513,11 +527,10 @@ void CubismShader_Metal::SetupShaderProgramForDrawable(CubismCommandBuffer_Metal
 void CubismShader_Metal::SetupShaderProgramForMask(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
                                                 , CubismRenderer_Metal* renderer, const CubismModel& model, const csmInt32 index)
 {
-    // シェーダー生成
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders(renderer);
-    }
+    // サンプラーの設定
+    id<MTLDevice> device = renderer->GetDevice();
+    CubismDeviceInfo_Metal* deviceInfo = CubismDeviceInfo_Metal::GetDeviceInfo(device);
+    deviceInfo->GetShader()->SetSampler(device, renderer->GetAnisotropy(), true);
 
     // シェーダーセットの設定
     CubismShaderSet* shaderSet = _shaderSets[ShaderNames_SetupMask];
@@ -546,7 +559,7 @@ void CubismShader_Metal::SetupShaderProgramForMask(CubismCommandBuffer_Metal::Dr
     // 転送
     [renderEncoder setVertexBytes:&shaderUniforms length:sizeof(CubismShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
     [renderEncoder setFragmentBytes:&shaderUniforms length:sizeof(CubismShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
-    [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+    [renderEncoder setFragmentSamplerState:shaderSet->MainSamplerState atIndex:0];
 
     drawCommandBuffer->GetCommandDraw()->SetRenderPipelineState(shaderSet->RenderPipelineState);
 }
@@ -570,10 +583,10 @@ void CubismShader_Metal::SetupShaderProgramForRenderTarget(CubismCommandBuffer_M
 void CubismShader_Metal::CopyTexture(id<MTLTexture> texture, CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
                                 , CubismRenderer_Metal* renderer)
 {
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders(renderer);
-    }
+    // サンプラーの設定
+    id<MTLDevice> device = renderer->GetDevice();
+    CubismDeviceInfo_Metal* deviceInfo = CubismDeviceInfo_Metal::GetDeviceInfo(device);
+    deviceInfo->GetShader()->SetSampler(device, renderer->GetAnisotropy(), false);
 
     CubismShaderSet* shaderSet = _shaderSets[ShaderNames_Copy];
 
@@ -584,7 +597,7 @@ void CubismShader_Metal::CopyTexture(id<MTLTexture> texture, CubismCommandBuffer
     SetVertexBufferForVerticesAndUvs(drawCommandBuffer, renderEncoder);
 
     // 転送
-    [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+    [renderEncoder setFragmentSamplerState:shaderSet->MainSamplerState atIndex:0];
     [renderEncoder setDepthStencilState:shaderSet->DepthStencilState];
 
     drawCommandBuffer->GetCommandDraw()->SetRenderPipelineState(shaderSet->RenderPipelineState);
@@ -593,13 +606,12 @@ void CubismShader_Metal::CopyTexture(id<MTLTexture> texture, CubismCommandBuffer
 void CubismShader_Metal::SetupShaderProgramForOffscreen(CubismCommandBuffer_Metal::DrawCommandBuffer* drawCommandBuffer, id <MTLRenderCommandEncoder> renderEncoder
                                 , CubismRenderer_Metal* renderer, const CubismModel& model, const CubismOffscreenRenderTarget_Metal* offscreen, id<MTLTexture> blendTexture)
 {
-    // シェーダー生成
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders(renderer);
-    }
-
     csmInt32 offscreenIndex = offscreen->GetOffscreenIndex();
+
+    // サンプラーの設定
+    id<MTLDevice> device = renderer->GetDevice();
+    CubismDeviceInfo_Metal* deviceInfo = CubismDeviceInfo_Metal::GetDeviceInfo(device);
+    deviceInfo->GetShader()->SetSampler(device, renderer->GetAnisotropy(), false);
 
     // シェーダーセットの設定
     const csmBool masked = renderer->GetClippingContextBufferForOffscreen() != NULL;
@@ -663,8 +675,9 @@ void CubismShader_Metal::SetupShaderProgramForOffscreen(CubismCommandBuffer_Meta
     // オフスクリーンはPMA前提
     csmFloat32 offscreenOpacity = model.GetOffscreenOpacity(offscreenIndex);
     CubismRenderer::CubismTextureColor baseColor(offscreenOpacity, offscreenOpacity, offscreenOpacity, offscreenOpacity);
-    CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColorOffscreen(offscreenIndex);
-    CubismRenderer::CubismTextureColor screenColor = model.GetScreenColorOffscreen(offscreenIndex);
+    const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+    CubismRenderer::CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetOffscreenMultiplyColor(offscreenIndex);
+    CubismRenderer::CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetOffscreenScreenColor(offscreenIndex);
 
     shaderUniforms.baseColor = (vector_float4){ baseColor.R, baseColor.G, baseColor.B, baseColor.A };
     shaderUniforms.multiplyColor = (vector_float4){ multiplyColor.R, multiplyColor.G, multiplyColor.B, multiplyColor.A };
@@ -673,7 +686,8 @@ void CubismShader_Metal::SetupShaderProgramForOffscreen(CubismCommandBuffer_Meta
     // 転送
     [renderEncoder setVertexBytes:&shaderUniforms length:sizeof(CubismShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
     [renderEncoder setFragmentBytes:&shaderUniforms length:sizeof(CubismShaderUniforms) atIndex:MetalVertexInputIndexUniforms];
-    [renderEncoder setFragmentSamplerState:shaderSet->SamplerState atIndex:0];
+    [renderEncoder setFragmentSamplerState:shaderSet->MainSamplerState atIndex:0];
+    [renderEncoder setFragmentSamplerState:shaderSet->SubSamplerState atIndex:1];
     [renderEncoder setDepthStencilState:shaderSet->DepthStencilState];
 
     drawCommandBuffer->GetCommandDraw()->SetRenderPipelineState(shaderSet->RenderPipelineState);
@@ -757,6 +771,7 @@ CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgramFromFile
    if([vertShaderData length] == 0)
    {
        NSLog(@"ERROR: File is loaded but file size is zero : %@", [vertShaderFileLibURL absoluteString]);
+       return nil;
    }
     NSUInteger vertShaderByteLen = [vertShaderData length];
     Byte* vertShaderByteData = (Byte*)malloc(vertShaderByteLen);
@@ -766,7 +781,7 @@ CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgramFromFile
     if(!vertShaderLib)
     {
         NSLog(@" ERROR: Couldnt create a vertex shader library");
-        return;
+        return nil;
     }
 
     // フラグメントシェーダの取得
@@ -779,6 +794,7 @@ CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgramFromFile
    if([fragShaderData length] == 0)
    {
        NSLog(@"ERROR: File is loaded but file size is zero : %@", [fragShaderFileLibURL absoluteString]);
+       return nil;
    }
     NSUInteger fragShaderByteLen = [fragShaderData length];
     Byte* fragShaderByteData = (Byte*)malloc(fragShaderByteLen);
@@ -788,7 +804,7 @@ CubismShader_Metal::ShaderProgram* CubismShader_Metal::LoadShaderProgramFromFile
     if(!fragShaderLib)
     {
         NSLog(@" ERROR: Couldnt create a frag shader library");
-        return;
+        return nil;
     }
   ShaderProgram* shaderProgram = LoadShaderProgram(vertShaderSrc, fragShaderSrc, vertShaderLib, fragShaderLib);
   return shaderProgram;
@@ -861,7 +877,7 @@ id<MTLDepthStencilState> CubismShader_Metal::MakeDepthStencilState(id<MTLDevice>
     return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
 }
 
-id<MTLSamplerState> CubismShader_Metal::MakeSamplerState(id<MTLDevice> device, CubismRenderer_Metal* renderer)
+id<MTLSamplerState> CubismShader_Metal::MakeDrawableSamplerState(id<MTLDevice> device, const csmFloat32 anisotropy)
 {
     MTLSamplerDescriptor* samplerDescriptor = [[[MTLSamplerDescriptor alloc] init] autorelease];
 
@@ -873,12 +889,79 @@ id<MTLSamplerState> CubismShader_Metal::MakeSamplerState(id<MTLDevice> device, C
     samplerDescriptor.mipFilter = MTLSamplerMipFilterLinear;
 
     //異方性フィルタリング
-    if (renderer->GetAnisotropy() >= 1.0f)
+    if (anisotropy >= 1.0f)
     {
-        samplerDescriptor.maxAnisotropy = renderer->GetAnisotropy();
+        samplerDescriptor.maxAnisotropy = anisotropy;
     }
 
     return [device newSamplerStateWithDescriptor:samplerDescriptor];
+}
+
+id<MTLSamplerState> CubismShader_Metal::MakeOtherSamplerState(id<MTLDevice> device, const csmFloat32 anisotropy)
+{
+    MTLSamplerDescriptor* samplerDescriptor = [[[MTLSamplerDescriptor alloc] init] autorelease];
+
+    samplerDescriptor.rAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.sAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.tAddressMode = MTLSamplerAddressModeRepeat;
+    samplerDescriptor.minFilter = MTLSamplerMinMagFilterNearest;
+    samplerDescriptor.magFilter = MTLSamplerMinMagFilterNearest;
+    samplerDescriptor.mipFilter = MTLSamplerMipFilterNotMipmapped;
+
+    //異方性フィルタリング
+    if (anisotropy >= 1.0f)
+    {
+        samplerDescriptor.maxAnisotropy = anisotropy;
+    }
+
+    return [device newSamplerStateWithDescriptor:samplerDescriptor];
+}
+
+void CubismShader_Metal::InitializeSampler(id<MTLDevice> device, csmFloat32 anisotropy, const csmBool useDrawable)
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        return;
+    }
+
+    ReleaseSampler();
+
+    id<MTLSamplerState> drawableSampler = MakeDrawableSamplerState(device, anisotropy);
+    id<MTLSamplerState> otherSampler = MakeOtherSamplerState(device, anisotropy);
+
+    _shaderSets[ShaderNames_SetupMask]->MainSamplerState = drawableSampler;
+    _shaderSets[ShaderNames_Copy]->MainSamplerState = otherSampler;
+
+    for (csmInt32 i = ShaderNames_Normal; i < ShaderNames_ShaderCount; ++i)
+    {
+        _shaderSets[i]->MainSamplerState = useDrawable ? drawableSampler : otherSampler;
+        _shaderSets[i]->SubSamplerState = otherSampler;
+    }
+    _anisotropy = anisotropy;
+}
+
+void CubismShader_Metal::ReleaseSampler()
+{
+    if (_shaderSets.GetSize() == 0)
+    {
+        return;
+    }
+
+    if (_shaderSets[ShaderNames_SetupMask]->MainSamplerState != nil)
+    {
+        [_shaderSets[ShaderNames_SetupMask]->MainSamplerState release];
+    }
+
+    if (_shaderSets[ShaderNames_Copy]->MainSamplerState != nil)
+    {
+        [_shaderSets[ShaderNames_Copy]->MainSamplerState release];
+    }
+
+    for (csmInt32 i = ShaderNames_SetupMask; i < ShaderNames_ShaderCount; ++i)
+    {
+        _shaderSets[i]->MainSamplerState = nil;
+        _shaderSets[i]->SubSamplerState = nil;
+    }
 }
 
 }}}}

--- a/src/Rendering/Metal/Shaders/FragShaderSrcBlend.metal
+++ b/src/Rendering/Metal/Shaders/FragShaderSrcBlend.metal
@@ -16,17 +16,19 @@ using namespace metal;
 #include "MetalShaderTypes.h"
 
 fragment float4
-FragShaderSrcBlend(NormalBlendRasterizerData in [[stage_in]],
-              texture2d<float> texture [[ texture(0) ]],
-              constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-              sampler smp [[sampler(0)]],
-              texture2d<float> blendTexture [[ texture(1) ]])
+FragShaderSrcBlend(
+    NormalBlendRasterizerData in [[ stage_in ]],
+    texture2d<float> texture [[ texture(0) ]],
+    texture2d<float> blendTexture [[ texture(1) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture.sample(smp, in.texCoord);
+    float4 texColor = texture.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
     float4 colorSource = texColor * uniforms.baseColor;
-    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(smp, in.blendCoord));
+    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(subSampler, in.blendCoord));
     float4 outColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 
     return outColor;

--- a/src/Rendering/Metal/Shaders/FragShaderSrcMaskBlend.metal
+++ b/src/Rendering/Metal/Shaders/FragShaderSrcMaskBlend.metal
@@ -16,21 +16,23 @@ using namespace metal;
 #include "MetalShaderTypes.h"
 
 fragment float4
-FragShaderSrcMaskBlend(MaskedBlendRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                    sampler smp [[sampler(0)]],
-                    texture2d<float> blendTexture [[ texture(2) ]])
+FragShaderSrcMaskBlend(
+    MaskedBlendRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    texture2d<float> blendTexture [[ texture(2) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = texColor * uniforms.baseColor;
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     float4 colorSource = float4(col_formask.rgb, col_formask.a * maskVal);
-    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(smp, in.blendCoord));
+    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(subSampler, in.blendCoord));
     float4 outColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 
     return outColor;

--- a/src/Rendering/Metal/Shaders/FragShaderSrcMaskInvertedBlend.metal
+++ b/src/Rendering/Metal/Shaders/FragShaderSrcMaskInvertedBlend.metal
@@ -16,21 +16,23 @@ using namespace metal;
 #include "MetalShaderTypes.h"
 
 fragment float4
-FragShaderSrcMaskInvertedBlend(MaskedBlendRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                    sampler smp [[sampler(0)]],
-                    texture2d<float> blendTexture [[ texture(2) ]])
+FragShaderSrcMaskInvertedBlend(
+    MaskedBlendRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    texture2d<float> blendTexture [[ texture(2) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[sampler(0)]],
+    sampler subSampler [[sampler(1)]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = texColor * uniforms.baseColor;
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     float4 colorSource = float4(col_formask.rgb, col_formask.a * (1.0 - maskVal));
-    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(smp, in.blendCoord));
+    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(subSampler, in.blendCoord));
     float4 outColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 
     return outColor;

--- a/src/Rendering/Metal/Shaders/FragShaderSrcMaskInvertedPremultipliedAlphaBlend.metal
+++ b/src/Rendering/Metal/Shaders/FragShaderSrcMaskInvertedPremultipliedAlphaBlend.metal
@@ -16,21 +16,23 @@ using namespace metal;
 #include "MetalShaderTypes.h"
 
 fragment float4
-FragShaderSrcMaskInvertedPremultipliedAlphaBlend(MaskedBlendRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                    sampler smp [[sampler(0)]],
-                    texture2d<float> blendTexture [[ texture(2) ]])
+FragShaderSrcMaskInvertedPremultipliedAlphaBlend(
+    MaskedBlendRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    texture2d<float> blendTexture [[ texture(2) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[sampler(0)]],
+    sampler subSampler [[sampler(1)]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = ConvertPremultipliedToStraight(texColor * uniforms.baseColor);
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     float4 colorSource = float4(col_formask.rgb, col_formask.a * (1.0 - maskVal));
-    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(smp, in.blendCoord));
+    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(subSampler, in.blendCoord));
     float4 outColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 
     return outColor;

--- a/src/Rendering/Metal/Shaders/FragShaderSrcMaskPremultipliedAlphaBlend.metal
+++ b/src/Rendering/Metal/Shaders/FragShaderSrcMaskPremultipliedAlphaBlend.metal
@@ -16,21 +16,23 @@ using namespace metal;
 #include "MetalShaderTypes.h"
 
 fragment float4
-FragShaderSrcMaskPremultipliedAlphaBlend(MaskedBlendRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                                    sampler smp [[sampler(0)]],
-                                    texture2d<float> blendTexture [[ texture(2) ]])
+FragShaderSrcMaskPremultipliedAlphaBlend(
+    MaskedBlendRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    texture2d<float> blendTexture [[ texture(2) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = ConvertPremultipliedToStraight(texColor * uniforms.baseColor);
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     float4 colorSource = float4(col_formask.rgb, col_formask.a * maskVal);
-    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(smp, in.blendCoord));
+    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(subSampler, in.blendCoord));
     float4 outColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 
     return outColor;

--- a/src/Rendering/Metal/Shaders/FragShaderSrcPremultipliedAlphaBlend.metal
+++ b/src/Rendering/Metal/Shaders/FragShaderSrcPremultipliedAlphaBlend.metal
@@ -16,17 +16,19 @@ using namespace metal;
 #include "MetalShaderTypes.h"
 
 fragment float4
-FragShaderSrcPremultipliedAlphaBlend(MaskedBlendRasterizerData in [[stage_in]],
-                        texture2d<float> texture [[ texture(0) ]],
-                        constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                        sampler smp [[sampler(0)]],
-                        texture2d<float> blendTexture [[ texture(1) ]])
+FragShaderSrcPremultipliedAlphaBlend(
+    MaskedBlendRasterizerData in [[stage_in]],
+    texture2d<float> texture [[ texture(0) ]],
+    texture2d<float> blendTexture [[ texture(1) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[sampler(0)]],
+    sampler subSampler [[sampler(1)]])
 {
-    float4 texColor = texture.sample(smp, in.texCoord);
+    float4 texColor = texture.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
     float4 colorSource = ConvertPremultipliedToStraight(texColor * uniforms.baseColor);
-    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(smp, in.blendCoord));
+    float4 colorDestination = ConvertPremultipliedToStraight(blendTexture.sample(subSampler, in.blendCoord));
     float4 outColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 
     return outColor;

--- a/src/Rendering/Metal/Shaders/MetalShaders.metal
+++ b/src/Rendering/Metal/Shaders/MetalShaders.metal
@@ -29,10 +29,11 @@ struct MaskedRasterizerData
 };
 
 vertex MaskedRasterizerData
-VertShaderSrcSetupMask(uint vertexID [[ vertex_id ]],
-             constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
-             constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
-             constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]])
+VertShaderSrcSetupMask(
+    uint vertexID [[ vertex_id ]],
+    constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+    constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]])
 {
     MaskedRasterizerData out;
     float2 vert = vertexArray[vertexID];
@@ -48,10 +49,11 @@ VertShaderSrcSetupMask(uint vertexID [[ vertex_id ]],
 }
 
 fragment float4
-FragShaderSrcSetupMask(MaskedRasterizerData in [[stage_in]],
-                       texture2d<float> texture [[ texture(0) ]],
-                       constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                       sampler smp [[sampler(0)]])
+FragShaderSrcSetupMask(
+    MaskedRasterizerData in [[stage_in]],
+    texture2d<float> texture [[ texture(0) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[sampler(0)]])
 {
     float isInside =
         step(uniforms.baseColor.x, in.myPos.x/in.myPos.w)
@@ -59,18 +61,18 @@ FragShaderSrcSetupMask(MaskedRasterizerData in [[stage_in]],
         * step(in.myPos.x/in.myPos.w, uniforms.baseColor.z)
         * step(in.myPos.y/in.myPos.w, uniforms.baseColor.w);
 
-    float4 gl_FragColor = float4(uniforms.channelFlag * texture.sample(smp, in.texCoord).a * isInside);
+    float4 gl_FragColor = float4(uniforms.channelFlag * texture.sample(mainSampler, in.texCoord).a * isInside);
     return gl_FragColor;
 }
 
 ////----- バーテックスシェーダプログラム -----
 //// Normal & Add & Mult 共通
 vertex NormalRasterizerData
-VertShaderSrc(uint vertexID [[ vertex_id ]],
-              constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
-              constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
-             constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]])
-
+VertShaderSrc(
+    uint vertexID [[ vertex_id ]],
+    constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+    constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]])
 {
     NormalRasterizerData out;
     float2 vert = vertexArray[vertexID];
@@ -86,10 +88,11 @@ VertShaderSrc(uint vertexID [[ vertex_id ]],
 
 //// Normal & Add & Mult 共通（クリッピングされたものの描画用）
 vertex MaskedRasterizerData
-VertShaderSrcMasked(uint vertexID [[ vertex_id ]],
-            constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
-            constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
-            constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]])
+VertShaderSrcMasked(
+    uint vertexID [[ vertex_id ]],
+    constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+    constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]])
 {
     MaskedRasterizerData out;
     float2 vert = vertexArray[vertexID];
@@ -106,10 +109,10 @@ VertShaderSrcMasked(uint vertexID [[ vertex_id ]],
 }
 
 vertex NormalRasterizerData
-VertShaderSrcCopy(uint vertexID [[ vertex_id ]],
-              constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
-              constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]]
-             )
+VertShaderSrcCopy(
+    uint vertexID [[ vertex_id ]],
+    constant float2 *vertexArray [[ buffer(MetalVertexInputIndexVertices) ]],
+    constant float2 *uvArray [[ buffer(MetalVertexInputUVs) ]])
 {
     NormalRasterizerData out;
     float2 vert = vertexArray[vertexID];
@@ -123,13 +126,13 @@ VertShaderSrcCopy(uint vertexID [[ vertex_id ]],
 }
 
 fragment float4
-FragShaderSrcCopy(NormalRasterizerData in [[stage_in]],
-              texture2d<float> texture [[ texture(0) ]],
-              sampler smp [[sampler(0)]],
-              constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]]
-            )
+FragShaderSrcCopy(
+    NormalRasterizerData in [[stage_in]],
+    texture2d<float> texture [[ texture(0) ]],
+    sampler mainSampler [[sampler(0)]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]])
 {
-    float4 texColor = texture.sample(smp, in.texCoord) * uniforms.baseColor;
+    float4 texColor = texture.sample(mainSampler, in.texCoord) * uniforms.baseColor;
 
     return texColor;
 }
@@ -137,12 +140,13 @@ FragShaderSrcCopy(NormalRasterizerData in [[stage_in]],
 ////----- フラグメントシェーダプログラム -----
 //// Normal & Add & Mult 共通
 fragment float4
-FragShaderSrc(NormalRasterizerData in [[stage_in]],
-              texture2d<float> texture [[ texture(0) ]],
-              constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-              sampler smp [[sampler(0)]])
+FragShaderSrc(
+    NormalRasterizerData in [[stage_in]],
+    texture2d<float> texture [[ texture(0) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[sampler(0)]])
 {
-    float4 texColor = texture.sample(smp, in.texCoord);
+    float4 texColor = texture.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
     float4 color = texColor * uniforms.baseColor;
@@ -153,12 +157,13 @@ FragShaderSrc(NormalRasterizerData in [[stage_in]],
 
 //// Normal & Add & Mult 共通 （PremultipliedAlpha）
 fragment float4
-FragShaderSrcPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
-                        texture2d<float> texture [[ texture(0) ]],
-                        constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                        sampler smp [[sampler(0)]])
+FragShaderSrcPremultipliedAlpha(
+    MaskedRasterizerData in [[stage_in]],
+    texture2d<float> texture [[ texture(0) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[sampler(0)]])
 {
-    float4 texColor = texture.sample(smp, in.texCoord);
+    float4 texColor = texture.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
     float4 gl_FragColor = texColor * uniforms.baseColor;
@@ -168,18 +173,20 @@ FragShaderSrcPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
 
 //// Normal & Add & Mult 共通（クリッピングされたものの描画用）
 fragment float4
-FragShaderSrcMask(MaskedRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                    sampler smp [[sampler(0)]])
+FragShaderSrcMask(
+    MaskedRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = texColor * uniforms.baseColor;
     col_formask.rgb = col_formask.rgb  * col_formask.a ;
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     col_formask = col_formask * maskVal;
     float4 gl_FragColor = col_formask;
@@ -188,18 +195,20 @@ FragShaderSrcMask(MaskedRasterizerData in [[stage_in]],
 
 //// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
 fragment float4
-FragShaderSrcMaskInverted(MaskedRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                    sampler smp [[sampler(0)]])
+FragShaderSrcMaskInverted(
+    MaskedRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = texColor.rgb + uniforms.screenColor.rgb - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = texColor * uniforms.baseColor;
     col_formask.rgb = col_formask.rgb  * col_formask.a ;
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     col_formask = col_formask * (1.0 - maskVal);
     float4 gl_FragColor = col_formask;
@@ -208,17 +217,19 @@ FragShaderSrcMaskInverted(MaskedRasterizerData in [[stage_in]],
 
 //// Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
 fragment float4
-FragShaderSrcMaskPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                                    sampler smp [[sampler(0)]])
+FragShaderSrcMaskPremultipliedAlpha(
+    MaskedRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = texColor * uniforms.baseColor;
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     col_formask = col_formask * maskVal;
     float4 gl_FragColor = col_formask;
@@ -227,17 +238,19 @@ FragShaderSrcMaskPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
 
 //// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
 fragment float4
-FragShaderSrcMaskInvertedPremultipliedAlpha(MaskedRasterizerData in [[stage_in]],
-                    texture2d<float> texture0 [[ texture(0) ]],
-                    texture2d<float> texture1 [[ texture(1) ]],
-                    constant CubismShaderUniforms &uniforms  [[ buffer(MetalVertexInputIndexUniforms) ]],
-                    sampler smp [[sampler(0)]])
+FragShaderSrcMaskInvertedPremultipliedAlpha(
+    MaskedRasterizerData in [[stage_in]],
+    texture2d<float> texture0 [[ texture(0) ]],
+    texture2d<float> texture1 [[ texture(1) ]],
+    constant CubismShaderUniforms &uniforms [[ buffer(MetalVertexInputIndexUniforms) ]],
+    sampler mainSampler [[ sampler(0) ]],
+    sampler subSampler [[ sampler(1) ]])
 {
-    float4 texColor = texture0.sample(smp, in.texCoord);
+    float4 texColor = texture0.sample(mainSampler, in.texCoord);
     texColor.rgb = texColor.rgb * uniforms.multiplyColor.rgb;
     texColor.rgb = (texColor.rgb + uniforms.screenColor.rgb * texColor.a) - (texColor.rgb * uniforms.screenColor.rgb);
     float4 col_formask = texColor * uniforms.baseColor;
-    float4 clipMask = (1.0 - texture1.sample(smp, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
+    float4 clipMask = (1.0 - texture1.sample(subSampler, in.myPos.xy / in.myPos.w)) * uniforms.channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
     col_formask = col_formask * (1.0 - maskVal);
     float4 gl_FragColor = col_formask;

--- a/src/Rendering/OpenGL/CubismRenderTarget_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderTarget_OpenGLES2.cpp
@@ -29,6 +29,7 @@ CubismRenderTarget_OpenGLES2::CubismRenderTarget_OpenGLES2()
     : _renderTexture(0)
     , _colorBuffer(0)
     , _oldFBO(0)
+    , _oldViewport{0, 0, 0, 0}
     , _bufferWidth(0)
     , _bufferHeight(0)
     , _isColorBufferInherited(false)
@@ -52,6 +53,9 @@ void CubismRenderTarget_OpenGLES2::BeginDraw(GLint restoreFBO)
         _oldFBO = restoreFBO;
     }
 
+    // ビューポートを記憶しておく
+    glGetIntegerv(GL_VIEWPORT, _oldViewport);
+
     // マスク用RenderTextureをactiveにセット
     glBindFramebuffer(GL_FRAMEBUFFER, _renderTexture);
 }
@@ -65,6 +69,7 @@ void CubismRenderTarget_OpenGLES2::EndDraw()
 
     // 描画対象を戻す
     glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
+    glViewport(_oldViewport[0], _oldViewport[1], _oldViewport[2], _oldViewport[3]);
 }
 
 void CubismRenderTarget_OpenGLES2::Clear(float r, float g, float b, float a)
@@ -90,10 +95,15 @@ csmBool CubismRenderTarget_OpenGLES2::CreateRenderTarget(csmUint32 displayBuffer
 
             glBindTexture(GL_TEXTURE_2D, _colorBuffer);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, displayBufferWidth, displayBufferHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+#if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+#else
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+#endif
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
             glBindTexture(GL_TEXTURE_2D, 0);
 
             _isColorBufferInherited = false;

--- a/src/Rendering/OpenGL/CubismRenderTarget_OpenGLES2.hpp
+++ b/src/Rendering/OpenGL/CubismRenderTarget_OpenGLES2.hpp
@@ -137,6 +137,7 @@ private:
     GLuint      _colorBuffer;           ///< 描画の際使用するテクスチャとしてのアドレス
 
     GLint       _oldFBO;                ///< 旧フレームバッファ
+    GLint       _oldViewport[4];        ///< 旧ビューポート
 
     csmUint32   _bufferWidth;           ///< Create時に指定された幅
     csmUint32   _bufferHeight;          ///< Create時に指定された高さ

--- a/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismRenderer_OpenGLES2.cpp
@@ -636,6 +636,9 @@ void CubismRenderer_OpenGLES2::Initialize(CubismModel* model, csmInt32 maskBuffe
     }
 
     CubismRenderer::Initialize(model, maskBufferCount);  //親クラスの処理を呼ぶ
+
+    // シェーダの事前初期化
+    CubismShader_OpenGLES2::GetInstance();
 }
 
 void CubismRenderer_OpenGLES2::SetupParentOffscreens(const CubismModel* model, csmInt32 offscreenCount)
@@ -865,6 +868,9 @@ void CubismRenderer_OpenGLES2::DrawDrawable(csmInt32 drawableIndex)
 
     if (clipContext != NULL && IsUsingHighPrecisionMask()) // マスクを書く必要がある
     {
+        GLint preHighPrecisionMaskViewport[4];
+        glGetIntegerv(GL_VIEWPORT, preHighPrecisionMaskViewport);
+
         if (clipContext->_isUsing) // 書くことになっていた
         {
             // 生成したRenderTargetと同じサイズでビューポートを設定
@@ -908,7 +914,8 @@ void CubismRenderer_OpenGLES2::DrawDrawable(csmInt32 drawableIndex)
             // --- 後処理 ---
             GetDrawableMaskBuffer(clipContext->_bufferIndex)->EndDraw();
             SetClippingContextBufferForMask(NULL);
-            glViewport(0, 0, _modelRenderTargetWidth, _modelRenderTargetHeight);
+            glViewport(preHighPrecisionMaskViewport[0], preHighPrecisionMaskViewport[1],
+                       preHighPrecisionMaskViewport[2], preHighPrecisionMaskViewport[3]);
 
             PreDraw(); // バッファをクリアする
         }
@@ -1043,6 +1050,9 @@ void CubismRenderer_OpenGLES2::DrawOffscreen(CubismOffscreenRenderTarget_OpenGLE
 
     if (clipContext != NULL && IsUsingHighPrecisionMask()) // マスクを書く必要がある
     {
+        GLint preHighPrecisionMaskViewport[4];
+        glGetIntegerv(GL_VIEWPORT, preHighPrecisionMaskViewport);
+
         if (clipContext->_isUsing) // 書くことになっていた
         {
             // 生成したRenderTargetと同じサイズでビューポートを設定
@@ -1086,7 +1096,8 @@ void CubismRenderer_OpenGLES2::DrawOffscreen(CubismOffscreenRenderTarget_OpenGLE
             // --- 後処理 ---
             GetOffscreenMaskBuffer(clipContext->_bufferIndex)->EndDraw();
             SetClippingContextBufferForMask(NULL);
-            glViewport(0, 0, _modelRenderTargetWidth, _modelRenderTargetHeight);
+            glViewport(preHighPrecisionMaskViewport[0], preHighPrecisionMaskViewport[1],
+                       preHighPrecisionMaskViewport[2], preHighPrecisionMaskViewport[3]);
 
             PreDraw(); // バッファをクリアする
         }
@@ -1218,6 +1229,7 @@ void CubismRenderer_OpenGLES2::BeforeDrawModelRenderTarget()
 
     // 別バッファに描画を開始
     _modelRenderTargets[0].BeginDraw();
+    glViewport(0, 0, _modelRenderTargetWidth, _modelRenderTargetHeight);
     _modelRenderTargets[0].Clear(0.0f, 0.0f, 0.0f, 0.0f);
 }
 
@@ -1340,6 +1352,7 @@ const CubismRenderTarget_OpenGLES2* CubismRenderer_OpenGLES2::CopyRenderTarget(c
     // textureBarrierが無効な場合は、オフスクリーンの内容をコピーしてから描画する
 #if defined(CSM_TARGET_ANDROID_ES2) || defined(CSM_TARGET_IPHONE_ES2)
     _modelRenderTargets[1].BeginDraw();
+    glViewport(0, 0, _modelRenderTargetWidth, _modelRenderTargetHeight);
 
     CubismShader_OpenGLES2::GetInstance()->CopyTexture(srcBuffer.GetColorBuffer());
     glDrawElements(GL_TRIANGLES, sizeof(ModelRenderTargetIndexArray) / sizeof(csmUint16), GL_UNSIGNED_SHORT, ModelRenderTargetIndexArray);

--- a/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
+++ b/src/Rendering/OpenGL/CubismShader_OpenGLES2.cpp
@@ -9,10 +9,6 @@
 #include <float.h>
 #include "Type/csmRectF.hpp"
 
-#ifdef CSM_TARGET_WIN_GL
-#include <Windows.h>
-#endif
-
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
@@ -301,6 +297,7 @@ CubismShader_OpenGLES2* CubismShader_OpenGLES2::GetInstance()
     if (s_instance == NULL)
     {
         s_instance = CSM_NEW CubismShader_OpenGLES2();
+        s_instance->GenerateShaders();
     }
     return s_instance;
 }
@@ -326,6 +323,11 @@ void CubismShader_OpenGLES2::SetExtShaderMode(csmBool extMode, csmBool extPAMode
 
 void CubismShader_OpenGLES2::GenerateShaders()
 {
+    if (_shaderSets.GetSize() > 0)
+    {
+        return;
+    }
+
     for (csmInt32 i = 0; i < ShaderNames_ShaderCount; i++)
     {
         _shaderSets.PushBack(CSM_NEW CubismShaderSet());
@@ -473,8 +475,6 @@ void CubismShader_OpenGLES2::GenerateShaders()
     _shaderSets[ShaderNames_SetupMask]->UniformClipMatrixLocation = glGetUniformLocation(_shaderSets[ShaderNames_SetupMask]->ShaderProgram, "u_clipMatrix");
     _shaderSets[ShaderNames_SetupMask]->UnifromChannelFlagLocation = glGetUniformLocation(_shaderSets[ShaderNames_SetupMask]->ShaderProgram, "u_channelFlag");
     _shaderSets[ShaderNames_SetupMask]->UniformBaseColorLocation = glGetUniformLocation(_shaderSets[ShaderNames_SetupMask]->ShaderProgram, "u_baseColor");
-    _shaderSets[ShaderNames_SetupMask]->UniformMultiplyColorLocation = glGetUniformLocation(_shaderSets[ShaderNames_SetupMask]->ShaderProgram, "u_multiplyColor");
-    _shaderSets[ShaderNames_SetupMask]->UniformScreenColorLocation = glGetUniformLocation(_shaderSets[ShaderNames_SetupMask]->ShaderProgram, "u_screenColor");
 
     // 通常
     SetShaderSet(*_shaderSets[ShaderNames_Normal], MaskType_None);
@@ -543,11 +543,6 @@ void CubismShader_OpenGLES2::GenerateShaders()
 
 void CubismShader_OpenGLES2::SetupShaderProgramForDrawable(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const csmInt32 index)
 {
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders();
-    }
-
     // Blending
     csmInt32 SRC_COLOR;
     csmInt32 DST_COLOR;
@@ -660,8 +655,9 @@ void CubismShader_OpenGLES2::SetupShaderProgramForDrawable(CubismRenderer_OpenGL
         // ブレンドモード使用しない場合はDrawable単位でモデルカラーを処理する
         baseColor = renderer->GetModelColorWithOpacity(model.GetDrawableOpacity(index));
     }
-    CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-    CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
+    const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+    CubismRenderer::CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetDrawableMultiplyColor(index);
+    CubismRenderer::CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetDrawableScreenColor(index);
     SetColorUniformVariables(renderer, model, index, shaderSet, baseColor, multiplyColor, screenColor);
 
     glBlendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
@@ -669,11 +665,6 @@ void CubismShader_OpenGLES2::SetupShaderProgramForDrawable(CubismRenderer_OpenGL
 
 void CubismShader_OpenGLES2::SetupShaderProgramForMask(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const csmInt32 index)
 {
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders();
-    }
-
     // Blending
     csmInt32 SRC_COLOR = GL_ZERO;
     csmInt32 DST_COLOR = GL_ONE_MINUS_SRC_COLOR;
@@ -697,9 +688,7 @@ void CubismShader_OpenGLES2::SetupShaderProgramForMask(CubismRenderer_OpenGLES2*
     // ユニフォーム変数設定
     csmRectF* rect = renderer->GetClippingContextBufferForMask()->_layoutBounds;
     CubismRenderer::CubismTextureColor baseColor = {rect->X * 2.0f - 1.0f, rect->Y * 2.0f - 1.0f, rect->GetRight() * 2.0f - 1.0f, rect->GetBottom() * 2.0f - 1.0f};
-    CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-    CubismRenderer::CubismTextureColor screenColor = model.GetScreenColor(index);
-    SetColorUniformVariables(renderer, model, index, shaderSet, baseColor, multiplyColor, screenColor);
+    glUniform4f(shaderSet->UniformBaseColorLocation, baseColor.R, baseColor.G, baseColor.B, baseColor.A);
 
     glBlendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
 }
@@ -717,11 +706,6 @@ void CubismShader_OpenGLES2::SetupShaderProgramForOffscreenRenderTarget(CubismRe
 
 void CubismShader_OpenGLES2::CopyTexture(GLint texture, csmInt32 srcColor, csmInt32 dstColor, csmInt32 srcAlpha, csmInt32 dstAlpha, CubismRenderer::CubismTextureColor baseColor)
 {
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders();
-    }
-
     CubismShaderSet* shaderSet = _shaderSets[ShaderNames_Copy];
     glUseProgram(shaderSet->ShaderProgram);
 
@@ -746,11 +730,6 @@ void CubismShader_OpenGLES2::CopyTexture(GLint texture, csmInt32 srcColor, csmIn
 
 void CubismShader_OpenGLES2::SetupShaderProgramForOffscreen(CubismRenderer_OpenGLES2* renderer, const CubismModel& model, const CubismOffscreenRenderTarget_OpenGLES2* offscreen)
 {
-    if (_shaderSets.GetSize() == 0)
-    {
-        GenerateShaders();
-    }
-
     // Blending
     csmInt32 SRC_COLOR;
     csmInt32 DST_COLOR;
@@ -856,8 +835,9 @@ void CubismShader_OpenGLES2::SetupShaderProgramForOffscreen(CubismRenderer_OpenG
     csmFloat32 offscreenOpacity = model.GetOffscreenOpacity(offscreenIndex);
     // PMAなのと不透明度だけを変更したいためすべてOpacityで初期化
     CubismRenderer::CubismTextureColor baseColor(offscreenOpacity, offscreenOpacity, offscreenOpacity, offscreenOpacity);
-    CubismRenderer::CubismTextureColor multiplyColor = model.GetMultiplyColorOffscreen(offscreenIndex);
-    CubismRenderer::CubismTextureColor screenColor = model.GetScreenColorOffscreen(offscreenIndex);
+    const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+    CubismRenderer::CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetOffscreenMultiplyColor(offscreenIndex);
+    CubismRenderer::CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetOffscreenScreenColor(offscreenIndex);
     SetColorUniformVariables(renderer, model, offscreenIndex, shaderSet, baseColor, multiplyColor, screenColor);
 
     glBlendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
@@ -970,6 +950,7 @@ GLuint CubismShader_OpenGLES2::LoadShaderProgramFromFile(const csmChar* vertShad
     if (fragSrc == NULL)
     {
         CubismLogError("Failed to load fragment shader");
+        bytesReleaser(vertSrc);
         return 0;
     }
 
@@ -982,7 +963,23 @@ GLuint CubismShader_OpenGLES2::LoadShaderProgramFromFile(const csmChar* vertShad
     {
         csmChar buffer[64];
         csmByte* colorBlendSrc = fileLoader(ColorBlendShaderPath, &colorBlendSrcSize);
+        if (colorBlendSrc == NULL)
+        {
+            CubismLogError("Failed to load color blend shader");
+            bytesReleaser(vertSrc);
+            bytesReleaser(fragSrc);
+            return 0;
+        }
+
         csmByte* alphaBlendSrc = fileLoader(AlphaBlendShaderPath, &alphaBlendSrcSize);
+        if (alphaBlendSrc == NULL)
+        {
+            CubismLogError("Failed to load alpha blend shader");
+            bytesReleaser(colorBlendSrc);
+            bytesReleaser(vertSrc);
+            bytesReleaser(fragSrc);
+            return 0;
+        }
 
         // ブレンド
         std::snprintf(buffer, sizeof(buffer), "\n#define CSM_COLOR_BLEND_MODE %d\n", colorBlendMode);
@@ -1099,6 +1096,10 @@ void CubismShader_OpenGLES2::SetupTexture(CubismRenderer_OpenGLES2* renderer, co
     const GLuint textureId = renderer->GetBindedTextureId(textureIndex);
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, textureId);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glUniform1i(shaderSet->SamplerTexture0Location, 0);
 }
 

--- a/src/Rendering/Vulkan/CMakeLists.txt
+++ b/src/Rendering/Vulkan/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(${LIB_NAME}
   PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismDeviceInfo_Vulkan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CubismDeviceInfo_Vulkan.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenManager_Vulkan.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenManager_Vulkan.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CubismOffscreenRenderTarget_Vulkan.cpp

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.cpp
@@ -176,22 +176,28 @@ void CubismImageVulkan::CreateView(VkDevice device, VkFormat format, VkImageAspe
     }
 }
 
-void CubismImageVulkan::CreateSampler(VkDevice device, csmFloat32 maxAnistropy,
-                                      csmUint32 mipLevel)
+void CubismImageVulkan::CreateSampler(
+    VkDevice device,
+    VkSamplerAddressMode addressMode,
+    VkFilter magFilter,
+    VkFilter minFilter,
+    VkSamplerMipmapMode mipmapMode,
+    csmFloat32 maxAnistropy,
+    csmUint32 mipLevel)
 {
     VkSamplerCreateInfo samplerInfo{};
     samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    samplerInfo.magFilter = VK_FILTER_LINEAR;
-    samplerInfo.minFilter = VK_FILTER_LINEAR;
-    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeU = addressMode;
+    samplerInfo.addressModeV = addressMode;
+    samplerInfo.addressModeW = addressMode;
+    samplerInfo.magFilter = magFilter;
+    samplerInfo.minFilter = minFilter;
+    samplerInfo.mipmapMode = mipmapMode;
     samplerInfo.maxAnisotropy = maxAnistropy;
     samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     samplerInfo.unnormalizedCoordinates = VK_FALSE;
     samplerInfo.compareEnable = VK_FALSE;
     samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
-    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
     samplerInfo.minLod = 0.0f;
     samplerInfo.maxLod = static_cast<csmFloat32>(mipLevel);
     samplerInfo.mipLodBias = 0.0f;

--- a/src/Rendering/Vulkan/CubismClass_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismClass_Vulkan.hpp
@@ -137,10 +137,14 @@ public:
      * @brief   サンプラーを作成する
      *
      * @param[in]  device          -> デバイス
+     * @param[in]  addressMode     -> アドレスモード
+     * @param[in]  magFilter       -> マグフィルター
+     * @param[in]  minFilter       -> ミニフィルター
+     * @param[in]  mipmapMode      -> ミップマップモード
      * @param[in]  maxAnistropy    -> 異方性の値の最大値
      * @param[in]  mipLevel        -> ミップマップのレベル
      */
-    void CreateSampler(VkDevice device, csmFloat32 maxAnistropy, csmUint32 mipLevel);
+    void CreateSampler(VkDevice device, VkSamplerAddressMode addressMode, VkFilter magFilter, VkFilter minFilter, VkSamplerMipmapMode mipmapMode, csmFloat32 maxAnistropy, csmUint32 mipLevel);
 
     /**
      * @brief   イメージのレイアウトを変更する

--- a/src/Rendering/Vulkan/CubismDeviceInfo_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismDeviceInfo_Vulkan.cpp
@@ -1,0 +1,53 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#include "CubismDeviceInfo_Vulkan.hpp"
+#include "Type/csmMap.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+namespace {
+    csmMap<VkDevice, CubismDeviceInfo_Vulkan> s_deviceInfoList; ///< デバイスに紐づいているデータの管理
+}
+
+CubismDeviceInfo_Vulkan* CubismDeviceInfo_Vulkan::GetDeviceInfo(VkDevice device)
+{
+    return &s_deviceInfoList[device];
+}
+
+void CubismDeviceInfo_Vulkan::ReleaseDeviceInfo(VkDevice device)
+{
+    s_deviceInfoList.Erase(device);
+}
+
+void CubismDeviceInfo_Vulkan::ReleaseAllDeviceInfo()
+{
+    s_deviceInfoList.Clear();
+}
+
+CubismDeviceInfo_Vulkan::CubismDeviceInfo_Vulkan()
+{
+}
+
+CubismDeviceInfo_Vulkan::~CubismDeviceInfo_Vulkan()
+{
+}
+
+CubismPipeline_Vulkan* CubismDeviceInfo_Vulkan::GetPipeline()
+{
+    return &_pipeline;
+}
+
+CubismOffscreenManager_Vulkan* CubismDeviceInfo_Vulkan::GetOffscreenManager()
+{
+    return &_offscreenManager;
+}
+
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/CubismDeviceInfo_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismDeviceInfo_Vulkan.hpp
@@ -1,0 +1,74 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+#pragma once
+
+#include "CubismRenderer_Vulkan.hpp"
+#include "CubismOffscreenManager_Vulkan.hpp"
+
+//------------ LIVE2D NAMESPACE ------------
+namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+/**
+ * @brief デバイスに紐づいているデータの使用箇所の数とデータを管理するクラス
+ */
+class CubismDeviceInfo_Vulkan
+{
+public:
+    /**
+     * @brief   デバイスに紐づいているデータを取得する
+     *
+     * @param[in]   device         -> 使用デバイス
+     *
+     * @return デバイスに紐づいているデータを返す
+     */
+    static CubismDeviceInfo_Vulkan* GetDeviceInfo(VkDevice device);
+
+    /**
+     * @brief   デバイスに紐づいているデータの使用を開放する
+     *
+     * @param[in]   device         -> 使用デバイス
+     */
+    static void ReleaseDeviceInfo(VkDevice device);
+
+    /**
+     * @brief   デバイスに紐づいているデータの使用を全て開放する
+     */
+    static void ReleaseAllDeviceInfo();
+
+    /**
+     * @brief   コンストラクタ
+     */
+    CubismDeviceInfo_Vulkan();
+
+    /**
+     * @brief   デストラクタ
+     */
+    ~CubismDeviceInfo_Vulkan();
+
+    /**
+     * @brief   パイプラインを取得する
+     *
+     * @return パイプラインを返す
+     */
+    CubismPipeline_Vulkan* GetPipeline();
+
+    /**
+     * @brief   オフスクリーンマネージャーを取得する
+     *
+     * @return オフスクリーンマネージャーを返す
+     */
+    CubismOffscreenManager_Vulkan* GetOffscreenManager();
+
+private:
+    CubismPipeline_Vulkan _pipeline; ///< パイプライン
+    CubismOffscreenManager_Vulkan _offscreenManager; ///< オフスクリーンマネージャー
+};
+
+}}}}
+
+//------------ LIVE2D NAMESPACE ------------

--- a/src/Rendering/Vulkan/CubismOffscreenManager_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismOffscreenManager_Vulkan.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -10,28 +10,12 @@
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
 
-namespace {
-    CubismOffscreenManager_Vulkan* s_instance = nullptr;
+CubismOffscreenManager_Vulkan::CubismOffscreenManager_Vulkan()
+{
 }
 
-CubismOffscreenManager_Vulkan* CubismOffscreenManager_Vulkan::GetInstance()
+CubismOffscreenManager_Vulkan::~CubismOffscreenManager_Vulkan()
 {
-    if (s_instance == NULL)
-    {
-        s_instance = new CubismOffscreenManager_Vulkan();
-    }
-
-    return s_instance;
-}
-
-void CubismOffscreenManager_Vulkan::ReleaseInstance()
-{
-    if (s_instance != NULL)
-    {
-        delete s_instance;
-    }
-
-    s_instance = NULL;
 }
 
 CubismRenderTarget_Vulkan* CubismOffscreenManager_Vulkan::GetOffscreenRenderTarget(
@@ -64,14 +48,6 @@ CubismRenderTarget_Vulkan* CubismOffscreenManager_Vulkan::GetOffscreenRenderTarg
         displayBufferWidth, displayBufferHeight, surfaceFormat, depthFormat);
 
     return offscreenRenderTarget;
-}
-
-CubismOffscreenManager_Vulkan::CubismOffscreenManager_Vulkan()
-{
-}
-
-CubismOffscreenManager_Vulkan::~CubismOffscreenManager_Vulkan()
-{
 }
 
 }}}}

--- a/src/Rendering/Vulkan/CubismOffscreenManager_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismOffscreenManager_Vulkan.hpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -22,18 +22,14 @@ class CubismOffscreenManager_Vulkan : public ICubismOffscreenManager<CubismRende
 
 public:
     /**
-    * @brief   クラスのインスタンス（シングルトン）を返す。
-    *           インスタンスが生成されていない場合は内部でインスタンスを生成する。
-    *
-    * @return  クラスのインスタンス
-    */
-    static CubismOffscreenManager_Vulkan* GetInstance();
+     * @brief   コンストラクタ
+     */
+    CubismOffscreenManager_Vulkan();
 
     /**
-    * @brief   クラスのインスタンス（シングルトン）を解放する。
-    *
-    */
-    static void ReleaseInstance();
+     * @brief   デストラクタ
+     */
+    ~CubismOffscreenManager_Vulkan();
 
     /**
     * @brief 使用可能なレンダーターゲットの取得
@@ -52,18 +48,6 @@ public:
         csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
         VkFormat surfaceFormat, VkFormat depthFormat
     );
-
-private:
-
-    /**
-     * @brief   コンストラクタ
-     */
-    CubismOffscreenManager_Vulkan();
-
-    /**
-     * @brief   デストラクタ
-     */
-    ~CubismOffscreenManager_Vulkan();
 
 };
 

--- a/src/Rendering/Vulkan/CubismOffscreenRenderTarget_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismOffscreenRenderTarget_Vulkan.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -21,10 +21,11 @@ CubismOffscreenRenderTarget_Vulkan::~CubismOffscreenRenderTarget_Vulkan()
 
 void CubismOffscreenRenderTarget_Vulkan::SetOffscreenRenderTarget(
     VkDevice device, VkPhysicalDevice physicalDevice,
+    CubismOffscreenManager_Vulkan* offscreenManager,
     csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
     VkFormat surfaceFormat, VkFormat depthFormat)
 {
-    if (GetUsingRenderTextureState())
+    if (GetUsingRenderTextureState(offscreenManager))
     {
 
         if (_renderTarget->GetBufferWidth() != displayBufferWidth ||
@@ -37,18 +38,18 @@ void CubismOffscreenRenderTarget_Vulkan::SetOffscreenRenderTarget(
         return;
     }
 
-    _renderTarget = CubismOffscreenManager_Vulkan::GetInstance()->GetOffscreenRenderTarget(
+    _renderTarget = offscreenManager->GetOffscreenRenderTarget(
         device, physicalDevice, displayBufferWidth, displayBufferHeight, surfaceFormat, depthFormat);
 }
 
-csmBool CubismOffscreenRenderTarget_Vulkan::GetUsingRenderTextureState() const
+csmBool CubismOffscreenRenderTarget_Vulkan::GetUsingRenderTextureState(CubismOffscreenManager_Vulkan* offscreenManager) const
 {
-    return CubismOffscreenManager_Vulkan::GetInstance()->GetUsingRenderTextureState(_renderTarget);
+    return offscreenManager->GetUsingRenderTextureState(_renderTarget);
 }
 
-void CubismOffscreenRenderTarget_Vulkan::StopUsingRenderTexture()
+void CubismOffscreenRenderTarget_Vulkan::StopUsingRenderTexture(CubismOffscreenManager_Vulkan* offscreenManager)
 {
-    CubismOffscreenManager_Vulkan::GetInstance()->StopUsingRenderTexture(_renderTarget);
+    offscreenManager->StopUsingRenderTexture(_renderTarget);
     _renderTarget = nullptr;
 }
 

--- a/src/Rendering/Vulkan/CubismOffscreenRenderTarget_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismOffscreenRenderTarget_Vulkan.hpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -12,6 +12,8 @@
 
 //------------ LIVE2D NAMESPACE ------------
 namespace Live2D { namespace Cubism { namespace Framework { namespace Rendering {
+
+class CubismOffscreenManager_Vulkan;
 
 /**
  * @brief  オフスクリーン用のレンダーターゲットを管理するクラス
@@ -34,6 +36,7 @@ public:
      *
      *  @param[in]  device                 -> 論理デバイス
      *  @param[in]  physicalDevice         -> 物理デバイス
+     *  @param[in]  offscreenManager       -> オフスクリーンマネージャー
      *  @param[in]  displayBufferWidth     -> オフスクリーンの横幅
      *  @param[in]  displayBufferHeight    -> オフスクリーンの縦幅
      *  @param[in]  surfaceFormat          -> サーフェスフォーマット
@@ -41,6 +44,7 @@ public:
      */
     void SetOffscreenRenderTarget(
         VkDevice device, VkPhysicalDevice physicalDevice,
+        CubismOffscreenManager_Vulkan* offscreenManager,
         csmUint32 displayBufferWidth, csmUint32 displayBufferHeight,
         VkFormat surfaceFormat, VkFormat depthFormat
     );
@@ -48,14 +52,18 @@ public:
     /**
      * @brief レンダーターゲットの使用状態を取得する。
      *
+     * @param[in]  offscreenManager       -> オフスクリーンマネージャー
+     *
      * @return 使用中はtrue、未使用の場合はfalseを返す。
      */
-    csmBool GetUsingRenderTextureState() const;
+    csmBool GetUsingRenderTextureState(CubismOffscreenManager_Vulkan* offscreenManager) const;
 
     /**
      * @brief オフスクリーン描画用レンダーターゲットの使用を終了する。
+     *
+     * @param[in]  offscreenManager       -> オフスクリーンマネージャー
      */
-    void StopUsingRenderTexture();
+    void StopUsingRenderTexture(CubismOffscreenManager_Vulkan* offscreenManager);
 
 };
 

--- a/src/Rendering/Vulkan/CubismRenderTarget_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismRenderTarget_Vulkan.cpp
@@ -61,7 +61,7 @@ void CubismRenderTarget_Vulkan::BeginDraw(VkCommandBuffer commandBuffer, csmFloa
     _isRendering = true;
 }
 
-void CubismRenderTarget_Vulkan::EndDraw(VkCommandBuffer commandBuffer)
+void CubismRenderTarget_Vulkan::EndDraw(VkCommandBuffer commandBuffer, VkImageLayout currentLayout)
 {
     // レンダリングパスがアクティブでない場合はスキップ
     if (!_isRendering)
@@ -78,7 +78,7 @@ void CubismRenderTarget_Vulkan::EndDraw(VkCommandBuffer commandBuffer)
     memoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     memoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     memoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-    memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    memoryBarrier.oldLayout = currentLayout;
     memoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     memoryBarrier.image = _colorImage->GetImage();
     memoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -87,6 +87,7 @@ void CubismRenderTarget_Vulkan::EndDraw(VkCommandBuffer commandBuffer)
                          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &memoryBarrier);
     _colorImage->SetCurrentLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
+    memoryBarrier.dstAccessMask = VK_ACCESS_NONE;
     memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     memoryBarrier.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     memoryBarrier.image = _depthImage->GetImage();
@@ -110,7 +111,7 @@ void CubismRenderTarget_Vulkan::CreateRenderTarget(
                              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
                              VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     _colorImage->CreateView(device, surfaceFormat, VK_IMAGE_ASPECT_COLOR_BIT, 1);
-    _colorImage->CreateSampler(device, 1.0, 1);
+    _colorImage->CreateSampler(device, VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_FILTER_NEAREST, VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST, 1.0, 1);
 
     _depthImage = CSM_NEW CubismImageVulkan;
     _depthImage->CreateImage(device, physicalDevice, displayBufferWidth, displayBufferHeight,
@@ -177,6 +178,14 @@ csmBool CubismRenderTarget_Vulkan::IsValid() const
 csmBool CubismRenderTarget_Vulkan::IsRendering() const
 {
     return _isRendering;
+}
+
+void CubismRenderTarget_Vulkan::SetColorImageCurrentLayout(VkImageLayout layout)
+{
+    if (_colorImage != VK_NULL_HANDLE)
+    {
+        _colorImage->SetCurrentLayout(layout);
+    }
 }
 }}}}
 

--- a/src/Rendering/Vulkan/CubismRenderTarget_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismRenderTarget_Vulkan.hpp
@@ -37,8 +37,9 @@ public:
      * @brief   描画終了
      *
      *  @param[in]  commandBuffer                 -> コマンドバッファ
+     *  @param[in]  currentLayout                 -> 現在のイメージレイアウト
      */
-    void EndDraw(VkCommandBuffer commandBuffer);
+    void EndDraw(VkCommandBuffer commandBuffer, VkImageLayout currentLayout=VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     /**
      *  @brief  CubismRenderTargetを作成する。
@@ -95,6 +96,13 @@ public:
      * @brief   レンダリングパスがアクティブかどうかを返す
      */
     csmBool IsRendering() const;
+
+    /**
+     * @brief   カラーイメージの現在のレイアウトを設定する
+     *
+     * @param[in]  newLayout  -> 新しいレイアウト
+     */
+    void SetColorImageCurrentLayout(VkImageLayout newLayout);
 
 private:
     VkDevice _device; ///< 論理デバイス

--- a/src/Rendering/Vulkan/CubismRenderer_Vulkan.cpp
+++ b/src/Rendering/Vulkan/CubismRenderer_Vulkan.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "CubismRenderer_Vulkan.hpp"
+#include "CubismDeviceInfo_Vulkan.hpp"
 #include "CubismOffscreenManager_Vulkan.hpp"
 #include "Math/CubismMatrix44.hpp"
 #include "Type/csmVector.hpp"
@@ -351,7 +352,6 @@ CubismClippingContext_Vulkan::GetClippingManager()
 namespace {
 const csmInt32 ShaderCount = ShaderNames_ShaderCount;
 ///<シェーダの数 = コピー用 + マスク生成用 + (通常 + 加算 + 乗算 + ブレンドモードの組み合わせ数) * (マスク無 + マスク有 + マスク有反転 + マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
-CubismPipeline_Vulkan* s_pipelineManager;
 }
 
 CubismPipeline_Vulkan::CubismPipeline_Vulkan()
@@ -651,6 +651,12 @@ void CubismPipeline_Vulkan::CreatePipelines(VkDescriptorSetLayout descriptorSetL
     _pipelineResource.Resize(ShaderCount);
     for (csmInt32 i = 0; i < ShaderCount; i++)
     {
+        // 加算と乗算は通常と同じリソースを参照するため生成しない
+        if (i >= ShaderNames_Add && i <= ShaderNames_MultMaskedInvertedPremultipliedAlpha)
+        {
+            _pipelineResource[i] = NULL;
+            continue;
+        }
         _pipelineResource[i] = CSM_NEW PipelineResource();
     }
 
@@ -737,15 +743,6 @@ void CubismPipeline_Vulkan::CreatePipelineResource(csmUint32 const& shaderName, 
     }
 }
 
-CubismPipeline_Vulkan* CubismPipeline_Vulkan::GetInstance()
-{
-    if (s_pipelineManager == NULL)
-    {
-        s_pipelineManager = CSM_NEW CubismPipeline_Vulkan();
-    }
-    return s_pipelineManager;
-}
-
 void CubismPipeline_Vulkan::ReleaseShaderProgram()
 {
     for (csmInt32 i = 0; i < _pipelineResource.GetSize(); i++)
@@ -782,6 +779,7 @@ void CubismRenderer::StaticRelease()
 CubismRenderer_Vulkan::CubismRenderer_Vulkan(csmUint32 width, csmUint32 height) :
                                                CubismRenderer(width, height)
                                                , vkCmdSetCullModeEXT()
+                                               , _deviceInfo(NULL)
                                                , _drawableClippingManager(NULL)
                                                , _clippingContextBufferForMask(NULL)
                                                , _clippingContextBufferForDraw(NULL)
@@ -791,6 +789,9 @@ CubismRenderer_Vulkan::CubismRenderer_Vulkan(csmUint32 width, csmUint32 height) 
                                                , _currentRenderTarget(NULL)
                                                , _descriptorPool(VK_NULL_HANDLE)
                                                , _descriptorSetLayout(VK_NULL_HANDLE)
+                                               , _offscreenDescriptorPool(VK_NULL_HANDLE)
+                                               , _copyDescriptorPool(VK_NULL_HANDLE)
+                                               , _copyDescriptorSetLayout(VK_NULL_HANDLE)
                                                , _clearColor()
                                                , _commandBufferCurrent(0)
 {
@@ -848,7 +849,10 @@ CubismRenderer_Vulkan::~CubismRenderer_Vulkan()
 
     // ディスクリプタ関連解放
     vkDestroyDescriptorPool(s_device, _descriptorPool, nullptr);
-    vkDestroyDescriptorPool(s_device, _offscreenDescriptorPool, nullptr);
+    if (_offscreenDescriptorPool != VK_NULL_HANDLE)
+    {
+        vkDestroyDescriptorPool(s_device, _offscreenDescriptorPool, nullptr);
+    }
     vkDestroyDescriptorPool(s_device, _copyDescriptorPool, nullptr);
     vkDestroyDescriptorSetLayout(s_device, _descriptorSetLayout, nullptr);
     vkDestroyDescriptorSetLayout(s_device, _copyDescriptorSetLayout, nullptr);
@@ -896,11 +900,6 @@ CubismRenderer_Vulkan::~CubismRenderer_Vulkan()
 
 void CubismRenderer_Vulkan::DoStaticRelease()
 {
-    if (s_pipelineManager)
-    {
-        CSM_DELETE_SELF(CubismPipeline_Vulkan, s_pipelineManager);
-        s_pipelineManager = NULL;
-    }
 }
 
 VkCommandBuffer CubismRenderer_Vulkan::BeginSingleTimeCommands()
@@ -954,8 +953,8 @@ void CubismRenderer_Vulkan::SubmitCommand(VkCommandBuffer commandBuffer, VkSemap
 
 }
 
-void CubismRenderer_Vulkan::InitializeConstantSettings(VkDevice device, VkPhysicalDevice physicalDevice, VkCommandPool commandPool, VkQueue queue,
-                                                       csmUint32 swapchainImageCount, VkExtent2D extent, VkImageView imageView, VkFormat imageFormat, VkFormat depthFormat)
+void CubismRenderer_Vulkan::SetConstantSettings(VkDevice device, VkPhysicalDevice physicalDevice, VkCommandPool commandPool, VkQueue queue,
+                                                 csmUint32 swapchainImageCount, VkExtent2D extent, VkImageView imageView, VkFormat imageFormat, VkFormat depthFormat)
 {
     s_device = device;
     s_physicalDevice = physicalDevice;
@@ -1214,19 +1213,21 @@ void CubismRenderer_Vulkan::CreateDescriptorSets()
     }
 
     // オフスクリーン用ディスクリプタプール作成
-    poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    poolSizes[0].descriptorCount = offscreenDescriptorSetCount;
-    poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    poolSizes[1].descriptorCount = offscreenDescriptorSetCount * textureCount; // offscreenCount * 描画方法の数 * テクスチャの数
-
-    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.poolSizeCount = sizeof(poolSizes) / sizeof(poolSizes[0]);
-    poolInfo.pPoolSizes = poolSizes;
-    poolInfo.maxSets = offscreenDescriptorSetCount;
-
-    if (vkCreateDescriptorPool(s_device, &poolInfo, nullptr, &_offscreenDescriptorPool) != VK_SUCCESS)
+    if (offscreenDescriptorSetCount > 0)
     {
-        CubismLogError("failed to create offscreen descriptor pool!");
+        poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        poolSizes[0].descriptorCount = offscreenDescriptorSetCount;
+        poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        poolSizes[1].descriptorCount = offscreenDescriptorSetCount * textureCount; // offscreenCount * 描画方法の数 * テクスチャの数
+        poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        poolInfo.poolSizeCount = sizeof(poolSizes) / sizeof(poolSizes[0]);
+        poolInfo.pPoolSizes = poolSizes;
+        poolInfo.maxSets = offscreenDescriptorSetCount;
+
+        if (vkCreateDescriptorPool(s_device, &poolInfo, nullptr, &_offscreenDescriptorPool) != VK_SUCCESS)
+        {
+            CubismLogError("failed to create offscreen descriptor pool!");
+        }
     }
 
     // コピー用ディスクリプタプール作成
@@ -1363,40 +1364,43 @@ void CubismRenderer_Vulkan::CreateDescriptorSets()
     }
 
     // オフスクリーン用
-    for (csmUint32 buffer = 0; buffer < s_bufferSetNum; buffer++)
+    if (offscreenCount > 0)
     {
-        _offscreenDescriptorSets[buffer].Resize(offscreenCount);
-        for (csmInt32 offscreenAssign = 0; offscreenAssign < offscreenCount; offscreenAssign++)
+        for (csmUint32 buffer = 0; buffer < s_bufferSetNum; buffer++)
         {
-            _offscreenDescriptorSets[buffer][offscreenAssign].uniformBuffer.CreateBuffer(s_device, s_physicalDevice, sizeof(ModelUBO),
-                                                                VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                                                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-            _offscreenDescriptorSets[buffer][offscreenAssign].uniformBuffer.Map(s_device, VK_WHOLE_SIZE);
-        }
+            _offscreenDescriptorSets[buffer].Resize(offscreenCount);
+            for (csmInt32 offscreenAssign = 0; offscreenAssign < offscreenCount; offscreenAssign++)
+            {
+                _offscreenDescriptorSets[buffer][offscreenAssign].uniformBuffer.CreateBuffer(s_device, s_physicalDevice, sizeof(ModelUBO),
+                                                                    VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                                                                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                                                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                _offscreenDescriptorSets[buffer][offscreenAssign].uniformBuffer.Map(s_device, VK_WHOLE_SIZE);
+            }
 
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = _offscreenDescriptorPool;
-        allocInfo.descriptorSetCount = offscreenDescriptorSetCountPerBuffer;
-        csmVector<VkDescriptorSetLayout> layouts;
-        for (csmInt32 i = 0; i < offscreenDescriptorSetCountPerBuffer; i++)
-        {
-            layouts.PushBack(_descriptorSetLayout);
-        }
-        allocInfo.pSetLayouts = layouts.GetPtr();
+            VkDescriptorSetAllocateInfo allocInfo{};
+            allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+            allocInfo.descriptorPool = _offscreenDescriptorPool;
+            allocInfo.descriptorSetCount = offscreenDescriptorSetCountPerBuffer;
+            csmVector<VkDescriptorSetLayout> layouts;
+            for (csmInt32 i = 0; i < offscreenDescriptorSetCountPerBuffer; i++)
+            {
+                layouts.PushBack(_descriptorSetLayout);
+            }
+            allocInfo.pSetLayouts = layouts.GetPtr();
 
-        csmVector<VkDescriptorSet> descriptorSets;
-        descriptorSets.Resize(offscreenDescriptorSetCountPerBuffer);
-        if (vkAllocateDescriptorSets(s_device, &allocInfo, descriptorSets.GetPtr()) != VK_SUCCESS)
-        {
-            CubismLogError("failed to allocate descriptor sets!");
-        }
+            csmVector<VkDescriptorSet> descriptorSets;
+            descriptorSets.Resize(offscreenDescriptorSetCountPerBuffer);
+            if (vkAllocateDescriptorSets(s_device, &allocInfo, descriptorSets.GetPtr()) != VK_SUCCESS)
+            {
+                CubismLogError("failed to allocate descriptor sets!");
+            }
 
-        for (csmInt32 offscreenAssign = 0; offscreenAssign < offscreenCount; offscreenAssign++)
-        {
-            _offscreenDescriptorSets[buffer][offscreenAssign].descriptorSet = descriptorSets[offscreenAssign * 2];
-            _offscreenDescriptorSets[buffer][offscreenAssign].descriptorSetMasked = descriptorSets[offscreenAssign * 2 + 1];
+            for (csmInt32 offscreenAssign = 0; offscreenAssign < offscreenCount; offscreenAssign++)
+            {
+                _offscreenDescriptorSets[buffer][offscreenAssign].descriptorSet = descriptorSets[offscreenAssign * 2];
+                _offscreenDescriptorSets[buffer][offscreenAssign].descriptorSetMasked = descriptorSets[offscreenAssign * 2 + 1];
+            }
         }
     }
 
@@ -1437,6 +1441,8 @@ void CubismRenderer_Vulkan::CreateDepthBuffer()
 
 void CubismRenderer_Vulkan::InitializeRenderer()
 {
+    _deviceInfo = CubismDeviceInfo_Vulkan::GetDeviceInfo(s_device);
+
     vkCmdSetCullModeEXT = reinterpret_cast<PFN_vkCmdSetCullMode>(vkGetDeviceProcAddr(s_device, "vkCmdSetCullModeEXT"));
 
     _updateFinishedSemaphores.Resize(s_bufferSetNum);
@@ -1452,7 +1458,7 @@ void CubismRenderer_Vulkan::InitializeRenderer()
     CreateIndexBuffer();
     CreateDescriptorSets();
     CreateDepthBuffer();
-    CubismPipeline_Vulkan::GetInstance()->CreatePipelines(_descriptorSetLayout, _copyDescriptorSetLayout);
+    _deviceInfo->GetPipeline()->CreatePipelines(_descriptorSetLayout, _copyDescriptorSetLayout);
 }
 
 void CubismRenderer_Vulkan::Initialize(CubismModel* model)
@@ -1721,7 +1727,7 @@ void CubismRenderer_Vulkan::UpdateDescriptorSet(Descriptor& descriptor, csmUint3
                                                           ? _currentRenderTarget
                                                           : GetModelRenderTarget();
 
-        imageInfo3.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+        imageInfo3.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
         imageInfo3.imageView = blendRenderTarget->GetTextureView();
         imageInfo3.sampler = blendRenderTarget->GetTextureSampler();
         VkWriteDescriptorSet image3{};
@@ -1856,7 +1862,7 @@ void CubismRenderer_Vulkan::UpdateDescriptorSetForOffscreen(Descriptor& descript
                                                           ? _currentRenderTarget
                                                           : GetModelRenderTarget();
 
-        blendImageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+        blendImageInfo.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
         blendImageInfo.imageView = blendRenderTarget->GetTextureView();
         blendImageInfo.sampler = blendRenderTarget->GetTextureSampler();
         VkWriteDescriptorSet blendImage{};
@@ -1954,13 +1960,13 @@ void CubismRenderer_Vulkan::ExecuteDrawForDrawable(const CubismModel& model, con
         break;
     }
 
-    VkPipelineLayout pipelineLayout = CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(shaderIndex, blendIndex);
+    VkPipelineLayout pipelineLayout = _deviceInfo->GetPipeline()->GetPipelineLayout(shaderIndex, blendIndex);
     if (pipelineLayout == NULL)
     {
         return;
     }
 
-    VkPipeline pipeline = CubismPipeline_Vulkan::GetInstance()->GetPipeline(shaderIndex, blendIndex);
+    VkPipeline pipeline = _deviceInfo->GetPipeline()->GetPipeline(shaderIndex, blendIndex);
     if (pipeline == NULL)
     {
         return;
@@ -2000,8 +2006,9 @@ void CubismRenderer_Vulkan::ExecuteDrawForDrawable(const CubismModel& model, con
         // ブレンドモード使用しない場合はDrawable単位でモデルカラーを処理する
         baseColor = GetModelColorWithOpacity(model.GetDrawableOpacity(index));
     }
-    CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-    CubismTextureColor screenColor = model.GetScreenColor(index);
+    const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+    CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetDrawableMultiplyColor(index);
+    CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetDrawableScreenColor(index);
     SetColorUniformBuffer(ubo, baseColor, multiplyColor, screenColor);
 
     // ディスクリプタにユニフォームバッファをコピー
@@ -2027,7 +2034,7 @@ void CubismRenderer_Vulkan::ExecuteDrawForDrawable(const CubismModel& model, con
 
     if (isBlendMode)
     {
-        SetBlendTextureBarrier(cmdBuffer);
+        SetBlendTextureBarrier(cmdBuffer, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     }
 
     // 描画
@@ -2039,13 +2046,13 @@ void CubismRenderer_Vulkan::ExecuteDrawForMask(const CubismModel& model, const c
     csmUint32 shaderIndex = ShaderNames_SetupMask;
     csmUint32 blendIndex = Blend_Mask;
 
-    VkPipelineLayout pipelineLayout = CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(shaderIndex, blendIndex);
+    VkPipelineLayout pipelineLayout = _deviceInfo->GetPipeline()->GetPipelineLayout(shaderIndex, blendIndex);
     if (pipelineLayout == NULL)
     {
         return;
     }
 
-    VkPipeline pipeline = CubismPipeline_Vulkan::GetInstance()->GetPipeline(shaderIndex, blendIndex);
+    VkPipeline pipeline = _deviceInfo->GetPipeline()->GetPipeline(shaderIndex, blendIndex);
     if (pipeline == NULL)
     {
         return;
@@ -2053,6 +2060,7 @@ void CubismRenderer_Vulkan::ExecuteDrawForMask(const CubismModel& model, const c
 
     Descriptor &descriptor = _descriptorSets[_commandBufferCurrent][index];
     ModelUBO ubo;
+    memset(&ubo, 0, sizeof(ubo));
 
     // クリッピング用行列の設定
     UpdateMatrix(ubo.clipMatrix, GetClippingContextBufferForMask()->_matrixForMask);
@@ -2066,9 +2074,7 @@ void CubismRenderer_Vulkan::ExecuteDrawForMask(const CubismModel& model, const c
     // 色定数バッファの設定
     csmRectF *rect = GetClippingContextBufferForMask()->_layoutBounds;
     CubismTextureColor baseColor = {rect->X * 2.0f - 1.0f, rect->Y * 2.0f - 1.0f, rect->GetRight() * 2.0f - 1.0f, rect->GetBottom() * 2.0f - 1.0f};
-    CubismTextureColor multiplyColor = model.GetMultiplyColor(index);
-    CubismTextureColor screenColor = model.GetScreenColor(index);
-    SetColorUniformBuffer(ubo, baseColor, multiplyColor, screenColor);
+    UpdateColor(ubo.baseColor, baseColor.R, baseColor.G, baseColor.B, baseColor.A);
 
     // マスク生成時用ユニフォームバッファにコピー
     descriptor.uniformBufferMask.MemCpy(&ubo, sizeof(ModelUBO));
@@ -2129,13 +2135,13 @@ void CubismRenderer_Vulkan::ExecuteDrawForOffscreen(const CubismModel& model, Cu
         break;
     }
 
-    VkPipelineLayout pipelineLayout = CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(shaderIndex, blendIndex);
+    VkPipelineLayout pipelineLayout = _deviceInfo->GetPipeline()->GetPipelineLayout(shaderIndex, blendIndex);
     if (pipelineLayout == NULL)
     {
         return;
     }
 
-    VkPipeline pipeline = CubismPipeline_Vulkan::GetInstance()->GetPipeline(shaderIndex, blendIndex);
+    VkPipeline pipeline = _deviceInfo->GetPipeline()->GetPipeline(shaderIndex, blendIndex);
     if (pipeline == NULL)
     {
         return;
@@ -2161,8 +2167,9 @@ void CubismRenderer_Vulkan::ExecuteDrawForOffscreen(const CubismModel& model, Cu
     // オフスクリーンはPreMultipliedAlpha
     csmFloat32 offscreenOpacity = model.GetOffscreenOpacity(offscreenIndex);
     CubismTextureColor baseColor = CubismTextureColor(offscreenOpacity, offscreenOpacity, offscreenOpacity, offscreenOpacity);
-    CubismTextureColor multiplyColor = model.GetMultiplyColorOffscreen(offscreenIndex);
-    CubismTextureColor screenColor = model.GetScreenColorOffscreen(offscreenIndex);
+    const CubismModelMultiplyAndScreenColor& overrideMultiplyAndScreenColor = model.GetOverrideMultiplyAndScreenColor();
+    CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.GetOffscreenMultiplyColor(offscreenIndex);
+    CubismTextureColor screenColor = overrideMultiplyAndScreenColor.GetOffscreenScreenColor(offscreenIndex);
     SetColorUniformBuffer(ubo, baseColor, multiplyColor, screenColor);
 
     // ディスクリプタにユニフォームバッファをコピー
@@ -2219,12 +2226,12 @@ void CubismRenderer_Vulkan::ExecuteDrawForRenderTarget(const CubismRenderTarget_
     // ディスクリプタセットバインド
     VkDescriptorSet* descriptorSet = &_copyDescriptorSets[_commandBufferCurrent].descriptorSet;
     vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                            CubismPipeline_Vulkan::GetInstance()->GetPipelineLayout(ShaderNames_Copy, 0),
+                            _deviceInfo->GetPipeline()->GetPipelineLayout(ShaderNames_Copy, 0),
                             0, 1, descriptorSet, 0, nullptr);
 
     // パイプラインバインド
     vkCmdBindPipeline(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                        CubismPipeline_Vulkan::GetInstance()->GetPipeline(ShaderNames_Copy, 0));
+                        _deviceInfo->GetPipeline()->GetPipeline(ShaderNames_Copy, 0));
 
     // 裏面描画の有効
     vkCmdSetCullModeEXT(cmdBuffer, VK_CULL_MODE_NONE);
@@ -2271,7 +2278,7 @@ void CubismRenderer_Vulkan::DrawMeshVulkan(const CubismModel& model, const csmIn
         return;
     }
 
-    csmInt32 textureIndex = model.GetDrawableTextureIndices(index);
+    csmInt32 textureIndex = model.GetDrawableTextureIndex(index);
     if (_textures[textureIndex].GetSampler() == VK_NULL_HANDLE || _textures[textureIndex].GetView() == VK_NULL_HANDLE)
     {
         return;
@@ -2316,7 +2323,9 @@ void CubismRenderer_Vulkan::BeginRendering(VkCommandBuffer drawCommandBuffer, cs
     memoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     memoryBarrier.srcAccessMask = VK_ACCESS_NONE;
     memoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    memoryBarrier.oldLayout = (s_useRenderTarget
+        ? (isResume ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED)
+        : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     memoryBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     memoryBarrier.image = s_renderImage;
     memoryBarrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
@@ -2361,7 +2370,7 @@ void CubismRenderer_Vulkan::EndRendering(VkCommandBuffer drawCommandBuffer)
     memoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     memoryBarrier.dstAccessMask = (s_useRenderTarget ? VK_ACCESS_SHADER_READ_BIT : VK_ACCESS_NONE);
     memoryBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    memoryBarrier.newLayout = (s_useRenderTarget ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_GENERAL);
+    memoryBarrier.newLayout = (s_useRenderTarget ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     memoryBarrier.image = s_renderImage;
     memoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
@@ -2567,7 +2576,7 @@ void CubismRenderer_Vulkan::CopyRenderTarget(const CubismRenderTarget_Vulkan* sr
     ExecuteDrawForRenderTarget(src, drawCommandBuffer);
 
     // 描画終了
-    _modelRenderTargets[0].EndDraw(drawCommandBuffer);
+    EndRendering(drawCommandBuffer);
 }
 
 void CubismRenderer_Vulkan::SetClippingContextBufferForMask(CubismClippingContext_Vulkan* clip)
@@ -2957,7 +2966,7 @@ void CubismRenderer_Vulkan::AddOffscreen(csmInt32 offscreenIndex,
     }
 
     CubismOffscreenRenderTarget_Vulkan* offscreen = &_offscreenList.At(offscreenIndex);
-    offscreen->SetOffscreenRenderTarget(s_device, s_physicalDevice,
+    offscreen->SetOffscreenRenderTarget(s_device, s_physicalDevice, _deviceInfo->GetOffscreenManager(),
         _modelRenderTargetWidth, _modelRenderTargetHeight, s_imageFormat, s_depthFormat);
 
     // 以前のオフスクリーンレンダリングターゲットを取得
@@ -3147,40 +3156,44 @@ void CubismRenderer_Vulkan::DrawOffscreenVulkan(const CubismModel& model, Cubism
     ExecuteDrawForOffscreen(model, offscreen, drawCommandBuffer);
 
     // 後処理
-    offscreen->StopUsingRenderTexture();
+    offscreen->StopUsingRenderTexture(_deviceInfo->GetOffscreenManager());
     SetClippingContextBufferForOffscreen(NULL);
     SetClippingContextBufferForMask(NULL);
 }
 
-void CubismRenderer_Vulkan::SetBlendTextureBarrier(VkCommandBuffer drawCommandBuffer)
+void CubismRenderer_Vulkan::SetBlendTextureBarrier(VkCommandBuffer drawCommandBuffer, VkImageLayout currentLayout, VkImageLayout newLayout)
 {
     CubismRenderTarget_Vulkan* blendRenderTarget = (_currentRenderTarget != NULL)
                                                           ? _currentRenderTarget
                                                           : GetModelRenderTarget();
 
-        VkImageMemoryBarrier2 imageBarrier{};
-        imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
-        imageBarrier.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
-        imageBarrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
-        imageBarrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-        imageBarrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
-        imageBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        imageBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    // レンダリング中でない場合は何もしない
+    if (blendRenderTarget == nullptr || !blendRenderTarget->IsRendering())
+    {
+        return;
+    }
 
-        imageBarrier.image = blendRenderTarget->GetTextureImage();
-        imageBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    // レンダリング中断
+    blendRenderTarget->EndDraw(drawCommandBuffer, currentLayout);
 
-        VkDependencyInfo depInfo{};
-        depInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
-        depInfo.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
-        depInfo.memoryBarrierCount = 0;
-        depInfo.pMemoryBarriers = nullptr;
-        depInfo.bufferMemoryBarrierCount = 0;
-        depInfo.pBufferMemoryBarriers = nullptr;
-        depInfo.imageMemoryBarrierCount = 1;
-        depInfo.pImageMemoryBarriers = &imageBarrier;
+    // ちらつきを無くすためバリア設定
+    VkImageMemoryBarrier imageBarrier{};
+    imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    imageBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    imageBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    imageBarrier.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    imageBarrier.newLayout = newLayout;
+    imageBarrier.image = blendRenderTarget->GetTextureImage();
+    imageBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-        vkCmdPipelineBarrier2(drawCommandBuffer, &depInfo);
+    vkCmdPipelineBarrier(drawCommandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+        VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &imageBarrier);
+
+    // バリアでレイアウトが変更されたので内部状態を更新
+    blendRenderTarget->SetColorImageCurrentLayout(newLayout);
+
+    // レンダリング再開
+    blendRenderTarget->BeginDraw(drawCommandBuffer, 0.0f, 0.0f, 0.0f, 0.0f, false);
 }
 
 void CubismRenderer_Vulkan::EnsurePreviousRenderFinished(VkCommandBuffer commandBuffer, const CubismRenderTarget_Vulkan* nextRenderTarget)

--- a/src/Rendering/Vulkan/CubismRenderer_Vulkan.hpp
+++ b/src/Rendering/Vulkan/CubismRenderer_Vulkan.hpp
@@ -47,6 +47,7 @@ VkRect2D GetScissor(csmFloat32 offsetX, csmFloat32 offsetY, csmFloat32 width, cs
 //  前方宣言
 class CubismRenderer_Vulkan;
 class CubismClippingContext_Vulkan;
+class CubismDeviceInfo_Vulkan;
 
 /**
  * @brief  クリッピングマスクの処理を実行するクラス
@@ -267,8 +268,7 @@ struct ModelVertex
 };
 
 /**
- * @brief  シェーダー関連のプログラムを生成・破棄するクラス<br>
- *         シングルトンなクラスであり、CubismShader_Vulkan::GetInstance()からアクセスする。
+ * @brief  シェーダー関連のプログラムを生成・破棄するクラス
  */
 class CubismPipeline_Vulkan
 {
@@ -373,13 +373,6 @@ public:
         }
         return _pipelineResource[shaderIndex]->GetPipelineLayout(blendIndex);
     }
-
-    /**
-     * @brief   インスタンスを取得する（シングルトン）
-     *
-     * @return  インスタンスのポインタ
-     */
-    static CubismPipeline_Vulkan* GetInstance();
 
     /**
      * @brief   リソースを開放する
@@ -489,10 +482,10 @@ public:
      * @param[in]   imageFormat         -> 描画対象のフォーマット
      * @param[in]   depthFormat         -> 深度フォーマット
      */
-    static void InitializeConstantSettings(VkDevice device, VkPhysicalDevice physicalDevice,
-                                           VkCommandPool commandPool, VkQueue queue,
-                                           csmUint32 swapchainImageCount, VkExtent2D extent,
-                                           VkImageView imageView, VkFormat imageFormat, VkFormat depthFormat);
+    static void SetConstantSettings(VkDevice device, VkPhysicalDevice physicalDevice,
+                                    VkCommandPool commandPool, VkQueue queue,
+                                    csmUint32 swapchainImageCount, VkExtent2D extent,
+                                    VkImageView imageView, VkFormat imageFormat, VkFormat depthFormat);
 
     /**
      * @brief    レンダーターゲット変更を有効にする
@@ -950,8 +943,12 @@ private:
      * @brief  ブレンドモードで使用するテクスチャにメモリバリアを設定する
      *
      * @param[in]   drawCommandBuffer     -> コマンドバッファ
+     * @param[in]   currentLayout         -> 現在のイメージレイアウト
+     * @param[in]   newLayout             -> 遷移するイメージレイアウト
      */
-    void SetBlendTextureBarrier(VkCommandBuffer drawCommandBuffer);
+    void SetBlendTextureBarrier(VkCommandBuffer drawCommandBuffer,
+         VkImageLayout currentLayout=VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+         VkImageLayout newLayout=VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     /**
      * @brief  レンダーターゲット切り替え時に現在の描画を終了する
@@ -970,6 +967,7 @@ private:
     CubismRenderer_Vulkan(const CubismRenderer_Vulkan&);
     CubismRenderer_Vulkan& operator=(const CubismRenderer_Vulkan&);
 
+    CubismDeviceInfo_Vulkan* _deviceInfo; ///< デバイスに紐づいているデータ
     CubismClippingManager_Vulkan* _drawableClippingManager; ///< クリッピングマスク管理オブジェクト
     csmVector<csmInt32> _sortedDrawableIndexList; ///< 描画オブジェクトのインデックスを描画順に並べたリスト
     CubismClippingContext_Vulkan* _clippingContextBufferForMask; ///< マスクテクスチャに描画するためのクリッピングコンテキスト


### PR DESCRIPTION
### Added

* Add the `SetRenderViewport` method to `CubismRenderer_Metal` to set the viewport when drawing the model.
* Add functionality to change motion calculation order.
* Add `cubismlook` class that implements the target tracking feature.
  * The target tracking feature can now specify parameter IDs through the `Framework`.

### Changed

* Change Vulkan renderer to use `CubismDeviceInfo_Vulkan` instead of singletons for pipeline and offscreen manager.
  * Rename `InitializeConstantSettings` to `SetConstantSettings` in Vulkan renderer.
* Change the access level of the private members in the `CubismMoc` and `CubismModel` classes to protected.
* Change multiply and screen color functions to separate class with renamed methods.
* Change shader generation from draw loop to Initialize() in OpenGL, D3D9, D3D11 and Metal.
* Change to unify sampler settings across all graphics APIs, except for OpenGL ES on Android and iOS.

### Fixed

* Fix a validation error on Vulkan.
* Fix unnecessary multiply color and screen color settings in mask drawing.
* Fix a memory leak in `CubismRenderer_D3D11::ReleaseCommandBuffer()` where `_indexBuffers` and `_vertexBuffers` were not freed due to a copy-paste bug.
* Fix a memory leak in `CubismRenderer_Vulkan::CreatePipelines()` where `PipelineResource` objects allocated for Add/Mult blend modes were overwritten and leaked.
* Fix missing null checks after loading shader source files in OpenGL, D3D9 and D3D11 renderers.
* Fix a resource leak in `CubismShader_D3D11::GenerateShaders()` where Copy and SetupMask shaders were loaded twice, causing the first set of COM objects to leak.
* Fix redundant matrix transpose in D3D11 renderer.
* Improve the viewport save and restore process on OpenGL.

### Removed

* Remove unnecessary shader processing in D3D11 and D3D9.
* Remove deprecated functions from CubismModel:
 * `GetDrawableTextureIndices(csmInt32 drawableIndex)` (use `GetDrawableTextureIndex(csmInt32 drawableIndex)` instead)
 * `GetDrawableBlendMode(csmInt32 drawableIndex)` (use `GetDrawableBlendModeType(csmInt32 drawableIndex)` instead)
 * `SetOverwriteFlagForModelCullings(csmBool value)` (use `SetOverrideFlagForModelCullings(csmBool value)` instead)
 * `GetOverwriteFlagForModelCullings()` (use `GetOverwriteFlagForModelCullings()` instead)
 * `SetOverwriteFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value)` (use `SetOverrideFlagForDrawableCullings(csmUint32 drawableIndex, csmBool value)` instead)
 * `GetOverwriteFlagForDrawableCullings(csmInt32 drawableIndex)` (use `GetOverrideFlagForDrawableCullings(csmInt32 drawableIndex)` instead)
* Remove deprecated functions from CubismExpressionMotion:
 * `GetFadeWeight()` (use `CubismExpressionMotionManager.GetFadeWeight(csmInt32 index)` instead)
* Remove deprecated fields from CubismExpressionMotion:
 * `_fadeWeight` (priority is not used in expression motion playback)
* Remove deprecated functions from CubismExpressionMotionManager:
 * `GetCurrentPriority()` (priority is not used in expression motion playback)
 * `SetReservePriority(csmInt32 priority)` (priority is not used in expression motion playback)
 * `GetReservePriority()` (priority is not used in expression motion playback)
 * `StartMotionPriority(ACubismMotion* motion, csmBool autoDelete, csmInt32 priority)` (use `CubismMotionQueueManager::StartMotion(ACubismMotion* motion, csmBool autoDelete)` instead)
* Remove deprecated fields from CubismExpressionMotionManager:
 * `_currentPriority` (priority is not used in expression motion playback)
 * `_reservePriority` (priority is not used in expression motion playback)
* Remove deprecated functions from CubismMotion:
 * `IsLoop(csmBool loop)` (use `ACubismMotion.SetLoop(csmBool loop)` instead)
 * `IsLoop()` (use `ACubismMotion.GetLoop()` instead)
 * `IsLoopFadeIn(csmBool loopFadeIn)` (use `ACubismMotion.SetLoopFadeIn(csmBool loopFadeIn)` instead)
 * `IsLoopFadeIn()` (use `ACubismMotion.GetLoopFadeIn()` instead)
* Remove deprecated functions from CubismMotionQueueManager:
 * `StartMotion(ACubismMotion* motion, csmBool autoDelete, csmFloat32 userTimeSeconds)` (use `StartMotion(ACubismMotion* motion, csmBool autoDelete)` instead)